### PR TITLE
Restore Towbar managed brand assets

### DIFF
--- a/apps/towbar-web-app/Dockerfile
+++ b/apps/towbar-web-app/Dockerfile
@@ -21,7 +21,8 @@ ENV NEXT_TELEMETRY_DISABLED=1 \
   NEXT_PUBLIC_TOWBAR_WEBSITE_BASE_URL=${NEXT_PUBLIC_TOWBAR_WEBSITE_BASE_URL} \
   SENTRY_ALLOW_MISSING=true SOURCE_COMMIT=${SOURCE_COMMIT}
 COPY --from=pruner /repo/out/full/ ./
-RUN pnpm --filter towbar-web-app build
+RUN mkdir -p apps/towbar-web-app/public \
+  && pnpm --filter towbar-web-app build
 FROM base AS runner
 WORKDIR /app
 ENV NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 HOSTNAME=0.0.0.0 PORT=4021

--- a/apps/towbar-web-app/public/towbar-mark.svg
+++ b/apps/towbar-web-app/public/towbar-mark.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" role="img" aria-label="Towbar">
-  <rect width="48" height="48" rx="14" fill="oklch(0.205 0 0)"/>
-  <path d="M12 14h24v6H27v16h-6V20h-9z" fill="oklch(0.985 0 0)"/>
-</svg>

--- a/apps/towbar-web-app/src/app/layout.tsx
+++ b/apps/towbar-web-app/src/app/layout.tsx
@@ -5,13 +5,14 @@ import "@workspace/web-design-system/styles/globals.css";
 import "@workspace/web-page-sections/styles.css";
 import { WorkspaceDocument } from "@workspace/web-design-system/layouts/workspace-document";
 import { designSystemViewportColors } from "@workspace/web-design-system/lib/design-theme";
+import { getTowbarBrandFaviconSource } from "@workspace/towbar-web-ui/brand-assets";
 
 import { ApplicationFrame } from "@/components/application-frame";
 
 export const metadata: Metadata = {
   title: { default: "Towbar", template: "%s · Towbar" },
   description: "Deploy Dockerfile applications to your Ubuntu servers.",
-  icons: { icon: "/towbar-mark.svg" },
+  icons: { icon: getTowbarBrandFaviconSource() },
   robots: { follow: false, index: false },
 };
 

