### PR TITLE
Fix slow manual redeployment admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to Towbar are documented in this file. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Manual App and Resource deployments now immediately admit the latest
+  synchronized revision instead of blocking on a Source sync. AWS secret values
+  continue to resolve at execution time.
+
 ## [1.0.0] - 2026-08-24
 
 ### Added

--- a/apps/towbar-api/README.md
+++ b/apps/towbar-api/README.md
@@ -64,6 +64,12 @@ entities. Resources support versioned images plus PostgreSQL and Redis presets.
 Root shared build/deployment secret references are copied into immutable
 deployable snapshots and resolved only at execution time.
 
+Manual App and Resource deployments admit the latest successfully synchronized
+revision without synchronizing the Source again. This keeps redeploy admission
+fast and lets a redeploy consume newly updated AWS Secrets Manager values,
+which are resolved just in time by the worker. Use `Sync now` for repository or
+manifest changes; signed GitHub webhooks keep the configured branch current.
+
 Owners can inspect key names and edit values for JSON environment bundles
 already attached to an App or Resource. Resources expose deployment bindings
 only; build bindings apply only to Apps. The API performs the read/merge/write

--- a/apps/towbar-api/eslint.config.js
+++ b/apps/towbar-api/eslint.config.js
@@ -1,4 +1,24 @@
 import { config } from "@workspace/eslint-config/backend";
 
 /** @type {import("eslint").Linter.Config} */
-export default [...config, { ignores: ["dist/**"] }];
+export default [
+  ...config,
+  {
+    files: ["src/areas/apps/service.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["../sources/*", "../sources/**"],
+              message:
+                "Deployment admission must use the latest synchronized snapshot. Synchronize Sources through the dedicated Source workflow.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  { ignores: ["dist/**"] },
+];

--- a/apps/towbar-api/src/areas/apps/automatic-deployments.ts
+++ b/apps/towbar-api/src/areas/apps/automatic-deployments.ts
@@ -175,7 +175,6 @@ async function scheduleEligibleAutomaticDeployments(input: {
           syncId: input.syncId,
         }),
         requestedBy: null,
-        synchronize: false,
         workspaceId: input.workspaceId,
       });
     }),

--- a/apps/towbar-api/src/areas/apps/service.ts
+++ b/apps/towbar-api/src/areas/apps/service.ts
@@ -16,7 +16,6 @@ import { conflict, notFound, unprocessable } from "../../http/errors.js";
 import { getTowbarDatabase } from "../../infrastructure/database.js";
 import { enqueueDeployment } from "../../infrastructure/temporal.js";
 import { publicDeploymentSelection } from "../deployment-selection.js";
-import { synchronizeSourceNow } from "../sources/service.js";
 import { requireSatisfiedAppDependencies } from "./dependencies.js";
 import { scopeDeploymentIdempotencyKey } from "./idempotency.js";
 import { getApp, getResource } from "./queries.js";
@@ -70,7 +69,6 @@ export async function requestAppDeployment(input: {
   expectedCommitSha?: string;
   idempotencyKey: string;
   requestedBy: string | null;
-  synchronize?: boolean;
   workspaceId: string;
   expectedType?: "app" | "resource";
 }) {
@@ -82,20 +80,6 @@ export async function requestAppDeployment(input: {
   const existing = await findIdempotentDeployment(request);
   if (existing) return { deployment: existing, replayed: true };
 
-  if (request.synchronize !== false) {
-    if (!request.requestedBy) {
-      throw new Error("Manual deployment synchronization requires an actor");
-    }
-    const initial = await getAppForDeployment(
-      request.appId,
-      request.workspaceId,
-    );
-    await synchronizeSourceNow(
-      initial.sourceId,
-      request.workspaceId,
-      request.requestedBy,
-    );
-  }
   const target = await getAppForDeployment(request.appId, request.workspaceId);
   requireDeployableType(target.config, request.expectedType ?? "app");
   if (target.archivedAt) {


### PR DESCRIPTION
## Summary

- admit manual App and Resource deployments from the latest synchronized revision without running a Source sync
- keep AWS Secrets Manager values resolved just in time by the worker
- add an ESLint boundary preventing deployment admission from importing Source synchronization
- document the redeploy versus Sync now contract

## Why

Redeploying after an AWS secret value change was blocking on a complete GitHub Source reconciliation before returning `202 Accepted`. The secret value is already resolved at execution time, so that synchronization added latency without changing the deployment snapshot.

## Verification

- Prettier check
- 46 Towbar API tests
- Towbar API lint
- Towbar API typecheck
- Towbar API production build
- `git diff --check`