### PR TITLE
fix(ui): clarify deployment queue states

### DIFF
--- a/apps/towbar-web-app/src/components/deployment-queue.tsx
+++ b/apps/towbar-web-app/src/components/deployment-queue.tsx
@@ -121,7 +121,7 @@ export function DeploymentQueue() {
           </span>
         </Button>
         <Popover.Content
-          className="w-[min(22rem,calc(100vw-2rem))] overflow-hidden bg-overlay"
+          className="w-[min(22rem,calc(100vw-2rem))] overflow-hidden border border-separator bg-overlay"
           offset={8}
           placement="top end"
         >

--- a/apps/towbar-web-app/src/components/source-detail.tsx
+++ b/apps/towbar-web-app/src/components/source-detail.tsx
@@ -15,6 +15,7 @@ import { type Key, type ReactNode } from "react";
 import type {
   App,
   AwsCredentialMetadata,
+  Deployment,
   Resource,
   SourceServer,
   Source,
@@ -78,12 +79,19 @@ export function SourceDetail() {
   );
   const apps = useApiQuery<{ apps: App[] }>(
     `/v1/core/sources/${sourceId}/apps`,
+    5_000,
   );
   const resources = useApiQuery<{ resources: Resource[] }>(
     `/v1/core/sources/${sourceId}/resources`,
+    5_000,
   );
   const servers = useApiQuery<{ servers: SourceServer[] }>(
     `/v1/core/sources/${sourceId}/servers`,
+    5_000,
+  );
+  const deployments = useApiQuery<{ deployments: Deployment[] }>(
+    `/v1/core/sources/${sourceId}/deployments`,
+    5_000,
   );
   const aws = useApiQuery<{ credential: AwsCredentialMetadata | null }>(
     `/v1/core/sources/${sourceId}/aws`,
@@ -225,7 +233,8 @@ export function SourceDetail() {
             content: (
               <SourceApps
                 apps={apps.data?.apps}
-                error={apps.error}
+                deployments={deployments.data?.deployments}
+                error={apps.error ?? deployments.error}
                 sourceId={sourceId}
               />
             ),
@@ -242,7 +251,8 @@ export function SourceDetail() {
               : undefined,
             content: (
               <SourceResources
-                error={resources.error}
+                deployments={deployments.data?.deployments}
+                error={resources.error ?? deployments.error}
                 resources={resources.data?.resources}
                 sourceId={sourceId}
               />
@@ -261,7 +271,13 @@ export function SourceDetail() {
             content: (
               <SourceServers
                 apps={apps.data?.apps}
-                error={servers.error ?? apps.error ?? resources.error}
+                deployments={deployments.data?.deployments}
+                error={
+                  servers.error ??
+                  apps.error ??
+                  resources.error ??
+                  deployments.error
+                }
                 resources={resources.data?.resources}
                 servers={servers.data?.servers}
                 sourceId={sourceId}

--- a/apps/towbar-web-app/src/components/source-inventory.tsx
+++ b/apps/towbar-web-app/src/components/source-inventory.tsx
@@ -6,141 +6,173 @@ import {
   CheckmarkCircle02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import type { App, Resource, SourceServer } from "@workspace/towbar-web-client";
+import type {
+  App,
+  Deployment,
+  DeploymentState,
+  Resource,
+  SourceServer,
+} from "@workspace/towbar-web-client";
 import { QueryError, QueryLoading } from "@workspace/towbar-web-ui/query-state";
 import {
   ResourceTable,
   type ResourceTableColumn,
 } from "@workspace/towbar-web-ui/resource-table";
 import { StatusBadge } from "@workspace/towbar-web-ui/status-badge";
+import {
+  getActiveDeploymentStates,
+  resolveInventoryStatus,
+  resolveInventorySyncStatus,
+} from "@/lib/inventory-status";
 import { LastSyncedTime, RelativeTimeProvider } from "./last-synced-time";
 
-const appColumns: ResourceTableColumn<App>[] = [
-  {
-    cell: (app) => app.name,
-    className: "min-w-56",
-    header: "App Name",
-    key: "name",
-  },
-  {
-    cell: (app) => app.serverIp,
-    className: "min-w-36 tabular-nums",
-    header: "Server",
-    key: "server",
-  },
-  {
-    cell: (app) => (
-      <AutoDeployIndicator enabled={Boolean(app.config.autoDeploy)} />
-    ),
-    className: "w-32",
-    header: "Auto-deploy",
-    key: "auto-deploy",
-  },
-  {
-    cell: (app) => <StatusBadge status={app.runtimeState.driftStatus} />,
-    className: "w-32",
-    header: "Sync status",
-    key: "sync-status",
-  },
-  {
-    cell: (app) => <LastSyncedTime value={app.updatedAt} />,
-    className: "min-w-48 whitespace-nowrap",
-    header: "Last synced",
-    key: "last-synced",
-  },
-  {
-    cell: (app) => (
-      <StatusBadge
-        status={
-          app.archivedAt
-            ? "archived"
-            : app.serverReady
-              ? app.runtimeState.healthStatus
-              : "server_setup_pending"
-        }
-      />
-    ),
-    className: "w-32",
-    header: "Status",
-    key: "status",
-  },
-];
+function appColumns(
+  activeDeploymentStates: Map<string, DeploymentState>,
+): ResourceTableColumn<App>[] {
+  return [
+    {
+      cell: (app) => app.name,
+      className: "min-w-56",
+      header: "App Name",
+      key: "name",
+    },
+    {
+      cell: (app) => app.serverIp,
+      className: "min-w-36 tabular-nums",
+      header: "Server",
+      key: "server",
+    },
+    {
+      cell: (app) => (
+        <AutoDeployIndicator enabled={Boolean(app.config.autoDeploy)} />
+      ),
+      className: "w-32",
+      header: "Auto-deploy",
+      key: "auto-deploy",
+    },
+    {
+      cell: (app) => (
+        <StatusBadge
+          status={resolveInventorySyncStatus(
+            app.runtimeState.driftStatus,
+            activeDeploymentStates.get(app.id),
+          )}
+        />
+      ),
+      className: "w-32",
+      header: "Sync status",
+      key: "sync-status",
+    },
+    {
+      cell: (app) => <LastSyncedTime value={app.updatedAt} />,
+      className: "min-w-48 whitespace-nowrap",
+      header: "Last synced",
+      key: "last-synced",
+    },
+    {
+      cell: (app) => (
+        <StatusBadge
+          status={resolveInventoryStatus({
+            activeDeploymentState: activeDeploymentStates.get(app.id),
+            archived: Boolean(app.archivedAt),
+            healthStatus: app.runtimeState.healthStatus,
+            serverReady: app.serverReady,
+          })}
+        />
+      ),
+      className: "w-32",
+      header: "Status",
+      key: "status",
+    },
+  ];
+}
 
-const resourceColumns: ResourceTableColumn<Resource>[] = [
-  {
-    cell: (resource) => resource.name,
-    className: "min-w-56",
-    header: "Resource Name",
-    key: "name",
-  },
-  {
-    cell: (resource) => formatResourceKind(resource.kind),
-    className: "min-w-28",
-    header: "Type",
-    key: "type",
-  },
-  {
-    cell: (resource) => resource.serverIp,
-    className: "min-w-36 tabular-nums",
-    header: "Server",
-    key: "server",
-  },
-  {
-    cell: (resource) => (
-      <AutoDeployIndicator enabled={Boolean(resource.config.autoDeploy)} />
-    ),
-    className: "w-32",
-    header: "Auto-deploy",
-    key: "auto-deploy",
-  },
-  {
-    cell: (resource) => (
-      <StatusBadge status={resource.runtimeState.driftStatus} />
-    ),
-    className: "w-32",
-    header: "Sync status",
-    key: "sync-status",
-  },
-  {
-    cell: (resource) => <LastSyncedTime value={resource.updatedAt} />,
-    className: "min-w-48 whitespace-nowrap",
-    header: "Last synced",
-    key: "last-synced",
-  },
-  {
-    cell: (resource) => (
-      <StatusBadge
-        status={
-          resource.archivedAt
-            ? "archived"
-            : resource.serverReady
-              ? resource.runtimeState.healthStatus
-              : "server_setup_pending"
-        }
-      />
-    ),
-    className: "w-32",
-    header: "Status",
-    key: "status",
-  },
-];
+function resourceColumns(
+  activeDeploymentStates: Map<string, DeploymentState>,
+): ResourceTableColumn<Resource>[] {
+  return [
+    {
+      cell: (resource) => resource.name,
+      className: "min-w-56",
+      header: "Resource Name",
+      key: "name",
+    },
+    {
+      cell: (resource) => formatResourceKind(resource.kind),
+      className: "min-w-28",
+      header: "Type",
+      key: "type",
+    },
+    {
+      cell: (resource) => resource.serverIp,
+      className: "min-w-36 tabular-nums",
+      header: "Server",
+      key: "server",
+    },
+    {
+      cell: (resource) => (
+        <AutoDeployIndicator enabled={Boolean(resource.config.autoDeploy)} />
+      ),
+      className: "w-32",
+      header: "Auto-deploy",
+      key: "auto-deploy",
+    },
+    {
+      cell: (resource) => (
+        <StatusBadge
+          status={resolveInventorySyncStatus(
+            resource.runtimeState.driftStatus,
+            activeDeploymentStates.get(resource.id),
+          )}
+        />
+      ),
+      className: "w-32",
+      header: "Sync status",
+      key: "sync-status",
+    },
+    {
+      cell: (resource) => <LastSyncedTime value={resource.updatedAt} />,
+      className: "min-w-48 whitespace-nowrap",
+      header: "Last synced",
+      key: "last-synced",
+    },
+    {
+      cell: (resource) => (
+        <StatusBadge
+          status={resolveInventoryStatus({
+            activeDeploymentState: activeDeploymentStates.get(resource.id),
+            archived: Boolean(resource.archivedAt),
+            healthStatus: resource.runtimeState.healthStatus,
+            serverReady: resource.serverReady,
+          })}
+        />
+      ),
+      className: "w-32",
+      header: "Status",
+      key: "status",
+    },
+  ];
+}
 
 export function SourceApps({
   apps,
+  deployments,
   error,
   sourceId,
 }: {
   apps?: App[];
+  deployments?: Deployment[];
   error?: string;
   sourceId: string;
 }) {
   if (error) return <QueryError message={error} />;
-  if (!apps) return <QueryLoading variant="list" />;
+  if (!apps || !deployments) return <QueryLoading variant="list" />;
+  const activeDeploymentStates = getActiveDeploymentStates(deployments);
   return (
     <RelativeTimeProvider>
       <ResourceTable
         ariaLabel="Source apps"
-        columns={appColumns}
+        columns={appColumns(activeDeploymentStates)}
         emptyDescription="A successful manifest sync imports this Source's apps."
         emptyTitle="No apps in this Source"
         getRowHref={(app) => `/sources/${sourceId}/apps/${app.id}`}
@@ -153,21 +185,24 @@ export function SourceApps({
 }
 
 export function SourceResources({
+  deployments,
   error,
   resources,
   sourceId,
 }: {
+  deployments?: Deployment[];
   error?: string;
   resources?: Resource[];
   sourceId: string;
 }) {
   if (error) return <QueryError message={error} />;
-  if (!resources) return <QueryLoading variant="list" />;
+  if (!resources || !deployments) return <QueryLoading variant="list" />;
+  const activeDeploymentStates = getActiveDeploymentStates(deployments);
   return (
     <RelativeTimeProvider>
       <ResourceTable
         ariaLabel="Source resources"
-        columns={resourceColumns}
+        columns={resourceColumns(activeDeploymentStates)}
         emptyDescription="Declare an image, PostgreSQL, or Redis resource in this Source's manifest."
         emptyTitle="No resources in this Source"
         getRowHref={(resource) =>
@@ -183,29 +218,39 @@ export function SourceResources({
 
 export function SourceServers({
   apps,
+  deployments,
   error,
   resources,
   servers,
   sourceId,
 }: {
   apps?: App[];
+  deployments?: Deployment[];
   error?: string;
   resources?: Resource[];
   servers?: SourceServer[];
   sourceId: string;
 }) {
   if (error) return <QueryError message={error} />;
-  if (!servers || !apps || !resources) return <QueryLoading variant="list" />;
+  if (!servers || !apps || !resources || !deployments)
+    return <QueryLoading variant="list" />;
+  const activeDeploymentStates = getActiveDeploymentStates(deployments);
   const appCounts = new Map<string, number>();
   const resourceCounts = new Map<string, number>();
-  const syncStatuses = new Map<string, App["runtimeState"]["driftStatus"]>();
+  const syncStatuses = new Map<
+    string,
+    App["runtimeState"]["driftStatus"] | DeploymentState
+  >();
   for (const app of apps) {
     appCounts.set(app.serverIp, (appCounts.get(app.serverIp) ?? 0) + 1);
     syncStatuses.set(
       app.serverIp,
       mergeSyncStatus(
         syncStatuses.get(app.serverIp),
-        app.runtimeState.driftStatus,
+        resolveInventorySyncStatus(
+          app.runtimeState.driftStatus,
+          activeDeploymentStates.get(app.id),
+        ),
       ),
     );
   }
@@ -218,7 +263,10 @@ export function SourceServers({
       resource.serverIp,
       mergeSyncStatus(
         syncStatuses.get(resource.serverIp),
-        resource.runtimeState.driftStatus,
+        resolveInventorySyncStatus(
+          resource.runtimeState.driftStatus,
+          activeDeploymentStates.get(resource.id),
+        ),
       ),
     );
   }
@@ -346,10 +394,12 @@ function formatDeployableCounts(apps: number, resources: number) {
 }
 
 function mergeSyncStatus(
-  current: App["runtimeState"]["driftStatus"] | undefined,
-  next: App["runtimeState"]["driftStatus"],
-): App["runtimeState"]["driftStatus"] {
+  current: App["runtimeState"]["driftStatus"] | DeploymentState | undefined,
+  next: App["runtimeState"]["driftStatus"] | DeploymentState,
+): App["runtimeState"]["driftStatus"] | DeploymentState {
   if (current === "drifted" || next === "drifted") return "drifted";
+  if (current && current !== "unknown" && current !== "in_sync") return current;
+  if (next !== "unknown" && next !== "in_sync") return next;
   if (current === "unknown" || next === "unknown") return "unknown";
   return "in_sync";
 }

--- a/apps/towbar-web-app/src/lib/inventory-status.test.ts
+++ b/apps/towbar-web-app/src/lib/inventory-status.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { Deployment } from "@workspace/towbar-web-client";
+
+import {
+  getActiveDeploymentStates,
+  resolveInventoryStatus,
+  resolveInventorySyncStatus,
+} from "./inventory-status";
+
+const deployment = (input: Partial<Deployment>): Deployment => ({
+  appId: "deployable-1",
+  commitSha: "abcdef123456",
+  createdAt: "2026-08-25T12:00:00.000Z",
+  deployableKind: "postgres",
+  errorCode: null,
+  errorMessage: null,
+  finishedAt: null,
+  id: "deployment-1",
+  kind: "deploy",
+  manifestDigest: "digest",
+  serverId: "server-1",
+  sourceId: "source-1",
+  startedAt: null,
+  state: "queued",
+  trigger: "auto_deploy",
+  updatedAt: "2026-08-25T12:00:00.000Z",
+  ...input,
+});
+
+void test("uses the newest active deployment state for each deployable", () => {
+  const states = getActiveDeploymentStates([
+    deployment({
+      createdAt: "2026-08-25T12:02:00.000Z",
+      id: "deployment-3",
+      state: "building",
+    }),
+    deployment({
+      createdAt: "2026-08-25T12:01:00.000Z",
+      id: "deployment-2",
+      state: "queued",
+    }),
+    deployment({
+      createdAt: "2026-08-25T12:03:00.000Z",
+      finishedAt: "2026-08-25T12:04:00.000Z",
+      id: "deployment-4",
+      state: "succeeded",
+    }),
+  ]);
+
+  assert.equal(states.get("deployable-1"), "building");
+});
+
+void test("surfaces an active deployment instead of unknown inventory state", () => {
+  assert.equal(resolveInventorySyncStatus("unknown", "queued"), "queued");
+  assert.equal(
+    resolveInventoryStatus({
+      activeDeploymentState: "queued",
+      archived: false,
+      healthStatus: "unknown",
+      serverReady: true,
+    }),
+    "queued",
+  );
+});
+
+void test("keeps server setup and archive states authoritative", () => {
+  assert.equal(
+    resolveInventoryStatus({
+      activeDeploymentState: "waiting_for_server",
+      archived: false,
+      healthStatus: "unknown",
+      serverReady: false,
+    }),
+    "server_setup_pending",
+  );
+  assert.equal(
+    resolveInventoryStatus({
+      activeDeploymentState: "queued",
+      archived: true,
+      healthStatus: "unknown",
+      serverReady: true,
+    }),
+    "archived",
+  );
+});

--- a/apps/towbar-web-app/src/lib/inventory-status.ts
+++ b/apps/towbar-web-app/src/lib/inventory-status.ts
@@ -1,0 +1,55 @@
+import type {
+  Deployment,
+  DeploymentState,
+  RuntimeState,
+} from "@workspace/towbar-web-client";
+
+const terminalDeploymentStates = new Set<DeploymentState>([
+  "cancelled",
+  "failed",
+  "skipped",
+  "succeeded",
+  "succeeded_with_warnings",
+]);
+
+export function getActiveDeploymentStates(deployments: Deployment[]) {
+  const activeStates = new Map<string, DeploymentState>();
+  const newestFirst = [...deployments].sort(
+    (left, right) =>
+      new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime(),
+  );
+
+  for (const deployment of newestFirst) {
+    if (
+      !activeStates.has(deployment.appId) &&
+      !terminalDeploymentStates.has(deployment.state)
+    ) {
+      activeStates.set(deployment.appId, deployment.state);
+    }
+  }
+
+  return activeStates;
+}
+
+export function resolveInventorySyncStatus(
+  driftStatus: RuntimeState["driftStatus"],
+  activeDeploymentState?: DeploymentState,
+) {
+  return activeDeploymentState ?? driftStatus;
+}
+
+export function resolveInventoryStatus({
+  activeDeploymentState,
+  archived,
+  healthStatus,
+  serverReady,
+}: {
+  activeDeploymentState?: DeploymentState;
+  archived: boolean;
+  healthStatus: RuntimeState["healthStatus"];
+  serverReady: boolean;
+}) {
+  if (archived) return "archived";
+  if (!serverReady) return "server_setup_pending";
+  return activeDeploymentState ?? healthStatus;
+}


### PR DESCRIPTION
## Summary
- restore the missing boundary around the deployment queue popover
- surface queued and in-progress deployment phases in Source inventory instead of Unknown
- refresh Source deployment and runtime state while work is active
- keep server-setup and archive states authoritative

## Verification
- `pnpm verify`
- added inventory-state unit coverage