### PR TITLE
TW-1 Keep server check history bounded

### DIFF
--- a/apps/towbar-api/README.md
+++ b/apps/towbar-api/README.md
@@ -86,6 +86,10 @@ to the exact normalized Server configuration digest; a manifest change makes
 the Server pending again. Deployment admission and automatic-deployment
 selection both require a current successful preparation.
 
+Server check history is retained as a rolling window of the newest 500 checks
+per Server. Older completed checks are removed as checks finish, while queued
+and running checks are preserved until they reach a terminal state.
+
 App and Resource lifecycle is manifest-owned. A deployable missing from the
 latest successful Source sync is archived; the same manifest ID reappearing
 restores it. Towbar has no independent decommission action or lifecycle flag.

--- a/apps/towbar-api/src/areas/resource-operations/maintenance.ts
+++ b/apps/towbar-api/src/areas/resource-operations/maintenance.ts
@@ -5,6 +5,7 @@ import {
   isNormalizedResource,
 } from "@workspace/towbar-core";
 import { terminalDeploymentStates } from "@workspace/towbar-core/temporal";
+import type { CheckStatus } from "@workspace/towbar-database/schema";
 import {
   apps,
   deployments,
@@ -131,9 +132,7 @@ async function hasPendingServerWork(serverId: string) {
 
 export function shouldQueueMaintenanceServerCheck(input: {
   hasPendingServerWork: boolean;
-  latestCheck:
-    | { createdAt: Date; status: "failed" | "queued" | "running" | "succeeded" }
-    | undefined;
+  latestCheck: { createdAt: Date; status: CheckStatus } | undefined;
   now: Date;
 }) {
   if (input.hasPendingServerWork) return false;

--- a/apps/towbar-api/src/areas/servers/check-retention.test.ts
+++ b/apps/towbar-api/src/areas/servers/check-retention.test.ts
@@ -1,12 +1,11 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import type { CheckStatus } from "@workspace/towbar-database/schema";
+
 import { serverCheckIdsToPrune } from "./check-retention.js";
 
-function check(
-  id: string,
-  status: "failed" | "queued" | "running" | "succeeded" = "succeeded",
-) {
+function check(id: string, status: CheckStatus = "succeeded") {
   return { id, status };
 }
 

--- a/apps/towbar-api/src/areas/servers/check-retention.test.ts
+++ b/apps/towbar-api/src/areas/servers/check-retention.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { serverCheckIdsToPrune } from "./check-retention.js";
+
+function check(
+  id: string,
+  status: "failed" | "queued" | "running" | "succeeded" = "succeeded",
+) {
+  return { id, status };
+}
+
+void describe("serverCheckIdsToPrune", () => {
+  void it("keeps the newest checks within the retention limit", () => {
+    assert.deepEqual(
+      serverCheckIdsToPrune([check("newest"), check("older")], 2),
+      [],
+    );
+  });
+
+  void it("prunes terminal checks beyond the retention limit", () => {
+    assert.deepEqual(
+      serverCheckIdsToPrune(
+        [check("newest"), check("older"), check("oldest", "failed")],
+        1,
+      ),
+      ["older", "oldest"],
+    );
+  });
+
+  void it("preserves active checks even when they are older than the limit", () => {
+    assert.deepEqual(
+      serverCheckIdsToPrune(
+        [
+          check("newest"),
+          check("queued", "queued"),
+          check("running", "running"),
+          check("finished"),
+        ],
+        1,
+      ),
+      ["finished"],
+    );
+  });
+});

--- a/apps/towbar-api/src/areas/servers/check-retention.ts
+++ b/apps/towbar-api/src/areas/servers/check-retention.ts
@@ -1,0 +1,41 @@
+import { desc, eq, inArray } from "drizzle-orm";
+
+import type { TowbarDatabase } from "@workspace/towbar-database";
+import { serverChecks } from "@workspace/towbar-database/schema";
+
+export const SERVER_CHECK_RETENTION_LIMIT = 500;
+
+type ServerCheckRetentionCandidate = {
+  id: string;
+  status: "failed" | "queued" | "running" | "succeeded";
+};
+
+const terminalStatuses = new Set<ServerCheckRetentionCandidate["status"]>([
+  "failed",
+  "succeeded",
+]);
+
+export function serverCheckIdsToPrune(
+  checks: ServerCheckRetentionCandidate[],
+  limit = SERVER_CHECK_RETENTION_LIMIT,
+) {
+  return checks
+    .slice(limit)
+    .filter((check) => terminalStatuses.has(check.status))
+    .map((check) => check.id);
+}
+
+export async function pruneServerCheckHistory(
+  database: Pick<TowbarDatabase, "delete" | "select">,
+  serverId: string,
+) {
+  const checks = await database
+    .select({ id: serverChecks.id, status: serverChecks.status })
+    .from(serverChecks)
+    .where(eq(serverChecks.serverId, serverId))
+    .orderBy(desc(serverChecks.createdAt), desc(serverChecks.id));
+  const ids = serverCheckIdsToPrune(checks);
+  if (ids.length === 0) return 0;
+  await database.delete(serverChecks).where(inArray(serverChecks.id, ids));
+  return ids.length;
+}

--- a/apps/towbar-api/src/areas/servers/check-retention.ts
+++ b/apps/towbar-api/src/areas/servers/check-retention.ts
@@ -1,13 +1,14 @@
 import { desc, eq, inArray } from "drizzle-orm";
 
 import type { TowbarDatabase } from "@workspace/towbar-database";
+import type { CheckStatus } from "@workspace/towbar-database/schema";
 import { serverChecks } from "@workspace/towbar-database/schema";
 
 export const SERVER_CHECK_RETENTION_LIMIT = 500;
 
 type ServerCheckRetentionCandidate = {
   id: string;
-  status: "failed" | "queued" | "running" | "succeeded";
+  status: CheckStatus;
 };
 
 const terminalStatuses = new Set<ServerCheckRetentionCandidate["status"]>([

--- a/apps/towbar-api/src/areas/servers/service.ts
+++ b/apps/towbar-api/src/areas/servers/service.ts
@@ -18,6 +18,7 @@ import { getTowbarDatabase } from "../../infrastructure/database.js";
 import { enqueueServerCheck } from "../../infrastructure/temporal.js";
 import { publicDeploymentSelection } from "../deployment-selection.js";
 import { resolveAwsSecret } from "../aws/service.js";
+import { pruneServerCheckHistory } from "./check-retention.js";
 
 export const sshLoginSecretSchema = z
   .object({
@@ -260,7 +261,8 @@ export async function requestServerCheck(input: {
     });
     return toPublicServerCheck(check);
   } catch (error) {
-    await getTowbarDatabase()
+    const database = getTowbarDatabase();
+    await database
       .update(serverChecks)
       .set({
         errorCode: "TEMPORAL_UNAVAILABLE",
@@ -269,6 +271,7 @@ export async function requestServerCheck(input: {
         status: "failed",
       })
       .where(eq(serverChecks.id, check.id));
+    await pruneServerCheckHistory(database, check.serverId);
     throw error;
   }
 }
@@ -463,6 +466,7 @@ export async function finishServerCheck(
           });
       }
     }
+    await pruneServerCheckHistory(transaction, check.serverId);
     return check;
   });
 }

--- a/packages/towbar-database/src/schema/index.ts
+++ b/packages/towbar-database/src/schema/index.ts
@@ -48,6 +48,7 @@ export const checkStatusEnum = pgEnum("towbar_check_status", [
   "succeeded",
   "failed",
 ]);
+export type CheckStatus = (typeof checkStatusEnum.enumValues)[number];
 export const credentialVerificationStatusEnum = pgEnum(
   "towbar_credential_verification_status",
   ["unverified", "verified", "failed"],


### PR DESCRIPTION
## Summary
- retain the newest 500 checks per server
- prune only completed checks so active work remains addressable
- run cleanup on terminal completion and queue failure

## Validation
- pnpm verify