### PR TITLE
Harden the release deployment setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      # v4.4.0
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       # v4.4.0
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
       # v4.4.0
@@ -43,8 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      # v4.4.0
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Configure non-production Compose values
         run: |
           cp .env.example .env

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -34,8 +34,8 @@ jobs:
       RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
 
     steps:
-      # v4.4.0
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
           ref: ${{ github.event.repository.default_branch }}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,9 +130,12 @@ Configure these variables on a GitHub environment named `production`:
 | `TOWBAR_DEPLOY_API_HEALTH_URL` | Optional public API health endpoint          |
 | `TOWBAR_DEPLOY_APP_HEALTH_URL` | Optional public app health endpoint          |
 
-Trust only `repo:<owner>/<repository>:environment:production` in the role's
-OIDC policy. Grant `ssm:SendCommand` only for `AWS-RunShellScript` and the
-target instance, plus `ssm:GetCommandInvocation` for reporting the result. The
+Read the repository's OIDC subject prefix with
+`gh api repos/<owner>/<repository>/actions/oidc/customization/sub --jq .sub_claim_prefix`,
+then trust only `<returned-prefix>:environment:production` in the role's OIDC
+policy. This supports GitHub's immutable repository-ID subject without using a
+wildcard. Grant `ssm:SendCommand` only for `AWS-RunShellScript` and the target
+instance, plus `ssm:GetCommandInvocation` for reporting the result. The
 instance must be online in Systems Manager and the deployment directory must
 contain a clean Git checkout plus an owner-readable-only `.env` file.
 Restrict the environment's deployment branches and tags to the protected


### PR DESCRIPTION
## Summary

- document the exact immutable GitHub OIDC subject prefix used by repository environments
- upgrade pinned Checkout actions from v4.4.0 to v7.0.1 to remove the Node 20 runner warning

## Context

The first production release run proved the OIDC subject includes immutable organization and repository IDs. The AWS trust policy has already been narrowed to the exact observed subject, and the successful retry deployed v1.0.1.

## Verification

- actionlint .github/workflows/ci.yml .github/workflows/deploy-release.yml
- Prettier
- git diff --check
- successful production workflow run 32870617867