### PR TITLE
Make worker activity capacity configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,11 @@ TOWBAR_TRUSTED_PROXY_HOPS=0
 # self-deployment can hand cleanup to the newly healthy worker.
 TOWBAR_APP_ID=towbar-worker
 
+# Global Temporal activity capacity. Per-server buildConcurrency remains the
+# deployment limit for each destination host. Increase this only after checking
+# worker and destination-host capacity.
+TOWBAR_WORKER_MAX_CONCURRENT_ACTIVITIES=4
+
 TOWBAR_API_BASE_URL=http://localhost:4020
 TOWBAR_APP_BASE_URL=http://localhost:4021
 TOWBAR_WEBSITE_BASE_URL=https://www.towbar.dev

--- a/apps/towbar-worker/src/env.test.ts
+++ b/apps/towbar-worker/src/env.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseEnv } from "./env.js";
+
+const requiredEnv = {
+  TOWBAR_INTERNAL_HMAC_SECRET: "x".repeat(32),
+};
+
+void test("worker activity concurrency defaults to four", () => {
+  assert.equal(
+    parseEnv(requiredEnv).TOWBAR_WORKER_MAX_CONCURRENT_ACTIVITIES,
+    4,
+  );
+});
+
+void test("worker activity concurrency accepts a bounded override", () => {
+  assert.equal(
+    parseEnv({
+      ...requiredEnv,
+      TOWBAR_WORKER_MAX_CONCURRENT_ACTIVITIES: "16",
+    }).TOWBAR_WORKER_MAX_CONCURRENT_ACTIVITIES,
+    16,
+  );
+  assert.throws(() =>
+    parseEnv({
+      ...requiredEnv,
+      TOWBAR_WORKER_MAX_CONCURRENT_ACTIVITIES: "65",
+    }),
+  );
+});

--- a/apps/towbar-worker/src/env.ts
+++ b/apps/towbar-worker/src/env.ts
@@ -11,6 +11,12 @@ const envSchema = z.object({
   ),
   TOWBAR_API_BASE_URL: z.string().url().default("http://127.0.0.1:4020"),
   TOWBAR_INTERNAL_HMAC_SECRET: z.string().min(32),
+  TOWBAR_WORKER_MAX_CONCURRENT_ACTIVITIES: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(64)
+    .default(4),
   WORKER_HEALTH_PORT: z.coerce.number().int().min(1).max(65_535).default(4_030),
 });
 
@@ -19,6 +25,10 @@ type TowbarWorkerEnv = z.infer<typeof envSchema>;
 let cached: TowbarWorkerEnv | undefined;
 
 export function getEnv() {
-  cached ??= envSchema.parse(process.env);
+  cached ??= parseEnv(process.env);
   return cached;
+}
+
+export function parseEnv(input: NodeJS.ProcessEnv) {
+  return envSchema.parse(input);
 }

--- a/apps/towbar-worker/src/worker.ts
+++ b/apps/towbar-worker/src/worker.ts
@@ -44,7 +44,8 @@ async function main() {
     activities: instrumentedActivities,
     connection,
     identity: `towbar-worker-${process.pid}`,
-    maxConcurrentActivityTaskExecutions: 4,
+    maxConcurrentActivityTaskExecutions:
+      env.TOWBAR_WORKER_MAX_CONCURRENT_ACTIVITIES,
     namespace: env.TEMPORAL_NAMESPACE,
     taskQueue: towbarTaskQueue,
     workflowBundle: await loadWorkflowBundle(),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,7 @@ services:
       <<: *backend-environment
       TOWBAR_API_BASE_URL: http://api:4023
       TOWBAR_APP_ID: ${TOWBAR_APP_ID:-}
+      TOWBAR_WORKER_MAX_CONCURRENT_ACTIVITIES: ${TOWBAR_WORKER_MAX_CONCURRENT_ACTIVITIES:-4}
       WORKER_HEALTH_PORT: 4030
     networks: [platform]
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,6 +98,11 @@ variables. Add a Source, store its scoped AWS credential through the dashboard,
 and declare servers and deployables in `.towbar/deployment.yml`. Secret values
 remain in AWS Secrets Manager; the manifest stores provider references only.
 
+`TOWBAR_WORKER_MAX_CONCURRENT_ACTIVITIES` defaults to `4` and limits activity
+execution across every Source. Keep it above the largest server
+`buildConcurrency` value with capacity left for Source sync and maintenance.
+Each destination server still enforces its own manifest limit.
+
 The App and Resource **Secrets** tabs can add, replace, or remove individual
 JSON environment keys behind an attached reference. Listings expose only key
 names and version metadata. The owner can explicitly reveal current values


### PR DESCRIPTION
## Summary

- add a bounded `TOWBAR_WORKER_MAX_CONCURRENT_ACTIVITIES` worker setting
- keep the safe self-hosted default at 4 while allowing production operators to raise the global activity cap
- pass the setting through Docker Compose and document its relationship to per-server `buildConcurrency`

## Production plan

The production environment is prepared with a value of 16. The primary applications server now declares `buildConcurrency: 10` in the monorepo manifest, leaving activity capacity for the other servers, Source sync, and maintenance. The new cap takes effect only after the next Towbar release deploys this change.

## Verification

- `pnpm verify`
- `actionlint .github/workflows/*.yml`
- `docker compose --env-file .env.example config --quiet`
- `git diff --check`