### PR TITLE
Keep maintenance checks behind deployment work

### DIFF
--- a/apps/towbar-api/src/areas/deployments/queue-blocker-query.ts
+++ b/apps/towbar-api/src/areas/deployments/queue-blocker-query.ts
@@ -1,0 +1,87 @@
+import { and, eq, inArray } from "drizzle-orm";
+
+import {
+  resourceOperations,
+  serverChecks,
+  serverPreparations,
+} from "@workspace/towbar-database/schema";
+
+import { getTowbarDatabase } from "../../infrastructure/database.js";
+import {
+  type ServerQueueBarrier,
+  resolveDeploymentQueueBlocker,
+} from "./queue-blocker.js";
+
+export async function attachDeploymentQueueBlockers<
+  T extends { createdAt: Date; serverId: string; state: string },
+>(items: T[]) {
+  const queuedServerIds = [
+    ...new Set(
+      items
+        .filter((item) => item.state === "queued")
+        .map((item) => item.serverId),
+    ),
+  ];
+  if (queuedServerIds.length === 0) {
+    return items.map((item) => ({ ...item, queueBlocker: null }));
+  }
+
+  const database = getTowbarDatabase();
+  const [checks, preparations, operations] = await Promise.all([
+    database
+      .select({
+        createdAt: serverChecks.createdAt,
+        serverId: serverChecks.serverId,
+      })
+      .from(serverChecks)
+      .where(
+        and(
+          inArray(serverChecks.serverId, queuedServerIds),
+          inArray(serverChecks.status, ["queued", "running"]),
+        ),
+      ),
+    database
+      .select({
+        createdAt: serverPreparations.createdAt,
+        serverId: serverPreparations.serverId,
+      })
+      .from(serverPreparations)
+      .where(
+        and(
+          inArray(serverPreparations.serverId, queuedServerIds),
+          inArray(serverPreparations.status, ["queued", "running"]),
+        ),
+      ),
+    database
+      .select({
+        createdAt: resourceOperations.createdAt,
+        serverId: resourceOperations.serverId,
+      })
+      .from(resourceOperations)
+      .where(
+        and(
+          inArray(resourceOperations.serverId, queuedServerIds),
+          inArray(resourceOperations.state, ["queued", "running"]),
+          eq(resourceOperations.type, "cleanup_orphans"),
+        ),
+      ),
+  ]);
+  const barriers: ServerQueueBarrier[] = [
+    ...checks.map((check) => ({ ...check, type: "server_check" as const })),
+    ...preparations.map((preparation) => ({
+      ...preparation,
+      type: "server_preparation" as const,
+    })),
+    ...operations.map((operation) => ({
+      ...operation,
+      type: "server_operation" as const,
+    })),
+  ];
+  return items.map((item) => ({
+    ...item,
+    queueBlocker: resolveDeploymentQueueBlocker({
+      barriers,
+      deployment: item,
+    }),
+  }));
+}

--- a/apps/towbar-api/src/areas/deployments/queue-blocker.test.ts
+++ b/apps/towbar-api/src/areas/deployments/queue-blocker.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveDeploymentQueueBlocker } from "./queue-blocker.js";
+
+const deployment = {
+  createdAt: new Date("2026-08-25T17:09:00.000Z"),
+  serverId: "server-1",
+  state: "queued",
+};
+
+void test("reports the earliest server barrier ahead of a queued deployment", () => {
+  assert.equal(
+    resolveDeploymentQueueBlocker({
+      barriers: [
+        {
+          createdAt: new Date("2026-08-25T17:08:00.000Z"),
+          serverId: "server-1",
+          type: "server_preparation",
+        },
+        {
+          createdAt: new Date("2026-08-25T17:06:00.000Z"),
+          serverId: "server-1",
+          type: "server_check",
+        },
+      ],
+      deployment,
+    }),
+    "server_check",
+  );
+});
+
+void test("ignores work enqueued after the deployment and work on other servers", () => {
+  assert.equal(
+    resolveDeploymentQueueBlocker({
+      barriers: [
+        {
+          createdAt: new Date("2026-08-25T17:10:00.000Z"),
+          serverId: "server-1",
+          type: "server_check",
+        },
+        {
+          createdAt: new Date("2026-08-25T17:05:00.000Z"),
+          serverId: "server-2",
+          type: "server_operation",
+        },
+      ],
+      deployment,
+    }),
+    "server_capacity",
+  );
+});
+
+void test("does not attach a queue blocker after execution starts", () => {
+  assert.equal(
+    resolveDeploymentQueueBlocker({
+      barriers: [
+        {
+          createdAt: new Date("2026-08-25T17:06:00.000Z"),
+          serverId: "server-1",
+          type: "server_check",
+        },
+      ],
+      deployment: { ...deployment, state: "waiting_for_server" },
+    }),
+    null,
+  );
+});

