### PR TITLE
fix(ui): mute chart gridlines

### DIFF
--- a/packages/web-design-system/src/charts/line-chart.tsx
+++ b/packages/web-design-system/src/charts/line-chart.tsx
@@ -33,6 +33,11 @@ function Root({
     </div>
   );
 }
+
+function Grid(props: ComponentProps<typeof CartesianGrid>) {
+  return <CartesianGrid stroke="var(--separator)" {...props} />;
+}
+
 type TooltipEntry = {
   color?: string;
   dataKey?: string | number;
@@ -82,7 +87,7 @@ function TooltipContent({
   );
 }
 export const LineChart = Object.assign(Root, {
-  Grid: CartesianGrid,
+  Grid,
   Line,
   Root,
   Tooltip,


### PR DESCRIPTION
## Summary
- use the design-system separator token for line-chart grids
- preserve explicit stroke overrides
- reduce visual competition between grid and data lines in both themes

## Verification
- `pnpm verify`
- dark-mode fixture render at the real Overview route
- `git diff --check`