### PR TITLE
fix(server): preserve readiness for scheduler changes

### DIFF
--- a/apps/towbar-api/src/areas/sources/materialization.ts
+++ b/apps/towbar-api/src/areas/sources/materialization.ts
@@ -1,6 +1,6 @@
 import { and, eq } from "drizzle-orm";
 
-import { digestValue } from "@workspace/towbar-core";
+import { digestValue, requiresServerPreparation } from "@workspace/towbar-core";
 import { apps, servers } from "@workspace/towbar-database/schema";
 
 import type {
@@ -27,7 +27,13 @@ export async function upsertServer(
   const desired = input.action.desired!;
   const digest = digestValue(desired);
   const [existing] = await transaction
-    .select({ id: servers.id })
+    .select({
+      config: servers.config,
+      configDigest: servers.configDigest,
+      id: servers.id,
+      preparedAt: servers.preparedAt,
+      preparedConfigDigest: servers.preparedConfigDigest,
+    })
     .from(servers)
     .where(
       and(
@@ -36,14 +42,22 @@ export async function upsertServer(
       ),
     )
     .limit(1);
-  let serverId = existing?.id;
-  if (serverId) {
+  let serverId: string;
+  if (existing) {
+    serverId = existing.id;
+    const preservePreparation =
+      Boolean(existing.preparedAt) &&
+      existing.preparedConfigDigest === existing.configDigest &&
+      !requiresServerPreparation(existing.config, desired);
     await transaction
       .update(servers)
       .set({
         archivedAt: null,
         config: desired,
         configDigest: digest,
+        preparedConfigDigest: preservePreparation
+          ? digest
+          : existing.preparedConfigDigest,
         sourceId: input.sourceId,
         sourceRevision: input.commitSha,
         updatedAt: new Date(),

--- a/packages/towbar-core/src/server-preparation.test.ts
+++ b/packages/towbar-core/src/server-preparation.test.ts
@@ -3,8 +3,21 @@ import test from "node:test";
 
 import {
   limitServerPreparationStepMessage,
+  requiresServerPreparation,
   serverPreparationStepMessageMaxLength,
 } from "./server-preparation.js";
+
+import type { NormalizedServer } from "./manifest.js";
+
+const server = {
+  buildConcurrency: 2,
+  ip: "203.0.113.10",
+  proxy: {
+    cloudflare: { apiToken: "aws:example/cloudflare" },
+  },
+  secrets: { login: "aws:example/server" },
+  ssh: { host: "10.0.0.10", port: 22, username: "deploy" },
+} satisfies NormalizedServer;
 
 void test("limits server preparation messages to the API contract", () => {
   const message = "x".repeat(serverPreparationStepMessageMaxLength + 1);
@@ -12,5 +25,38 @@ void test("limits server preparation messages to the API contract", () => {
   assert.equal(
     limitServerPreparationStepMessage(message).length,
     serverPreparationStepMessageMaxLength,
+  );
+});
+
+void test("does not invalidate preparation for scheduler or routing changes", () => {
+  assert.equal(
+    requiresServerPreparation(server, { ...server, buildConcurrency: 10 }),
+    false,
+  );
+  assert.equal(
+    requiresServerPreparation(server, {
+      ...server,
+      proxy: {
+        cloudflare: { apiToken: "aws:example/new-cloudflare-token" },
+      },
+    }),
+    false,
+  );
+});
+
+void test("invalidates preparation when SSH access changes", () => {
+  assert.equal(
+    requiresServerPreparation(server, {
+      ...server,
+      ssh: { ...server.ssh, username: "ubuntu" },
+    }),
+    true,
+  );
+  assert.equal(
+    requiresServerPreparation(server, {
+      ...server,
+      secrets: { login: "aws:example/new-server-login" },
+    }),
+    true,
   );
 });

--- a/packages/towbar-core/src/server-preparation.ts
+++ b/packages/towbar-core/src/server-preparation.ts
@@ -59,3 +59,24 @@ export function createServerPreparationSteps(): ServerPreparationStep[] {
     status: "waiting",
   }));
 }
+
+export function serverPreparationInputs(server: NormalizedServer) {
+  return {
+    ip: server.ip,
+    secrets: server.secrets,
+    ssh: server.ssh,
+  };
+}
+
+export function requiresServerPreparation(
+  current: NormalizedServer,
+  desired: NormalizedServer,
+) {
+  return (
+    digestValue(serverPreparationInputs(current)) !==
+    digestValue(serverPreparationInputs(desired))
+  );
+}
+import { digestValue } from "./manifest-values.js";
+
+import type { NormalizedServer } from "./manifest.js";


### PR DESCRIPTION
## Summary
- keep prepared servers ready when only build concurrency or routing token references change
- continue requiring preparation when SSH connection or login-secret inputs change
- add regression coverage for scheduler-only and SSH-sensitive changes

## Incident recovery
- monorepo concurrency was temporarily restored to 2 so the existing production preparation digest matches again
- after this fix is deployed, concurrency can safely return to 10

## Verification
- `pnpm verify`