--- a/apps/towbar-api/src/areas/deployments/queue-blocker.ts
+++ b/apps/towbar-api/src/areas/deployments/queue-blocker.ts
@@ -1,0 +1,28 @@
+export type DeploymentQueueBlocker =
+  | "server_capacity"
+  | "server_check"
+  | "server_operation"
+  | "server_preparation";
+
+export type ServerQueueBarrier = {
+  createdAt: Date;
+  serverId: string;
+  type: Exclude<DeploymentQueueBlocker, "server_capacity">;
+};
+
+export function resolveDeploymentQueueBlocker(input: {
+  barriers: ServerQueueBarrier[];
+  deployment: { createdAt: Date; serverId: string; state: string };
+}): DeploymentQueueBlocker | null {
+  if (input.deployment.state !== "queued") return null;
+  const barrier = input.barriers
+    .filter(
+      (candidate) =>
+        candidate.serverId === input.deployment.serverId &&
+        candidate.createdAt.getTime() <= input.deployment.createdAt.getTime(),
+    )
+    .sort(
+      (left, right) => left.createdAt.getTime() - right.createdAt.getTime(),
+    )[0];
+  return barrier?.type ?? "server_capacity";
+}

--- a/apps/towbar-api/src/areas/deployments/service.ts
+++ b/apps/towbar-api/src/areas/deployments/service.ts
@@ -34,6 +34,7 @@ import { resolveAwsSecret } from "../aws/service.js";
 import { createInstallationToken } from "../github/client.js";
 import { sshLoginSecretSchema } from "../servers/service.js";
 import { collectRetainedImageTags } from "./image-retention.js";
+import { attachDeploymentQueueBlockers } from "./queue-blocker-query.js";
 
 import type { DeploymentState } from "@workspace/towbar-core/temporal";
 
