### PR TITLE
TW-3 Add SSH host key untrust action

### DIFF
--- a/apps/towbar-api/src/areas/servers/service.ts
+++ b/apps/towbar-api/src/areas/servers/service.ts
@@ -13,12 +13,11 @@ import {
   sshHostKeys,
 } from "@workspace/towbar-database/schema";
 
-import { badRequest, notFound } from "../../http/errors.js";
+import { notFound } from "../../http/errors.js";
 import { getTowbarDatabase } from "../../infrastructure/database.js";
 import { enqueueServerCheck } from "../../infrastructure/temporal.js";
 import { publicDeploymentSelection } from "../deployment-selection.js";
 import { resolveAwsSecret } from "../aws/service.js";
-import { parseTrustedHostKey } from "./host-key.js";
 
 export const sshLoginSecretSchema = z
   .object({
@@ -235,57 +234,6 @@ export async function listServerDeployments(
     .from(deployments)
     .where(eq(deployments.serverId, serverId))
     .orderBy(desc(deployments.createdAt));
-}
-
-export async function listTrustedHostKeys(
-  serverId: string,
-  workspaceId: string,
-) {
-  await getServer(serverId, workspaceId);
-  return await getTowbarDatabase()
-    .select({
-      algorithm: sshHostKeys.algorithm,
-      createdAt: sshHostKeys.createdAt,
-      fingerprint: sshHostKeys.fingerprint,
-      id: sshHostKeys.id,
-    })
-    .from(sshHostKeys)
-    .where(
-      and(eq(sshHostKeys.serverId, serverId), isNull(sshHostKeys.revokedAt)),
-    );
-}
-
-export async function trustServerHostKey(input: {
-  algorithm: string;
-  fingerprint: string;
-  publicKey: string;
-  serverId: string;
-  trustedBy: string;
-  workspaceId: string;
-}) {
-  await getServer(input.serverId, input.workspaceId);
-  let hostKey: ReturnType<typeof parseTrustedHostKey>;
-  try {
-    hostKey = parseTrustedHostKey(input);
-  } catch (error) {
-    throw badRequest(
-      error instanceof Error ? error.message : "Host public key is invalid",
-      "INVALID_HOST_KEY",
-    );
-  }
-  const [key] = await getTowbarDatabase()
-    .insert(sshHostKeys)
-    .values({ ...input, ...hostKey })
-    .onConflictDoUpdate({
-      target: [sshHostKeys.serverId, sshHostKeys.fingerprint],
-      set: { publicKey: hostKey.publicKey, revokedAt: null },
-    })
-    .returning({
-      algorithm: sshHostKeys.algorithm,
-      fingerprint: sshHostKeys.fingerprint,
-      id: sshHostKeys.id,
-    });
-  return key;
 }
 
 export async function requestServerCheck(input: {

--- a/apps/towbar-api/src/areas/servers/trusted-host-keys.ts
+++ b/apps/towbar-api/src/areas/servers/trusted-host-keys.ts
@@ -1,0 +1,80 @@
+import { and, eq, isNull } from "drizzle-orm";
+
+import { sshHostKeys } from "@workspace/towbar-database/schema";
+
+import { badRequest, notFound } from "../../http/errors.js";
+import { getTowbarDatabase } from "../../infrastructure/database.js";
+import { parseTrustedHostKey } from "./host-key.js";
+import { getServer } from "./service.js";
+
+export async function listTrustedHostKeys(
+  serverId: string,
+  workspaceId: string,
+) {
+  await getServer(serverId, workspaceId);
+  return await getTowbarDatabase()
+    .select({
+      algorithm: sshHostKeys.algorithm,
+      createdAt: sshHostKeys.createdAt,
+      fingerprint: sshHostKeys.fingerprint,
+      id: sshHostKeys.id,
+    })
+    .from(sshHostKeys)
+    .where(
+      and(eq(sshHostKeys.serverId, serverId), isNull(sshHostKeys.revokedAt)),
+    );
+}
+
+export async function trustServerHostKey(input: {
+  algorithm: string;
+  fingerprint: string;
+  publicKey: string;
+  serverId: string;
+  trustedBy: string;
+  workspaceId: string;
+}) {
+  await getServer(input.serverId, input.workspaceId);
+  let hostKey: ReturnType<typeof parseTrustedHostKey>;
+  try {
+    hostKey = parseTrustedHostKey(input);
+  } catch (error) {
+    throw badRequest(
+      error instanceof Error ? error.message : "Host public key is invalid",
+      "INVALID_HOST_KEY",
+    );
+  }
+  const [key] = await getTowbarDatabase()
+    .insert(sshHostKeys)
+    .values({ ...input, ...hostKey })
+    .onConflictDoUpdate({
+      target: [sshHostKeys.serverId, sshHostKeys.fingerprint],
+      set: { publicKey: hostKey.publicKey, revokedAt: null },
+    })
+    .returning({
+      algorithm: sshHostKeys.algorithm,
+      fingerprint: sshHostKeys.fingerprint,
+      id: sshHostKeys.id,
+    });
+  return key;
+}
+
+export async function revokeServerHostKey(input: {
+  hostKeyId: string;
+  serverId: string;
+  workspaceId: string;
+}) {
+  await getServer(input.serverId, input.workspaceId);
+  const [key] = await getTowbarDatabase()
+    .update(sshHostKeys)
+    .set({ revokedAt: new Date() })
+    .where(
+      and(
+        eq(sshHostKeys.id, input.hostKeyId),
+        eq(sshHostKeys.serverId, input.serverId),
+        isNull(sshHostKeys.revokedAt),
+      ),
+    )
+    .returning({ id: sshHostKeys.id });
+  if (!key) throw notFound("Trusted host key");
+  return key;
+}

--- a/apps/towbar-api/src/routes/v1/core/servers.ts
+++ b/apps/towbar-api/src/routes/v1/core/servers.ts
@@ -7,10 +7,13 @@ import {
   listServerDeployments,
   listServerResources,
   listServers,
-  listTrustedHostKeys,
   requestServerCheck,
-  trustServerHostKey,
 } from "../../../areas/servers/service.js";
+import {
+  listTrustedHostKeys,
+  revokeServerHostKey,
+  trustServerHostKey,
+} from "../../../areas/servers/trusted-host-keys.js";
 import { listServerChecks } from "../../../areas/servers/checks.js";
 import {
   listServerPreparations,
@@ -191,6 +194,15 @@ serverRoutes.post("/:serverId/host-keys/actions/trust", async (context) => {
     },
     201,
   );
+});
+serverRoutes.delete("/:serverId/host-keys/:hostKeyId", async (context) => {
+  const user = context.get("user");
+  await revokeServerHostKey({
+    hostKeyId: context.req.param("hostKeyId"),
+    serverId: context.req.param("serverId"),
+    workspaceId: user.workspaceId,
+  });
+  return context.body(null, 204);
 });
 
 function requireIdempotencyKey(value: string | undefined) {

--- a/apps/towbar-web-app/README.md
+++ b/apps/towbar-web-app/README.md
@@ -28,7 +28,8 @@ connection view exposes non-secret private-network and SSH-tunnel coordinates
 for tools such as TablePlus. Database restores remain a manual operator task.
 Server pages list only Source-scoped orphan candidates from the latest check;
 owner-confirmed cleanup is destructive and persistent volumes are never
-removed automatically.
+removed automatically. Trusted SSH host keys can be explicitly untrusted from
+the Server's Host Keys tab after confirmation.
 
 ## Local UI fixture
 

--- a/apps/towbar-web-app/scripts/fixture-api.test.mjs
+++ b/apps/towbar-web-app/scripts/fixture-api.test.mjs
@@ -516,6 +516,28 @@ test("the local fixture covers first-connection host-key trust", async () => {
       trustedSourceServersPayload.servers[0].hostKeyStatus,
       "trusted",
     );
+
+    const revokeResponse = await fetch(
+      `${baseUrl}/v1/core/servers/${fixtureIds.server}/host-keys/${keysPayload.hostKeys[0].id}`,
+      { method: "DELETE" },
+    );
+    assert.equal(revokeResponse.status, 204);
+
+    const revokedKeysResponse = await fetch(
+      `${baseUrl}/v1/core/servers/${fixtureIds.server}/host-keys`,
+    );
+    const revokedKeysPayload = await revokedKeysResponse.json();
+    assert.deepEqual(revokedKeysPayload.hostKeys, []);
+
+    const untrustedSourceServersResponse = await fetch(
+      `${baseUrl}/v1/core/sources/${fixtureIds.source}/servers`,
+    );
+    const untrustedSourceServersPayload =
+      await untrustedSourceServersResponse.json();
+    assert.equal(
+      untrustedSourceServersPayload.servers[0].hostKeyStatus,
+      "untrusted",
+    );
   } finally {
     server.close();
     await once(server, "close");

--- a/apps/towbar-web-app/scripts/fixture-api.ts
+++ b/apps/towbar-web-app/scripts/fixture-api.ts
@@ -597,6 +597,22 @@ export function createFixtureApiServer() {
       if (failedCheckIndex >= 0) serverChecks.splice(failedCheckIndex, 1);
       return writeJson(response, 201, { hostKey: hostKeys[0] });
     }
+    const revokeHostKeyMatch = path.match(
+      /^\/v1\/core\/servers\/([^/]+)\/host-keys\/([^/]+)$/,
+    );
+    if (request.method === "DELETE" && revokeHostKeyMatch) {
+      const hostKeys = hostKeysByServer.get(revokeHostKeyMatch[1]!);
+      const index = hostKeys?.findIndex(
+        (key) => key.id === revokeHostKeyMatch[2],
+      );
+      if (!hostKeys || index === undefined || index < 0) {
+        return writeNotFound(response);
+      }
+      hostKeys.splice(index, 1);
+      response.writeHead(204);
+      response.end();
+      return;
+    }
     const prepareServerMatch = path.match(
       /^\/v1\/core\/servers\/([^/]+)\/actions\/prepare$/,
     );

--- a/apps/towbar-web-app/src/components/server-detail.tsx
+++ b/apps/towbar-web-app/src/components/server-detail.tsx
@@ -49,6 +49,7 @@ type DiscoveredKey = {
 type HostKeyRow = {
   algorithm: string;
   fingerprint: string;
+  id?: string;
   publicKey?: string;
   status: "trusted" | "untrusted";
 };
@@ -144,6 +145,7 @@ export function ServerDetail() {
     ...keys.data.hostKeys.map((key) => ({
       algorithm: key.algorithm,
       fingerprint: key.fingerprint,
+      id: key.id,
       status: "trusted" as const,
     })),
     ...discovered
@@ -230,7 +232,32 @@ export function ServerDetail() {
       key: "action",
       header: "Action",
       cell: (key) =>
-        key.status === "untrusted" && key.publicKey ? (
+        key.status === "trusted" && key.id ? (
+          <ActionButton
+            action={() =>
+              api.delete(`/v1/core/servers/${serverId}/host-keys/${key.id}`)
+            }
+            confirm={{
+              actionLabel: "Untrust key",
+              description:
+                "Towbar will stop accepting this SSH host key. Verify and trust a replacement before the next server operation if this is the last trusted key.",
+              title: (
+                <span className="inline-flex flex-wrap items-center gap-1.5">
+                  <span>Untrust</span>
+                  <TypographyCode className="break-all">
+                    {key.fingerprint}
+                  </TypographyCode>
+                  <span>?</span>
+                </span>
+              ),
+            }}
+            pendingLabel="Untrusting…"
+            success="Host key untrusted"
+            variant="danger"
+          >
+            Untrust key
+          </ActionButton>
+        ) : key.status === "untrusted" && key.publicKey ? (
           <ActionButton
             action={() =>
               api.post(`/v1/core/servers/${serverId}/host-keys/actions/trust`, {


### PR DESCRIPTION
## Summary
- add a workspace-scoped API operation that revokes trusted SSH host keys
- expose a confirmed destructive action in the Server Host Keys table
- cover trust-to-untrust behavior in the local fixture contract

## Validation
- pnpm verify