### PR TITLE
release: prepare v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,19 @@ All notable changes to Towbar are documented in this file. This project follows
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-08-25
+
 ### Changed
 
 - Manual App and Resource deployments now immediately admit the latest
   synchronized revision instead of blocking on a Source sync. AWS secret values
   continue to resolve at execution time.
+- Scheduler and routing-only server configuration changes preserve prepared
+  server readiness.
+- Deployment inventory and the floating queue now distinguish active and queued
+  work, with clearer boundaries and quieter chart gridlines.
+- Updated compatible authentication, Node.js type, lint-support, path-matching,
+  and utility dependencies.
 
 ## [1.0.0] - 2026-08-24
 
@@ -23,4 +31,6 @@ All notable changes to Towbar are documented in this file. This project follows
 - Source-scoped AWS Secrets Manager integration and environment editors.
 - A same-domain owner setup, authentication, and operations dashboard.
 
+[Unreleased]: https://github.com/avgeek-inc/towbar/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/avgeek-inc/towbar/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/avgeek-inc/towbar/tree/v1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "towbar",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Opinionated, source-driven deployments to Ubuntu servers you own.",
   "keywords": [
     "deployment",


### PR DESCRIPTION
## Summary

- bump the Towbar repository version to 1.0.1
- document the fast redeploy, server-readiness, deployment-state UI, and compatible dependency updates
- reset the Unreleased comparison link for the next release

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm verify`
- `docker compose --env-file .env.example config --quiet` with non-production validation secrets
- `docker compose --env-file .env.example build` with non-production validation secrets