### PR TITLE
Fix stale Caddy routes after app restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Towbar are documented in this file. This project follows
 
 ## [Unreleased]
 
+### Fixed
+
+- Application containers now retain their loopback host port across Docker
+  restarts, preventing Caddy from keeping an obsolete upstream after an OOM or
+  runtime restart.
+
 ## [1.0.2] - 2026-08-25
 
 ### Added

--- a/packages/towbar-deployer/README.md
+++ b/packages/towbar-deployer/README.md
@@ -31,6 +31,9 @@ exfiltrate the app's own declared build secrets.
 
 Every candidate receives `SOURCE_COMMIT` for the selected immutable revision,
 along with Towbar's app, deployment, and commit metadata variables.
+Application candidates receive an explicit loopback host port selected by the
+executor. Docker therefore retains the same Caddy upstream when a container is
+restarted by its runtime policy instead of assigning a new anonymous port.
 
 Resource deployments pull a versioned image, create a release-owned local tag,
 and replace only the current Resource container. Logical volume names map to

--- a/packages/towbar-deployer/src/remote-scripts.test.ts
+++ b/packages/towbar-deployer/src/remote-scripts.test.ts
@@ -58,7 +58,7 @@ void describe("remote deployment scripts", () => {
     assert.match(startRemoteScript, /secrets\/runtime/);
     assert.match(startRemoteScript, /secret_path\.read_text/);
     assert.match(startRemoteScript, /\("--env", secret_path\.name\)/);
-    assert.match(startRemoteScript, /os\.execve/);
+    assert.match(startRemoteScript, /subprocess\.run/);
     assert.match(startRemoteScript, /\/usr\/bin\/docker run/);
     assert.doesNotMatch(startRemoteScript, /--env-file/);
   });
@@ -68,6 +68,17 @@ void describe("remote deployment scripts", () => {
       startRemoteScript,
       /--env "SOURCE_COMMIT=\$TOWBAR_COMMIT_SHA"/,
     );
+  });
+
+  void it("publishes applications on explicit restart-stable loopback ports", () => {
+    assert.match(startRemoteScript, /port_minimum = 20_000/);
+    assert.match(
+      startRemoteScript,
+      /127\.0\.0\.1:\{host_port\}:\{container_port\}/,
+    );
+    assert.match(startRemoteScript, /towbar\.host-port=__TOWBAR_HOST_PORT__/);
+    assert.match(startRemoteScript, /port is already allocated/);
+    assert.doesNotMatch(startRemoteScript, /127\.0\.0\.1::\$container_port/);
   });
 
   void it("starts resources with stable labeled volumes and stops only the previous release", () => {

--- a/packages/towbar-deployer/src/remote-scripts.ts
+++ b/packages/towbar-deployer/src/remote-scripts.ts
@@ -55,7 +55,7 @@ runtime_args=()
 if test -n "$network_name"; then runtime_args+=(--network "$network_name"); fi
 if test -n "$resource_cpus"; then runtime_args+=(--cpus "$resource_cpus"); fi
 if test -n "$resource_memory"; then runtime_args+=(--memory "$resource_memory"); fi
-/usr/bin/python3 - "$remote_dir/secrets/runtime" \
+/usr/bin/python3 - "$remote_dir/secrets/runtime" "$container_name" "$container_port" \
   /usr/bin/docker run -d "${"$"}{runtime_args[@]}" \
   --name "$container_name" \
   --restart unless-stopped \
@@ -69,22 +69,86 @@ if test -n "$resource_memory"; then runtime_args+=(--memory "$resource_memory");
   --label "towbar.deployable=$TOWBAR_DEPLOYABLE_ID" \
   --label "towbar.source=$TOWBAR_SOURCE_ID" \
   --label "towbar.deployment=$TOWBAR_DEPLOYMENT_ID" \
-  -p "127.0.0.1::$container_port" \
+  --label "towbar.host-port=__TOWBAR_HOST_PORT__" \
+  -p "__TOWBAR_PUBLISH__" \
   "$image_tag" <<'PYTHON' >/dev/null
+import hashlib
 import os
 from pathlib import Path
+import socket
+import subprocess
 import sys
 
 runtime_directory = Path(sys.argv[1])
-command = sys.argv[2:]
+container_name = sys.argv[2]
+container_port = sys.argv[3]
+command = sys.argv[4:]
 runtime_arguments: list[str] = []
 for secret_path in sorted(runtime_directory.iterdir()):
     if not secret_path.is_file():
         continue
     os.environ[secret_path.name] = secret_path.read_text(encoding="utf-8")
     runtime_arguments.extend(("--env", secret_path.name))
-command[3:3] = runtime_arguments
-os.execve(command[0], command, os.environ)
+
+# Docker records an anonymous loopback publication with an empty HostPort and
+# may assign a different port when it restarts the container. Caddy would then
+# retain the obsolete upstream. Select an explicit port instead so the binding
+# remains stable for the lifetime of the container, including restarts.
+port_minimum = 20_000
+port_count = 10_000
+seed = int.from_bytes(
+    hashlib.sha256(os.environ["TOWBAR_DEPLOYABLE_ID"].encode()).digest()[:4],
+    "big",
+)
+retryable_errors = (
+    "address already in use",
+    "port is already allocated",
+)
+
+for offset in range(port_count):
+    host_port = port_minimum + ((seed + offset) % port_count)
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        probe.bind(("127.0.0.1", host_port))
+    except OSError:
+        probe.close()
+        continue
+    probe.close()
+
+    publish = f"127.0.0.1:{host_port}:{container_port}"
+    candidate_command = [
+        argument
+        .replace("__TOWBAR_HOST_PORT__", str(host_port))
+        .replace("__TOWBAR_PUBLISH__", publish)
+        for argument in command
+    ]
+    candidate_command[3:3] = runtime_arguments
+    result = subprocess.run(
+        candidate_command,
+        check=False,
+        env=os.environ,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode == 0:
+        sys.stdout.write(result.stdout)
+        raise SystemExit(0)
+
+    error = result.stderr.strip()
+    if not any(fragment in error.lower() for fragment in retryable_errors):
+        if error:
+            print(error, file=sys.stderr)
+        raise SystemExit(result.returncode)
+
+    subprocess.run(
+        ["/usr/bin/docker", "rm", "-f", container_name],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+raise SystemExit("Towbar could not allocate a stable loopback host port")
 PYTHON
 docker port "$container_name" "$container_port/tcp" | awk -F: 'NR==1 {print $NF}'
 `;


### PR DESCRIPTION
## Summary

- allocate an explicit loopback host port for every application candidate
- keep that port stable when Docker restarts a container after an OOM or runtime failure
- retry safely when concurrent deployments race for a port
- document and test the restart behavior

## Why

Docker anonymous host-port publications can be reassigned during a container restart while Caddy continues proxying to the old port. This caused Internal HQ API to become healthy on a new port while its public route returned 502.

Existing application containers adopt stable ports on their next deployment. Ports remain bound to `127.0.0.1`; this does not expand network exposure.

## Verification

- `pnpm verify`
- embedded remote Python script compiled with `compile()`
- `pnpm --filter @workspace/towbar-deployer test`