### PR TITLE
Release Towbar v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to Towbar are documented in this file. This project follows
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-08-25
+
+### Added
+
+- Stable GitHub releases can deploy the exact published commit to the Towbar
+  host through GitHub Actions, AWS OIDC, and SSM.
+- Operators can set a bounded global Temporal activity capacity while each
+  destination server continues to enforce its own build concurrency.
+
+### Changed
+
+- Release deployment guidance now documents the immutable GitHub OIDC subject
+  used by protected repository environments.
+- GitHub Actions use the current pinned Checkout release.
+
 ## [1.0.1] - 2026-08-25
 
 ### Changed
@@ -31,6 +46,7 @@ All notable changes to Towbar are documented in this file. This project follows
 - Source-scoped AWS Secrets Manager integration and environment editors.
 - A same-domain owner setup, authentication, and operations dashboard.
 
-[Unreleased]: https://github.com/avgeek-inc/towbar/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/avgeek-inc/towbar/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/avgeek-inc/towbar/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/avgeek-inc/towbar/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/avgeek-inc/towbar/tree/v1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "towbar",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Opinionated, source-driven deployments to Ubuntu servers you own.",
   "keywords": [
     "deployment",


### PR DESCRIPTION
## Summary

- bump Towbar to `1.0.2`
- document release-driven production deployment and configurable worker activity capacity
- prepare the changelog and comparison links

## Verification

- `pnpm verify`
- `actionlint .github/workflows/*.yml`
- `docker compose --env-file .env.example config --quiet`
- `git diff --check`

## After merge

Publish the stable `v1.0.2` release from the merged commit. The release workflow will deploy that exact commit to production; production is already configured with worker activity capacity 16.