@@ -60,7 +61,7 @@ const publicDeploymentLogSelection = {
 };
 
 export async function listDeployments(workspaceId: string, sourceId?: string) {
-  return await getTowbarDatabase()
+  const items = await getTowbarDatabase()
     .select(publicDeploymentSelection)
     .from(deployments)
     .where(
@@ -72,6 +73,7 @@ export async function listDeployments(workspaceId: string, sourceId?: string) {
         : eq(deployments.workspaceId, workspaceId),
     )
     .orderBy(desc(deployments.createdAt));
+  return await attachDeploymentQueueBlockers(items);
 }
 
 export async function getDeployment(deploymentId: string, workspaceId: string) {
@@ -86,7 +88,7 @@ export async function getDeployment(deploymentId: string, workspaceId: string) {
     )
     .limit(1);
   if (!deployment) throw notFound("Deployment");
-  return deployment;
+  return (await attachDeploymentQueueBlockers([deployment]))[0]!;
 }
 
 export async function listDeploymentSteps(

--- a/apps/towbar-api/src/areas/resource-operations/maintenance.test.ts
+++ b/apps/towbar-api/src/areas/resource-operations/maintenance.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldQueueMaintenanceServerCheck } from "./maintenance.js";
+
+const now = new Date("2026-08-25T17:30:00.000Z");
+
+void test("queues the first maintenance check only when the server queue is idle", () => {
+  assert.equal(
+    shouldQueueMaintenanceServerCheck({
+      hasPendingServerWork: false,
+      latestCheck: undefined,
+      now,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldQueueMaintenanceServerCheck({
+      hasPendingServerWork: true,
+      latestCheck: undefined,
+      now,
+    }),
+    false,
+  );
+});
+
+void test("defers stale checks while deployments or operations are pending", () => {
+  assert.equal(
+    shouldQueueMaintenanceServerCheck({
+      hasPendingServerWork: true,
+      latestCheck: {
+        createdAt: new Date("2026-08-25T17:20:00.000Z"),
+        status: "succeeded",
+      },
+      now,
+    }),
+    false,
+  );
+});
+
+void test("queues only completed checks that are at least five minutes old", () => {
+  for (const status of ["queued", "running"] as const) {
+    assert.equal(
+      shouldQueueMaintenanceServerCheck({
+        hasPendingServerWork: false,
+        latestCheck: {
+          createdAt: new Date("2026-08-25T17:20:00.000Z"),
+          status,
+        },
+        now,
+      }),
+      false,
+    );
+  }
+  assert.equal(
+    shouldQueueMaintenanceServerCheck({
+      hasPendingServerWork: false,
+      latestCheck: {
+        createdAt: new Date("2026-08-25T17:25:00.001Z"),
+        status: "failed",
+      },
+      now,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldQueueMaintenanceServerCheck({
+      hasPendingServerWork: false,
+      latestCheck: {
+        createdAt: new Date("2026-08-25T17:25:00.000Z"),
+        status: "succeeded",
+      },
+      now,
+    }),
+    true,
+  );
+});

--- a/apps/towbar-api/src/areas/resource-operations/maintenance.ts
+++ b/apps/towbar-api/src/areas/resource-operations/maintenance.ts
@@ -1,16 +1,27 @@
-import { and, desc, eq, isNull, ne } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, ne, notInArray } from "drizzle-orm";
 
 import {
   getLatestBackupScheduleOccurrence,
   isNormalizedResource,
 } from "@workspace/towbar-core";
-import { apps, serverChecks, servers } from "@workspace/towbar-database/schema";
+import { terminalDeploymentStates } from "@workspace/towbar-core/temporal";
+import {
+  apps,
+  deployments,
+  resourceOperations,
+  serverChecks,
+  serverPreparations,
+  servers,
+} from "@workspace/towbar-database/schema";
 
 import { getTowbarDatabase } from "../../infrastructure/database.js";
 import { requestServerCheck } from "../servers/service.js";
 import { requestDeployableOperation } from "./service.js";
 
 export async function runMaintenanceSweep() {
+  // Scheduled deployable work has priority; health checks are maintenance and
+  // should enter a server coordinator only after its queue becomes idle.
+  const backupsQueued = await queueScheduledBackups();
   const activeServers = await getTowbarDatabase()
     .select({
       id: servers.id,
@@ -31,9 +42,11 @@ export async function runMaintenanceSweep() {
       .orderBy(desc(serverChecks.createdAt))
       .limit(1);
     if (
-      !latest ||
-      (!["queued", "running"].includes(latest.status) &&
-        Date.now() - latest.createdAt.getTime() >= 5 * 60_000)
+      shouldQueueMaintenanceServerCheck({
+        hasPendingServerWork: await hasPendingServerWork(server.id),
+        latestCheck: latest,
+        now: new Date(),
+      })
     ) {
       const queued = await requestServerCheck({
         requestedBy: null,
@@ -45,6 +58,10 @@ export async function runMaintenanceSweep() {
     }
   }
 
+  return { backupsQueued, checksQueued };
+}
+
+async function queueScheduledBackups() {
   const resources = await getTowbarDatabase()
     .select({ id: apps.id, config: apps.config, workspaceId: apps.workspaceId })
     .from(apps)
@@ -69,5 +86,60 @@ export async function runMaintenanceSweep() {
       })
       .catch(() => undefined);
   }
-  return { backupsQueued, checksQueued };
+  return backupsQueued;
+}
+
+async function hasPendingServerWork(serverId: string) {
+  const database = getTowbarDatabase();
+  const [activeDeployments, activeOperations, activePreparations] =
+    await Promise.all([
+      database
+        .select({ id: deployments.id })
+        .from(deployments)
+        .where(
+          and(
+            eq(deployments.serverId, serverId),
+            notInArray(deployments.state, [...terminalDeploymentStates]),
+          ),
+        )
+        .limit(1),
+      database
+        .select({ id: resourceOperations.id })
+        .from(resourceOperations)
+        .where(
+          and(
+            eq(resourceOperations.serverId, serverId),
+            inArray(resourceOperations.state, ["queued", "running"]),
+          ),
+        )
+        .limit(1),
+      database
+        .select({ id: serverPreparations.id })
+        .from(serverPreparations)
+        .where(
+          and(
+            eq(serverPreparations.serverId, serverId),
+            inArray(serverPreparations.status, ["queued", "running"]),
+          ),
+        )
+        .limit(1),
+    ]);
+  return Boolean(
+    activeDeployments[0] || activeOperations[0] || activePreparations[0],
+  );
+}
+
+export function shouldQueueMaintenanceServerCheck(input: {
+  hasPendingServerWork: boolean;
+  latestCheck:
+    | { createdAt: Date; status: "failed" | "queued" | "running" | "succeeded" }
+    | undefined;
+  now: Date;
+}) {
+  if (input.hasPendingServerWork) return false;
+  if (!input.latestCheck) return true;
+  if (["queued", "running"].includes(input.latestCheck.status)) return false;
+  return (
+    input.now.getTime() - input.latestCheck.createdAt.getTime() >= 5 * 60_000
+  );
 }

--- a/apps/towbar-web-app/src/components/app-detail.tsx
+++ b/apps/towbar-web-app/src/components/app-detail.tsx
@@ -19,6 +19,7 @@ import { Tabs } from "@workspace/web-design-system/navigation/tabs";
 import { TypographyCode } from "@workspace/web-design-system/typography/typography";
 import { QueryError, QueryLoading } from "@workspace/towbar-web-ui/query-state";
 import { StatusBadge } from "@workspace/towbar-web-ui/status-badge";
+import { getDeploymentDisplayStatus } from "@/lib/deployment-status";
 
 import { ActionButton, DashboardPage, PageTabs } from "@/components/page-parts";
 import { useApiQuery } from "@/hooks/use-api-query";
@@ -204,7 +205,9 @@ export function AppDetail() {
                 >
                   <Attributes.Item label="Status">
                     {latestDeployment ? (
-                      <StatusBadge status={latestDeployment.state} />
+                      <StatusBadge
+                        status={getDeploymentDisplayStatus(latestDeployment)}
+                      />
                     ) : (
                       "Not deployed"
                     )}

--- a/apps/towbar-web-app/src/components/deployment-detail.tsx
+++ b/apps/towbar-web-app/src/components/deployment-detail.tsx
@@ -38,6 +38,7 @@ import { api } from "@/lib/api";
 import { formatDate } from "./dashboard-overview";
 import { formatDeploymentTrigger } from "./deployment-table";
 import { useSourceBreadcrumbs } from "./source-breadcrumbs";
+import { getDeploymentDisplayStatus } from "@/lib/deployment-status";
 
 const terminal = new Set([
   "cancelled",
@@ -110,6 +111,7 @@ export function DeploymentDetail() {
     );
 
   const item = stream.deployment;
+  const displayStatus = getDeploymentDisplayStatus(item);
   if (item.sourceId !== sourceId) {
     return (
       <DashboardPage
@@ -181,7 +183,7 @@ export function DeploymentDetail() {
   return (
     <DashboardPage
       actions={actions}
-      badge={<StatusBadge status={item.state} />}
+      badge={<StatusBadge status={displayStatus} />}
       breadcrumbAncestors={breadcrumbAncestors}
       breadcrumbLabel={`Deployment ${item.id.slice(0, 8)}`}
       title={`Deployment ${item.id.slice(0, 8)}`}
@@ -327,7 +329,7 @@ export function DeploymentDetail() {
               <Widget className="min-w-0">
                 <Widget.Header>
                   <Widget.Title>
-                    {formatStatus(currentStep?.state ?? item.state)}
+                    {formatStatus(currentStep?.state ?? displayStatus)}
                   </Widget.Title>
                   <StatusBadge status={stream.connection} />
                 </Widget.Header>

--- a/apps/towbar-web-app/src/components/deployment-queue.tsx
+++ b/apps/towbar-web-app/src/components/deployment-queue.tsx
@@ -16,6 +16,7 @@ import { ScrollShadow } from "@workspace/web-design-system/utilities/scroll-shad
 import { formatStatus } from "@workspace/towbar-web-ui/status-badge";
 
 import { useApiQuery } from "@/hooks/use-api-query";
+import { getDeploymentDisplayStatus } from "@/lib/deployment-status";
 
 const terminalDeploymentStates = new Set<DeploymentState>([
   "cancelled",
@@ -30,8 +31,8 @@ const waitingDeploymentStates = new Set<DeploymentState>([
   "waiting_for_server",
 ]);
 
-function DeploymentStateIndicator({ state }: { state: DeploymentState }) {
-  const isWaiting = waitingDeploymentStates.has(state);
+function DeploymentStateIndicator({ deployment }: { deployment: Deployment }) {
+  const isWaiting = waitingDeploymentStates.has(deployment.state);
 
   return (
     <span className="flex shrink-0 items-center gap-2">
@@ -54,7 +55,7 @@ function DeploymentStateIndicator({ state }: { state: DeploymentState }) {
         </ProgressCircle>
       )}
       <span className="typography--body-sm text-muted">
-        {formatStatus(state)}
+        {formatStatus(getDeploymentDisplayStatus(deployment))}
       </span>
     </span>
   );
@@ -148,7 +149,7 @@ export function DeploymentQueue() {
                       >
                         {deployableName}
                       </span>
-                      <DeploymentStateIndicator state={deployment.state} />
+                      <DeploymentStateIndicator deployment={deployment} />
                     </Button>
                   );
                 })}

--- a/apps/towbar-web-app/src/components/deployment-table.tsx
+++ b/apps/towbar-web-app/src/components/deployment-table.tsx
@@ -11,6 +11,7 @@ import {
 import { StatusBadge } from "@workspace/towbar-web-ui/status-badge";
 
 import { RelativeTime, RelativeTimeProvider } from "./last-synced-time";
+import { getDeploymentDisplayStatus } from "@/lib/deployment-status";
 
 const DEPLOYMENT_PAGE_SIZE = 10;
 
@@ -76,7 +77,9 @@ export function DeploymentTable({
     {
       key: "status",
       header: "Status",
-      cell: (deployment) => <StatusBadge status={deployment.state} />,
+      cell: (deployment) => (
+        <StatusBadge status={getDeploymentDisplayStatus(deployment)} />
+      ),
       className: "whitespace-nowrap",
     },
   ];

--- a/apps/towbar-web-app/src/components/resource-detail.tsx
+++ b/apps/towbar-web-app/src/components/resource-detail.tsx
@@ -24,6 +24,7 @@ import { Tabs } from "@workspace/web-design-system/navigation/tabs";
 import { TypographyCode } from "@workspace/web-design-system/typography/typography";
 import { QueryError, QueryLoading } from "@workspace/towbar-web-ui/query-state";
 import { StatusBadge } from "@workspace/towbar-web-ui/status-badge";
+import { getDeploymentDisplayStatus } from "@/lib/deployment-status";
 
 import { ActionButton, DashboardPage, PageTabs } from "@/components/page-parts";
 import { useApiQuery } from "@/hooks/use-api-query";
@@ -150,7 +151,9 @@ export function ResourceDetail() {
           <Attributes columns={2} title="Latest deployment" variant="card">
             <Attributes.Item label="Status">
               {latestDeployment ? (
-                <StatusBadge status={latestDeployment.state} />
+                <StatusBadge
+                  status={getDeploymentDisplayStatus(latestDeployment)}
+                />
               ) : (
                 "Not deployed"
               )}

--- a/apps/towbar-web-app/src/lib/deployment-status.test.ts
+++ b/apps/towbar-web-app/src/lib/deployment-status.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getDeploymentDisplayStatus } from "./deployment-status";
+
+void test("explains each queued deployment blocker", () => {
+  assert.equal(
+    getDeploymentDisplayStatus({
+      queueBlocker: "server_check",
+      state: "queued",
+    }),
+    "waiting_for_server_check",
+  );
+  assert.equal(
+    getDeploymentDisplayStatus({
+      queueBlocker: "server_preparation",
+      state: "queued",
+    }),
+    "waiting_for_server_preparation",
+  );
+  assert.equal(
+    getDeploymentDisplayStatus({
+      queueBlocker: "server_operation",
+      state: "queued",
+    }),
+    "waiting_for_server_operation",
+  );
+  assert.equal(
+    getDeploymentDisplayStatus({
+      queueBlocker: "server_capacity",
+      state: "queued",
+    }),
+    "waiting_for_server_capacity",
+  );
+});
+
+void test("keeps workflow states authoritative after a deployment starts", () => {
+  assert.equal(
+    getDeploymentDisplayStatus({
+      queueBlocker: "server_check",
+      state: "waiting_for_server",
+    }),
+    "waiting_for_server",
+  );
+});

--- a/apps/towbar-web-app/src/lib/deployment-status.ts
+++ b/apps/towbar-web-app/src/lib/deployment-status.ts
@@ -1,0 +1,19 @@
+import type { Deployment, DeploymentState } from "@workspace/towbar-web-client";
+
+export function getDeploymentDisplayStatus(
+  deployment: Pick<Deployment, "queueBlocker" | "state">,
+): DeploymentState | string {
+  if (deployment.state !== "queued") return deployment.state;
+  switch (deployment.queueBlocker) {
+    case "server_check":
+      return "waiting_for_server_check";
+    case "server_preparation":
+      return "waiting_for_server_preparation";
+    case "server_operation":
+      return "waiting_for_server_operation";
+    case "server_capacity":
+      return "waiting_for_server_capacity";
+    default:
+      return deployment.state;
+  }
+}

--- a/packages/towbar-web-client/src/types.ts
+++ b/packages/towbar-web-client/src/types.ts
@@ -292,6 +292,12 @@ export type Deployment = {
   id: string;
   kind: "deploy" | "rollback";
   manifestDigest: string;
+  queueBlocker?:
+    | "server_capacity"
+    | "server_check"
+    | "server_operation"
+    | "server_preparation"
+    | null;
   serverId: string;
   sourceId: string;
   startedAt: string | null;

--- a/packages/towbar-web-ui/src/status-badge.tsx
+++ b/packages/towbar-web-ui/src/status-badge.tsx
@@ -40,6 +40,10 @@ const warning = new Set([
   "untrusted",
   "waiting",
   "waiting_for_server",
+  "waiting_for_server_capacity",
+  "waiting_for_server_check",
+  "waiting_for_server_operation",
+  "waiting_for_server_preparation",
   "server_setup_pending",
   "pending",
 ]);


### PR DESCRIPTION
## Summary
- schedule due backups before automatic server health checks and defer checks while a server has queued or active work
- derive the specific barrier ahead of queued deployments without changing the persisted deployment state machine
- show waiting-for-check, preparation, operation, or capacity labels across deployment surfaces

## Why
Automatic five-minute server checks are exclusive FIFO barriers. A check admitted while builds were active could retain its queue position and delay deployments requested afterward even when server build concurrency remained available.

## Verification
- `pnpm verify`
- 182 workspace tests passed
- API, worker workflow bundle, and Next.js production builds passed