--- a/apps/towbar-web-app/src/lib/application-layout.ts
+++ b/apps/towbar-web-app/src/lib/application-layout.ts
@@ -23,7 +23,7 @@ const sidebarIcons = defineSidebarIcons({
 
 const brand = {
   accessibleLabel: "Towbar home",
-  id: "company",
+  id: "towbar",
   logo: createElement(TowbarBrandLogo),
   title: "Towbar",
 } as const;

--- a/packages/towbar-web-ui/package.json
+++ b/packages/towbar-web-ui/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "scripts": {
     "lint": "eslint . --max-warnings 0",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -21,6 +22,7 @@
     "@workspace/eslint-config": "workspace:*",
     "@workspace/typescript-config": "workspace:*",
     "eslint": "catalog:",
+    "tsx": "^4.21.0",
     "typescript": "catalog:"
   },
   "exports": {

--- a/packages/towbar-web-ui/package.json
+++ b/packages/towbar-web-ui/package.json
@@ -26,6 +26,7 @@
     "typescript": "catalog:"
   },
   "exports": {
+    "./brand-assets": "./src/brand-assets.ts",
     "./*": "./src/*.tsx"
   }
 }

--- a/packages/towbar-web-ui/src/brand-assets.ts
+++ b/packages/towbar-web-ui/src/brand-assets.ts
@@ -1,0 +1,14 @@
+const brandImageBaseUrl =
+  "https://www.towbar.dev/cdn-cgi/imagedelivery/phvjnb9w1G6QHeeoMJptkQ";
+
+function brandImageSource(customId: string, width: number) {
+  return `${brandImageBaseUrl}/${customId}/w=${width},fit=scale-down`;
+}
+
+export function getTowbarBrandFaviconSource() {
+  return brandImageSource("brands/towbar/favicon", 256);
+}
+
+export function getTowbarBrandLogoSource(theme: "dark" | "light") {
+  return brandImageSource(`brands/towbar/logo/${theme}-transparent-edge`, 128);
+}

--- a/packages/towbar-web-ui/src/brand.test.ts
+++ b/packages/towbar-web-ui/src/brand.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { TowbarLockup } from "./brand.js";
+
+Object.assign(globalThis, { React });
+
+void test("Towbar lockup uses the Towbar brand assets", () => {
+  const markup = renderToStaticMarkup(React.createElement(TowbarLockup));
+
+  assert.match(markup, /brands\/towbar\/logo\/light-transparent-edge/u);
+  assert.match(markup, /brands\/towbar\/logo\/dark-transparent-edge/u);
+  assert.doesNotMatch(markup, /brands\/company\/logo/u);
+  assert.match(markup, />Towbar<\/span>/u);
+});

--- a/packages/towbar-web-ui/src/brand.test.ts
+++ b/packages/towbar-web-ui/src/brand.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
+import { getTowbarBrandFaviconSource } from "./brand-assets.js";
 import { TowbarLockup } from "./brand.js";
 
 Object.assign(globalThis, { React });
@@ -14,4 +15,11 @@ void test("Towbar lockup uses the Towbar brand assets", () => {
   assert.match(markup, /brands\/towbar\/logo\/dark-transparent-edge/u);
   assert.doesNotMatch(markup, /brands\/company\/logo/u);
   assert.match(markup, />Towbar<\/span>/u);
+});
+
+void test("Towbar favicon uses the managed brand asset", () => {
+  const source = getTowbarBrandFaviconSource();
+
+  assert.match(source, /brands\/towbar\/favicon/u);
+  assert.doesNotMatch(source, /towbar-mark\.svg/u);
 });

--- a/packages/towbar-web-ui/src/brand.tsx
+++ b/packages/towbar-web-ui/src/brand.tsx
@@ -16,7 +16,7 @@ const brandLogoSources = {
 } as const;
 
 function brandLogoSource(theme: "dark" | "light") {
-  return `${brandImageBaseUrl}/brands/company/logo/${theme}-transparent-edge/w=128,fit=scale-down`;
+  return `${brandImageBaseUrl}/brands/towbar/logo/${theme}-transparent-edge/w=128,fit=scale-down`;
 }
 
 export function TowbarBrandLogo({

--- a/packages/towbar-web-ui/src/brand.tsx
+++ b/packages/towbar-web-ui/src/brand.tsx
@@ -4,20 +4,18 @@ import { useCallback, useState } from "react";
 
 import { BrandLockup } from "@workspace/web-design-system/media/brand-lockup";
 import { cn } from "@workspace/web-design-system/lib/utils";
+import {
+  getTowbarBrandFaviconSource,
+  getTowbarBrandLogoSource,
+} from "@workspace/towbar-web-ui/brand-assets";
 
 import type { ComponentPropsWithoutRef } from "react";
 
-const brandImageBaseUrl =
-  "https://www.towbar.dev/cdn-cgi/imagedelivery/phvjnb9w1G6QHeeoMJptkQ";
-const fallbackLogoSource = "/towbar-mark.svg";
+const fallbackLogoSource = getTowbarBrandFaviconSource();
 const brandLogoSources = {
-  dark: brandLogoSource("dark"),
-  light: brandLogoSource("light"),
+  dark: getTowbarBrandLogoSource("dark"),
+  light: getTowbarBrandLogoSource("light"),
 } as const;
-
-function brandLogoSource(theme: "dark" | "light") {
-  return `${brandImageBaseUrl}/brands/towbar/logo/${theme}-transparent-edge/w=128,fit=scale-down`;
-}
 
 export function TowbarBrandLogo({
   className,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -545,6 +545,9 @@ importers:
       eslint:
         specifier: "catalog:"
         version: 9.39.5(jiti@2.7.0)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.23.12
       typescript:
         specifier: "catalog:"
         version: 5.9.3


### PR DESCRIPTION
## Summary

- restore the Towbar-specific yellow trailer mark in the shared lockup
- align the application-shell brand identifier with Towbar instead of the company fallback
- resolve the favicon and lockup fallback through the managed `brands/towbar/favicon` asset
- remove the local `towbar-mark.svg` duplicate
- keep the web Docker image build valid when the app has no local `public` assets
- add regression coverage for the Towbar logo and favicon custom IDs

## Root cause

The lockup requested `brands/company/logo`, which resolves to the Avgeek company radar mark, while rendering the Towbar label. The favicon and fallback also bypassed the managed brand catalogue through a local SVG. Removing that final public asset exposed an unconditional Docker `COPY` of the now-absent directory.

## Verification

- confirmed the managed Towbar favicon and both light/dark logo variants return successfully
- `pnpm verify`
- `docker compose --env-file .env.example build web-app`
- `git diff --check`