### PR TITLE
Deploy stable releases through GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
+      - run: bash -n infra/deploy-release.sh
+      - run: shellcheck infra/deploy-release.sh
       - run: pnpm install --frozen-lockfile
       - run: pnpm format:check
       - run: pnpm lint

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -1,0 +1,173 @@
+name: Deploy release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Stable published release tag to deploy
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: towbar-production-release
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.release.draft == false && github.event.release.prerelease == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: production
+    env:
+      AWS_REGION: ${{ vars.TOWBAR_DEPLOY_AWS_REGION }}
+      DEPLOY_INSTANCE_ID: ${{ vars.TOWBAR_DEPLOY_INSTANCE_ID }}
+      DEPLOY_PATH: ${{ vars.TOWBAR_DEPLOY_PATH || '/opt/towbar' }}
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+
+    steps:
+      # v4.4.0
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Validate stable published release
+        id: release
+        env:
+          DEPLOY_ROLE_ARN: ${{ vars.TOWBAR_DEPLOY_AWS_ROLE_ARN }}
+        run: |
+          set -euo pipefail
+          : "${DEPLOY_ROLE_ARN:?set TOWBAR_DEPLOY_AWS_ROLE_ARN in the production environment}"
+          : "${AWS_REGION:?set TOWBAR_DEPLOY_AWS_REGION in the production environment}"
+          : "${DEPLOY_INSTANCE_ID:?set TOWBAR_DEPLOY_INSTANCE_ID in the production environment}"
+
+          if [[ ! "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "Release tag must be a stable semantic version" >&2
+            exit 1
+          fi
+          if [[ "$DEPLOY_PATH" != /* || "$DEPLOY_PATH" == / ]]; then
+            echo "TOWBAR_DEPLOY_PATH must be a specific absolute path" >&2
+            exit 1
+          fi
+
+          release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG")"
+          jq -e \
+            '.draft == false and .prerelease == false and .published_at != null' \
+            <<<"$release_json" >/dev/null
+
+          git fetch --force --tags origin \
+            "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          release_commit="$(git rev-parse "$RELEASE_TAG^{commit}")"
+          package_version="$(git show "$RELEASE_TAG:package.json" | jq -r .version)"
+          test "$package_version" = "${RELEASE_TAG#v}"
+          echo "commit=$release_commit" >>"$GITHUB_OUTPUT"
+
+      # v6.2.3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+        with:
+          aws-region: ${{ vars.TOWBAR_DEPLOY_AWS_REGION }}
+          role-session-name: towbar-release-${{ github.run_id }}
+          role-to-assume: ${{ vars.TOWBAR_DEPLOY_AWS_ROLE_ARN }}
+
+      - name: Deploy exact release through SSM
+        env:
+          RELEASE_COMMIT: ${{ steps.release.outputs.commit }}
+        run: |
+          set -euo pipefail
+
+          script_base64="$(base64 --wrap=0 infra/deploy-release.sh)"
+          remote_command="$(
+            jq -rn \
+              --arg script "$script_base64" \
+              --arg tag "$RELEASE_TAG" \
+              --arg commit "$RELEASE_COMMIT" \
+              --arg path "$DEPLOY_PATH" \
+              '[
+                "printf", "%s", ($script | @sh),
+                "|", "base64", "--decode",
+                "|", "flock", "--nonblock", "/var/lock/towbar-release-deploy.lock",
+                "bash", "-s", "--", ($tag | @sh), ($commit | @sh), ($path | @sh)
+              ] | join(" ")'
+          )"
+          parameters="$(
+            jq -cn \
+              --arg command "$remote_command" \
+              '{commands: [$command], executionTimeout: ["2400"]}'
+          )"
+
+          command_id="$(
+            aws ssm send-command \
+              --region "$AWS_REGION" \
+              --instance-ids "$DEPLOY_INSTANCE_ID" \
+              --document-name AWS-RunShellScript \
+              --comment "Deploy Towbar $RELEASE_TAG" \
+              --timeout-seconds 2700 \
+              --parameters "$parameters" \
+              --query Command.CommandId \
+              --output text
+          )"
+          echo "SSM command: $command_id"
+
+          status=Pending
+          deadline=$((SECONDS + 2400))
+          while ((SECONDS < deadline)); do
+            status="$(
+              aws ssm get-command-invocation \
+                --region "$AWS_REGION" \
+                --command-id "$command_id" \
+                --instance-id "$DEPLOY_INSTANCE_ID" \
+                --query Status \
+                --output text 2>/dev/null || true
+            )"
+            case "$status" in
+              Success | Cancelled | TimedOut | Failed | Cancelling) break ;;
+            esac
+            sleep 10
+          done
+
+          aws ssm get-command-invocation \
+            --region "$AWS_REGION" \
+            --command-id "$command_id" \
+            --instance-id "$DEPLOY_INSTANCE_ID" \
+            --query StandardOutputContent \
+            --output text || true
+          aws ssm get-command-invocation \
+            --region "$AWS_REGION" \
+            --command-id "$command_id" \
+            --instance-id "$DEPLOY_INSTANCE_ID" \
+            --query StandardErrorContent \
+            --output text >&2 || true
+
+          if [[ "$status" != Success ]]; then
+            echo "SSM deployment finished with status: $status" >&2
+            exit 1
+          fi
+
+      - name: Verify public health
+        env:
+          API_HEALTH_URL: ${{ vars.TOWBAR_DEPLOY_API_HEALTH_URL }}
+          APP_HEALTH_URL: ${{ vars.TOWBAR_DEPLOY_APP_HEALTH_URL }}
+          RELEASE_COMMIT: ${{ steps.release.outputs.commit }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$API_HEALTH_URL" ]]; then
+            api_version="$(
+              curl --fail --silent --show-error --retry 8 --retry-all-errors \
+                --retry-delay 3 "$API_HEALTH_URL" | jq -r .version
+            )"
+            test "$api_version" = "$RELEASE_COMMIT"
+          fi
+          if [[ -n "$APP_HEALTH_URL" ]]; then
+            curl --fail --silent --show-error --retry 8 --retry-all-errors \
+              --retry-delay 3 "$APP_HEALTH_URL" >/dev/null
+          fi

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,3 +111,35 @@ changing the reference itself still requires a manifest commit and Source sync.
 The current deployment schema is served by the configured website at
 `${TOWBAR_WEBSITE_BASE_URL}/schemas/deployment.v1.json` and documented under
 `${TOWBAR_WEBSITE_BASE_URL}/docs/deployment-file`.
+
+## Automatic release deployment
+
+The `Deploy release` GitHub workflow deploys each stable published release to
+one existing Towbar installation. It assumes an AWS role through GitHub OIDC
+and runs the release script on the host through Systems Manager; no AWS access
+key or SSH private key is stored in GitHub.
+
+Configure these variables on a GitHub environment named `production`:
+
+| Variable                       | Purpose                                      |
+| ------------------------------ | -------------------------------------------- |
+| `TOWBAR_DEPLOY_AWS_ROLE_ARN`   | OIDC role assumed by the release workflow    |
+| `TOWBAR_DEPLOY_AWS_REGION`     | Region containing the managed EC2 instance   |
+| `TOWBAR_DEPLOY_INSTANCE_ID`    | Only instance the role may command           |
+| `TOWBAR_DEPLOY_PATH`           | Existing checkout; defaults to `/opt/towbar` |
+| `TOWBAR_DEPLOY_API_HEALTH_URL` | Optional public API health endpoint          |
+| `TOWBAR_DEPLOY_APP_HEALTH_URL` | Optional public app health endpoint          |
+
+Trust only `repo:<owner>/<repository>:environment:production` in the role's
+OIDC policy. Grant `ssm:SendCommand` only for `AWS-RunShellScript` and the
+target instance, plus `ssm:GetCommandInvocation` for reporting the result. The
+instance must be online in Systems Manager and the deployment directory must
+contain a clean Git checkout plus an owner-readable-only `.env` file.
+Restrict the environment's deployment branches and tags to the protected
+default branch and stable release tags.
+
+The workflow verifies the published tag and package version, streams the
+protected default branch's `infra/deploy-release.sh` to SSM, checks out the
+exact release commit on the host, builds it there, runs migrations, waits for
+Compose health, and verifies the running API commit. A failed replacement
+attempts to restore the previous checkout and images.

--- a/infra/deploy-release.sh
+++ b/infra/deploy-release.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+release_tag="${1:-}"
+release_commit="${2:-}"
+deploy_root="${3:-/opt/towbar}"
+
+fail() {
+  echo "Towbar release deployment failed: $*" >&2
+  exit 1
+}
+
+if [[ ! "$release_tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  fail "release tag must be a stable semantic version"
+fi
+if [[ ! "$release_commit" =~ ^[0-9a-f]{40}$ ]]; then
+  fail "release commit must be a full Git commit SHA"
+fi
+if [[ "$deploy_root" != /* || "$deploy_root" == / ]]; then
+  fail "deployment root must be a specific absolute path"
+fi
+if ((EUID != 0)); then
+  fail "deployment must run as root through the host's SSM agent"
+fi
+
+for command_name in curl docker git runuser stat; do
+  command -v "$command_name" >/dev/null ||
+    fail "missing required command: $command_name"
+done
+
+[[ -d "$deploy_root/.git" ]] || fail "$deploy_root is not a Git checkout"
+[[ -f "$deploy_root/docker-compose.yml" ]] ||
+  fail "$deploy_root/docker-compose.yml is missing"
+[[ -f "$deploy_root/.env" ]] || fail "$deploy_root/.env is missing"
+
+env_mode="$(stat -c '%a' "$deploy_root/.env")"
+if [[ "$env_mode" != 400 && "$env_mode" != 600 ]]; then
+  fail "$deploy_root/.env must be readable only by its owner"
+fi
+
+repo_owner="$(stat -c '%U' "$deploy_root")"
+id "$repo_owner" >/dev/null 2>&1 || fail "repository owner does not exist"
+
+git_as_owner() {
+  runuser --user "$repo_owner" -- \
+    git -c "safe.directory=$deploy_root" -C "$deploy_root" "$@"
+}
+
+compose_for() {
+  local image_tag="$1"
+  local source_commit="$2"
+  shift 2
+  TOWBAR_IMAGE_TAG="$image_tag" \
+    SOURCE_COMMIT="$source_commit" \
+    docker compose \
+      --env-file "$deploy_root/.env" \
+      --project-directory "$deploy_root" \
+      --file "$deploy_root/docker-compose.yml" \
+      "$@"
+}
+
+if [[ -n "$(git_as_owner status --porcelain --untracked-files=no)" ]]; then
+  fail "tracked files in $deploy_root have local changes"
+fi
+
+git_as_owner fetch --force --tags origin \
+  "refs/tags/$release_tag:refs/tags/$release_tag"
+
+resolved_commit="$(git_as_owner rev-parse "$release_tag^{commit}")"
+if [[ "$resolved_commit" != "$release_commit" ]]; then
+  fail "$release_tag resolves to $resolved_commit instead of $release_commit"
+fi
+
+previous_commit="$(git_as_owner rev-parse HEAD)"
+containers_changed=false
+
+rollback() {
+  local exit_code="${1:-1}"
+  trap - ERR INT TERM
+  set +e
+
+  echo "Release deployment failed; restoring checkout $previous_commit" >&2
+  git_as_owner checkout --detach --force "$previous_commit"
+  if [[ "$containers_changed" == true && "$previous_commit" != "$release_commit" ]]; then
+    echo "Restoring the previous Towbar Compose images" >&2
+    compose_for "$previous_commit" "$previous_commit" \
+      up --detach --wait --remove-orphans
+  fi
+  exit "$exit_code"
+}
+deployment_fail() {
+  echo "Towbar release deployment failed: $*" >&2
+  rollback 1
+}
+trap 'rollback $?' ERR
+trap 'rollback 130' INT
+trap 'rollback 143' TERM
+
+git_as_owner checkout --detach --force "$release_commit"
+
+echo "Building Towbar $release_tag ($release_commit)"
+compose_for "$release_commit" "$release_commit" \
+  build --quiet api worker web-app
+
+containers_changed=true
+echo "Applying migrations and replacing Towbar services"
+compose_for "$release_commit" "$release_commit" \
+  up --detach --wait --remove-orphans
+
+for service in api worker web-app; do
+  container_id="$(compose_for "$release_commit" "$release_commit" ps -q "$service")"
+  [[ -n "$container_id" ]] || deployment_fail "$service container was not created"
+
+  health_status="$(
+    docker inspect \
+      --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' \
+      "$container_id"
+  )"
+  [[ "$health_status" == healthy ]] ||
+    deployment_fail "$service finished with status $health_status"
+
+  case "$service" in
+    api) expected_image="towbar/api:$release_commit" ;;
+    worker) expected_image="towbar/worker:$release_commit" ;;
+    web-app) expected_image="towbar/web-app:$release_commit" ;;
+  esac
+  running_image="$(docker inspect --format '{{.Config.Image}}' "$container_id")"
+  [[ "$running_image" == "$expected_image" ]] ||
+    deployment_fail "$service runs $running_image instead of $expected_image"
+done
+
+api_container_id="$(
+  compose_for "$release_commit" "$release_commit" ps -q api
+)"
+api_version="$(
+  docker exec "$api_container_id" node -e \
+    'fetch("http://127.0.0.1:4020/health").then((response) => response.json()).then((body) => process.stdout.write(body.version ?? ""))'
+)"
+[[ "$api_version" == "$release_commit" ]] ||
+  deployment_fail "API reports $api_version instead of $release_commit"
+
+trap - ERR INT TERM
+echo "Towbar $release_tag is healthy at $release_commit"


### PR DESCRIPTION
## Summary

- deploy every stable published release, with manual dispatch for retries and backfills
- authenticate to AWS through GitHub OIDC and invoke only the Towbar production EC2 through SSM
- validate the published tag and package version, build the exact release commit on the ARM host, wait for health, and attempt rollback on failure
- document the production environment variables and run ShellCheck in CI

## Infrastructure

- GitHub production environment is limited to the protected main branch and v* tags
- the AWS role can send AWS-RunShellScript only to the Towbar production instance
- no AWS access key or SSH private key is stored in GitHub

## Verification

- pnpm verify
- bash -n infra/deploy-release.sh
- shellcheck infra/deploy-release.sh
- actionlint .github/workflows/deploy-release.yml .github/workflows/ci.yml
- docker compose --env-file .env.example config --quiet
- git diff --check
- IAM policy simulation: target instance allowed; another instance denied