### PR TITLE
feat: report Preview status in pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ truth and runs deployments through durable Temporal workflows.
 - AWS Secrets Manager values are resolved just in time and stay out of Git.
 - SSH host-key pinning, server preparation, queued deployments, control-plane
   diagnostics, and runtime capacity checks are built in.
-- Opt-in pull request Previews use stable URLs, isolated secrets, and automatic
-  cleanup without changing production health or release history.
+- Opt-in pull request Previews use stable URLs, isolated secrets, one live PR
+  status comment, and automatic cleanup without changing production health or
+  release history.
 - PostgreSQL and Temporal provide persistent state and durable execution.
 
 ## Quick start

--- a/apps/towbar-api/README.md
+++ b/apps/towbar-api/README.md
@@ -56,9 +56,10 @@ Relevant pull request events for Apps with Preview enabled enter a Source/PR
 coalescing workflow. The API reads the pull request's current state before each
 reconciliation, so delayed or out-of-order webhooks cannot recreate a closed
 Preview. Admission records independent Preview deployments and releases,
-publishes GitHub Deployment statuses, and keeps production runtime health
-unchanged. Pull request merge or closure, retargeting, TTL expiry, manifest
-disablement, and owner deletion converge on the same cleanup admission path.
+publishes GitHub Deployment statuses, updates one aggregate Preview comment on
+the pull request, and keeps production runtime health unchanged. Pull request
+merge or closure, retargeting, TTL expiry, manifest disablement, and owner
+deletion converge on the same cleanup admission path.
 
 AWS credentials and Servers are Source-scoped. Server identity is
 `(source_id, canonical_ip)`, allowing independent Sources to target the same IP

--- a/apps/towbar-api/src/areas/deployments/preview-status.ts
+++ b/apps/towbar-api/src/areas/deployments/preview-status.ts
@@ -13,6 +13,7 @@ import {
   createGitHubPreviewDeployment,
   updateGitHubPreviewDeployment,
 } from "../github/client.js";
+import { publishPreviewPullRequestCommentForDeployment } from "../previews/pr-comment.js";
 
 import type { DeploymentState } from "@workspace/towbar-core/temporal";
 
@@ -54,9 +55,14 @@ export async function propagatePreviewDeploymentState(
 ) {
   await recordPreviewTerminalState(deploymentId, state);
   if (options.publish !== false) {
-    await publishPreviewDeploymentStatus(deploymentId, state).catch(
-      () => undefined,
-    );
+    await Promise.all([
+      publishPreviewDeploymentStatus(deploymentId, state).catch(
+        () => undefined,
+      ),
+      publishPreviewPullRequestCommentForDeployment(deploymentId).catch(
+        () => undefined,
+      ),
+    ]);
   }
 }
 

--- a/apps/towbar-api/src/areas/github/client.ts
+++ b/apps/towbar-api/src/areas/github/client.ts
@@ -71,6 +71,16 @@ const gitTreeSchema = z.object({
 
 const githubDeploymentSchema = z.object({ id: z.number().int().positive() });
 
+const issueCommentSchema = z.object({
+  body: z.string().nullable(),
+  id: z.number().int().positive(),
+  performed_via_github_app: z
+    .object({ id: z.number().int().positive() })
+    .nullable()
+    .optional(),
+});
+const issueCommentListSchema = z.array(issueCommentSchema);
+
 const pullRequestSchema = z.object({
   base: z.object({
     ref: z.string().min(1).max(255),
@@ -363,6 +373,48 @@ export async function updateGitHubPreviewDeployment(input: {
   );
 }
 
+export async function upsertGitHubPullRequestComment(input: {
+  body: string;
+  installationId: string;
+  marker: string;
+  pullRequestNumber: number;
+  repositoryName: string;
+  repositoryOwner: string;
+}) {
+  const token = await createInstallationToken(input.installationId);
+  const repository = `${encodeURIComponent(input.repositoryOwner)}/${encodeURIComponent(input.repositoryName)}`;
+  const appId = requireGitHubEnv().appId;
+  let existing: z.infer<typeof issueCommentSchema> | undefined;
+  for (let page = 1; page <= 10; page += 1) {
+    const comments = issueCommentListSchema.parse(
+      await githubRequest(
+        `/repos/${repository}/issues/${input.pullRequestNumber}/comments?per_page=100&page=${page}`,
+        { token },
+      ),
+    );
+    existing = comments.find(
+      (comment) =>
+        comment.body?.includes(input.marker) === true &&
+        String(comment.performed_via_github_app?.id) === appId,
+    );
+    if (existing || comments.length < 100) break;
+  }
+  if (existing?.body === input.body) return String(existing.id);
+  const comment = issueCommentSchema.parse(
+    await githubRequest(
+      existing
+        ? `/repos/${repository}/issues/comments/${existing.id}`
+        : `/repos/${repository}/issues/${input.pullRequestNumber}/comments`,
+      {
+        body: { body: input.body },
+        method: existing ? "PATCH" : "POST",
+        token,
+      },
+    ),
+  );
+  return String(comment.id);
+}
+
 async function createGitHubAppJwt() {
   const github = requireGitHubEnv();
   const now = Math.floor(Date.now() / 1_000);
@@ -378,7 +430,7 @@ async function githubRequest(
   path: string,
   options: {
     body?: unknown;
-    method?: "DELETE" | "GET" | "POST";
+    method?: "DELETE" | "GET" | "PATCH" | "POST";
     token: string;
   },
 ) {

--- a/apps/towbar-api/src/areas/previews/cleanup.ts
+++ b/apps/towbar-api/src/areas/previews/cleanup.ts
@@ -24,6 +24,10 @@ import {
   enqueueClaimedPreviewCleanups,
   previewCleanupAdmissionFailureMessage,
 } from "./cleanup-admission.js";
+import {
+  publishPreviewPullRequestComment,
+  publishPreviewPullRequestCommentForEnvironment,
+} from "./pr-comment.js";
 
 const cleanablePreviewStatuses = [
   "building",
@@ -57,6 +61,10 @@ export async function requestPreviewPullRequestCleanup(input: {
       serverId: previewEnvironments.serverId,
     });
   await queuePreviewCleanup(environments, input.reason);
+  await publishPreviewPullRequestComment({
+    pullRequestNumber: input.pullRequestNumber,
+    sourceId: input.sourceId,
+  }).catch(() => undefined);
   return {
     cleanupIds: environments.map((environment) => environment.id),
     deploymentIds: [],
@@ -81,12 +89,15 @@ export async function requestPreviewEnvironmentCleanup(input: {
     .returning({
       appId: previewEnvironments.appId,
       id: previewEnvironments.id,
+      pullRequestNumber: previewEnvironments.pullRequestNumber,
       serverId: previewEnvironments.serverId,
+      sourceId: previewEnvironments.sourceId,
     });
   await queuePreviewCleanup(
     environments,
     input.reason ?? "Preview cleanup was requested",
   );
+  await publishPreviewCommentGroups(environments);
   return { accepted: environments.length > 0 };
 }
 
@@ -103,9 +114,12 @@ export async function requestExpiredPreviewCleanups(now = new Date()) {
     .returning({
       appId: previewEnvironments.appId,
       id: previewEnvironments.id,
+      pullRequestNumber: previewEnvironments.pullRequestNumber,
       serverId: previewEnvironments.serverId,
+      sourceId: previewEnvironments.sourceId,
     });
   await queuePreviewCleanup(environments, "The Preview deployment expired");
+  await publishPreviewCommentGroups(environments);
   return environments.length;
 }
 
@@ -147,11 +161,14 @@ export async function requestDisabledPreviewCleanups(sourceId: string) {
       .returning({
         appId: previewEnvironments.appId,
         id: previewEnvironments.id,
+        pullRequestNumber: previewEnvironments.pullRequestNumber,
         serverId: previewEnvironments.serverId,
+        sourceId: previewEnvironments.sourceId,
       });
     if (claimed) cleanups.push(claimed);
   }
   await queuePreviewCleanup(cleanups, "Preview deployments were disabled");
+  await publishPreviewCommentGroups(cleanups);
   return cleanups.length;
 }
 
@@ -242,6 +259,9 @@ async function markPreviewCleanupAdmissionFailed(
         eq(previewEnvironments.status, "deleting"),
       ),
     );
+  await publishPreviewPullRequestCommentForEnvironment(environment.id).catch(
+    () => undefined,
+  );
 }
 
 export async function getPreviewCleanupContext(previewEnvironmentId: string) {
@@ -320,7 +340,11 @@ export async function recordPreviewCleanupResult(
 ) {
   const now = new Date();
   const [environment] = await getTowbarDatabase()
-    .select({ latestDeploymentId: previewEnvironments.latestDeploymentId })
+    .select({
+      latestDeploymentId: previewEnvironments.latestDeploymentId,
+      pullRequestNumber: previewEnvironments.pullRequestNumber,
+      sourceId: previewEnvironments.sourceId,
+    })
     .from(previewEnvironments)
     .where(eq(previewEnvironments.id, previewEnvironmentId))
     .limit(1);
@@ -347,5 +371,25 @@ export async function recordPreviewCleanupResult(
       "inactive",
     ).catch(() => undefined);
   }
+  if (environment) {
+    await publishPreviewPullRequestComment(environment).catch(() => undefined);
+  }
   return { accepted: true };
+}
+
+async function publishPreviewCommentGroups(
+  environments: Array<{ pullRequestNumber: number; sourceId: string }>,
+) {
+  const groups = new Map<string, (typeof environments)[number]>();
+  for (const environment of environments) {
+    groups.set(
+      `${environment.sourceId}:${environment.pullRequestNumber}`,
+      environment,
+    );
+  }
+  await Promise.all(
+    [...groups.values()].map((environment) =>
+      publishPreviewPullRequestComment(environment).catch(() => undefined),
+    ),
+  );
 }

--- a/apps/towbar-api/src/areas/previews/pr-comment.test.ts
+++ b/apps/towbar-api/src/areas/previews/pr-comment.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  previewPullRequestCommentMarker,
+  renderPreviewPullRequestComment,
+} from "./pr-comment.js";
+
+const sourceId = "11111111-1111-4111-8111-111111111111";
+const marker = previewPullRequestCommentMarker({
+  pullRequestNumber: 42,
+  sourceId,
+});
+
+void test("uses one stable hidden marker for a Source and pull request", () => {
+  assert.equal(
+    marker,
+    "<!-- towbar:preview-status:11111111-1111-4111-8111-111111111111:42 -->",
+  );
+});
+
+void test("renders all app previews in one status table", () => {
+  const body = renderPreviewPullRequestComment({
+    appBaseUrl: "https://app.towbar.dev",
+    entries: [
+      {
+        appName: "Admin | Console",
+        deploymentId: "31111111-1111-4111-8111-111111111111",
+        deploymentState: "building",
+        environmentStatus: "building",
+        hostname: "admin-pr-42.preview.example.com",
+      },
+      {
+        appName: "Website",
+        deploymentId: "41111111-1111-4111-8111-111111111111",
+        deploymentState: "succeeded",
+        environmentStatus: "healthy",
+        hostname: "website-pr-42.preview.example.com",
+      },
+    ],
+    marker,
+    sourceId,
+  });
+  assert.match(body, /Admin \\| Console \| 🟡 Building/u);
+  assert.match(body, /Website \| 🟢 Ready/u);
+  assert.match(
+    body,
+    /\[Open preview\]\(https:\/\/website-pr-42\.preview\.example\.com\)/u,
+  );
+  assert.equal(body.match(/## Towbar previews/gu)?.length, 1);
+});
+
+void test("shows cleanup and failure states without exposing error details", () => {
+  const body = renderPreviewPullRequestComment({
+    appBaseUrl: "https://app.towbar.dev",
+    entries: [
+      {
+        appName: "API",
+        deploymentId: null,
+        deploymentState: null,
+        environmentStatus: "deleted",
+        hostname: "api-pr-42.preview.example.com",
+      },
+      {
+        appName: "Worker",
+        deploymentId: null,
+        deploymentState: "failed",
+        environmentStatus: "failed",
+        hostname: "worker-pr-42.preview.example.com",
+      },
+    ],
+    marker,
+    sourceId,
+  });
+  assert.match(body, /API \| ⚪ Cleaned up/u);
+  assert.match(body, /Worker \| 🔴 Failed/u);
+});

--- a/apps/towbar-api/src/areas/previews/pr-comment.ts
+++ b/apps/towbar-api/src/areas/previews/pr-comment.ts
@@ -1,0 +1,218 @@
+import { and, asc, eq } from "drizzle-orm";
+
+import {
+  apps,
+  deployments,
+  githubInstallations,
+  previewEnvironments,
+  sources,
+} from "@workspace/towbar-database/schema";
+
+import { getEnv } from "../../env.js";
+import { getTowbarDatabase } from "../../infrastructure/database.js";
+import { upsertGitHubPullRequestComment } from "../github/client.js";
+
+import type { DeploymentState } from "@workspace/towbar-core/temporal";
+
+type PreviewEnvironmentStatus =
+  (typeof previewEnvironments.$inferSelect)["status"];
+
+const deploymentCommentStatuses = {
+  building: "🟡 Building",
+  cancelled: "⚪ Inactive",
+  checking_health: "🟡 Checking health",
+  checking_public_endpoint: "🟡 Checking health",
+  checking_server: "🟡 Preparing",
+  cleaning_up: "🟡 Preparing",
+  configuring_routing: "🟡 Deploying",
+  failed: "🔴 Failed",
+  fetching_source: "🟡 Preparing",
+  preparing: "🟡 Preparing",
+  provisioning_tls: "🟡 Deploying",
+  queued: "🟡 Queued",
+  resolving_secrets: "🟡 Preparing",
+  running_post_deploy: "🟡 Preparing",
+  running_pre_deploy: "🟡 Preparing",
+  skipped: "⚪ Inactive",
+  starting_candidate: "🟡 Preparing",
+  succeeded: "🟢 Ready",
+  succeeded_with_warnings: "🟢 Ready",
+  switching_traffic: "🟡 Deploying",
+  transferring: "🟡 Preparing",
+  validating_credentials: "🟡 Preparing",
+  waiting_for_server: "🟡 Waiting for server",
+} satisfies Record<DeploymentState, string>;
+
+const environmentCommentStatuses: Partial<
+  Record<PreviewEnvironmentStatus, string>
+> = {
+  cleanup_failed: "🔴 Cleanup failed",
+  deleted: "⚪ Cleaned up",
+  deleting: "⚪ Cleaning up",
+  failed: "🔴 Failed",
+  healthy: "🟢 Ready",
+};
+
+export type PreviewPullRequestCommentEntry = {
+  appName: string;
+  deploymentId: string | null;
+  deploymentState: DeploymentState | null;
+  environmentStatus: PreviewEnvironmentStatus;
+  hostname: string;
+};
+
+export async function publishPreviewPullRequestComment(input: {
+  pullRequestNumber: number;
+  sourceId: string;
+}) {
+  const database = getTowbarDatabase();
+  const [[source], environments] = await Promise.all([
+    database
+      .select({
+        installationId: githubInstallations.installationId,
+        repositoryName: sources.repositoryName,
+        repositoryOwner: sources.repositoryOwner,
+      })
+      .from(sources)
+      .innerJoin(
+        githubInstallations,
+        eq(githubInstallations.id, sources.githubInstallationId),
+      )
+      .where(eq(sources.id, input.sourceId))
+      .limit(1),
+    database
+      .select({
+        appName: apps.name,
+        deploymentId: previewEnvironments.latestDeploymentId,
+        deploymentState: deployments.state,
+        environmentStatus: previewEnvironments.status,
+        hostname: previewEnvironments.hostname,
+      })
+      .from(previewEnvironments)
+      .innerJoin(apps, eq(apps.id, previewEnvironments.appId))
+      .leftJoin(
+        deployments,
+        eq(deployments.id, previewEnvironments.latestDeploymentId),
+      )
+      .where(
+        and(
+          eq(previewEnvironments.sourceId, input.sourceId),
+          eq(previewEnvironments.pullRequestNumber, input.pullRequestNumber),
+        ),
+      )
+      .orderBy(asc(apps.name)),
+  ]);
+  if (!source || environments.length === 0) return null;
+  const marker = previewPullRequestCommentMarker(input);
+  return await upsertGitHubPullRequestComment({
+    body: renderPreviewPullRequestComment({
+      appBaseUrl: getEnv().TOWBAR_APP_BASE_URL,
+      entries: environments,
+      marker,
+      sourceId: input.sourceId,
+    }),
+    installationId: source.installationId,
+    marker,
+    pullRequestNumber: input.pullRequestNumber,
+    repositoryName: source.repositoryName,
+    repositoryOwner: source.repositoryOwner,
+  });
+}
+
+export async function publishPreviewPullRequestCommentForDeployment(
+  deploymentId: string,
+) {
+  const [preview] = await getTowbarDatabase()
+    .select({
+      pullRequestNumber: previewEnvironments.pullRequestNumber,
+      sourceId: previewEnvironments.sourceId,
+    })
+    .from(deployments)
+    .innerJoin(
+      previewEnvironments,
+      eq(previewEnvironments.id, deployments.previewEnvironmentId),
+    )
+    .where(eq(deployments.id, deploymentId))
+    .limit(1);
+  if (!preview) return null;
+  return await publishPreviewPullRequestComment(preview);
+}
+
+export async function publishPreviewPullRequestCommentForEnvironment(
+  previewEnvironmentId: string,
+) {
+  const [preview] = await getTowbarDatabase()
+    .select({
+      pullRequestNumber: previewEnvironments.pullRequestNumber,
+      sourceId: previewEnvironments.sourceId,
+    })
+    .from(previewEnvironments)
+    .where(eq(previewEnvironments.id, previewEnvironmentId))
+    .limit(1);
+  if (!preview) return null;
+  return await publishPreviewPullRequestComment(preview);
+}
+
+export function previewPullRequestCommentMarker(input: {
+  pullRequestNumber: number;
+  sourceId: string;
+}) {
+  return `<!-- towbar:preview-status:${input.sourceId}:${input.pullRequestNumber} -->`;
+}
+
+export function renderPreviewPullRequestComment(input: {
+  appBaseUrl: string;
+  entries: PreviewPullRequestCommentEntry[];
+  marker: string;
+  sourceId: string;
+}) {
+  const visibleEntries = input.entries.slice(0, 50);
+  const rows = visibleEntries.map((entry) => {
+    const deploymentUrl = entry.deploymentId
+      ? new URL(
+          `/sources/${encodeURIComponent(input.sourceId)}/deployments/${encodeURIComponent(entry.deploymentId)}`,
+          input.appBaseUrl,
+        ).toString()
+      : null;
+    const status = previewCommentStatus(entry);
+    const preview =
+      entry.environmentStatus === "healthy"
+        ? `[Open preview](https://${entry.hostname})`
+        : "—";
+    return `| ${escapeMarkdownTableCell(entry.appName)} | ${status} | ${preview} | ${deploymentUrl ? `[View details](${deploymentUrl})` : "—"} |`;
+  });
+  const remaining = input.entries.length - visibleEntries.length;
+  return [
+    input.marker,
+    "## Towbar previews",
+    "",
+    "| App | Build status | Preview | Deployment |",
+    "| --- | --- | --- | --- |",
+    ...rows,
+    ...(remaining > 0
+      ? [
+          "",
+          `_And ${remaining} more preview${remaining === 1 ? "" : "s"} in Towbar._`,
+        ]
+      : []),
+    "",
+    "<sub>This comment is updated automatically by Towbar.</sub>",
+  ].join("\n");
+}
+
+function previewCommentStatus(entry: PreviewPullRequestCommentEntry) {
+  return (
+    environmentCommentStatuses[entry.environmentStatus] ??
+    (entry.deploymentState
+      ? deploymentCommentStatuses[entry.deploymentState]
+      : "🟡 Preparing")
+  );
+}
+
+function escapeMarkdownTableCell(value: string) {
+  return value
+    .replaceAll("\r", " ")
+    .replaceAll("\n", " ")
+    .replaceAll("\\", "\\\\")
+    .replaceAll("|", "\\|");
+}

--- a/apps/towbar-api/src/areas/previews/service.ts
+++ b/apps/towbar-api/src/areas/previews/service.ts
@@ -45,6 +45,7 @@ import {
   previewPullRequestDisposition,
   previewPullRequestsToReconcile,
 } from "./pull-request.js";
+import { publishPreviewPullRequestComment } from "./pr-comment.js";
 
 import type { PreviewPullRequestEvent } from "@workspace/towbar-core/temporal";
 import type { NormalizedApp } from "@workspace/towbar-core";
@@ -333,6 +334,10 @@ export async function processPreviewPullRequestEvent(
       }
     }
   }
+  await publishPreviewPullRequestComment({
+    pullRequestNumber: pullRequest.number,
+    sourceId: event.sourceId,
+  }).catch(() => undefined);
   return {
     cleanupIds: [],
     deploymentIds: admissions

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,9 @@ and an owner action, all enter the same durable cleanup path. Cleanup
 revalidates Towbar-owned runtime identities and removes only that Preview's
 containers, images, Caddy route, and DNS record. Apps and Resources in the
 production inventory are unchanged. GitHub Deployment statuses mirror the
-Preview lifecycle when the GitHub App has deployment write permission.
+Preview lifecycle, while one aggregate PR comment reports every App's build
+status and Preview URL. Towbar updates that comment in place when the GitHub
+App has deployment and pull-request write permission.
 
 An owner may also edit the JSON environment bundle behind a secret reference
 already attached to an App or Resource. Listings expose key names and AWS

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,12 +48,15 @@ a Source. Configure a GitHub App with:
 
 - Repository contents: read-only
 - Repository metadata: read-only
-- Pull requests: read-only (required for Preview deployments)
+- Pull requests: read and write (required for Preview deployments and their PR status comment)
 - Deployments: read and write (required for Preview deployment statuses)
 - Webhook events: push, pull request, and installation
 - Webhook URL: `${TOWBAR_API_BASE_URL}/v1/public/webhooks/github`
 - Setup URL with redirect enabled:
   `${TOWBAR_APP_BASE_URL}/settings?section=github`
+
+Existing installations must approve the Pull requests permission upgrade before
+Towbar can create or update the Preview status comment.
 
 Encode the downloaded PEM without line wrapping:
 
@@ -177,6 +180,10 @@ same PR identity. Pull requests from forks and pull requests targeting another
 base branch are not deployed. A successful `Sync now` also reconciles open
 eligible pull requests and existing Preview environments, so enabling Preview
 after a PR opens or recovering a missed webhook does not require a new commit.
+Towbar also maintains one comment per Source and pull request with every App's
+build status, Preview URL, and deployment details link. A hidden stable marker
+lets Towbar update the same GitHub comment instead of posting a new comment for
+each state change.
 
 Treat Preview pull requests as executable deployment input. Use separate,
 least-privilege Preview secret references with disposable or non-production

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,7 +88,7 @@ Create one GitHub App for this Towbar installation:
 
 - Repository contents: read-only
 - Repository metadata: read-only
-- Pull requests: read-only (required when using Preview deployments)
+- Pull requests: read and write (required for Preview deployments and their PR status comment)
 - Deployments: read and write (required when using Preview deployments)
 - Webhook events: `push`, `pull_request`, and `installation`
 - Webhook URL: `${TOWBAR_API_BASE_URL}/v1/public/webhooks/github`


### PR DESCRIPTION
## Summary
- maintain one Towbar-managed status comment per Source and pull request
- aggregate Preview build states, ready URLs, and deployment detail links across apps
- update the same comment through deployment and cleanup transitions
- document the required Pull requests read/write GitHub App permission

## Validation
- `pnpm --filter towbar-api lint`
- `pnpm --filter towbar-api typecheck`
- `pnpm --filter towbar-api test`
- `pnpm --filter towbar-api build`

## Rollout note
Existing GitHub App installations must approve the Pull requests permission upgrade before Towbar can create or update this comment.