### PR TITLE
fix: honor preview deployment change patterns

### DIFF
--- a/apps/towbar-api/src/areas/github/client.ts
+++ b/apps/towbar-api/src/areas/github/client.ts
@@ -15,6 +15,7 @@ const installationSchema = z.object({
     type: z.string(),
   }),
   id: z.number().int().positive(),
+  permissions: z.record(z.string(), z.string()),
   suspended_at: z.string().nullable(),
 });
 
@@ -81,11 +82,19 @@ const issueCommentSchema = z.object({
 });
 const issueCommentListSchema = z.array(issueCommentSchema);
 
+const pullRequestFileListSchema = z.array(
+  z.object({
+    filename: z.string().min(1).max(4_096),
+    previous_filename: z.string().min(1).max(4_096).optional(),
+  }),
+);
+
 const pullRequestSchema = z.object({
   base: z.object({
     ref: z.string().min(1).max(255),
     repo: z.object({ full_name: z.string().min(3).max(255) }),
   }),
+  changed_files: z.number().int().nonnegative(),
   draft: z.boolean().nullable(),
   head: z.object({
     ref: z.string().min(1).max(255),
@@ -105,6 +114,7 @@ const pullRequestListSchema = z.array(
 export type GitHubPullRequest = {
   baseBranch: string;
   baseRepository: string;
+  changedFileCount: number;
   draft: boolean;
   headBranch: string;
   headRepository: string | null;
@@ -265,6 +275,7 @@ export async function fetchGitHubPullRequest(input: {
   return {
     baseBranch: pullRequest.base.ref,
     baseRepository: pullRequest.base.repo.full_name,
+    changedFileCount: pullRequest.changed_files,
     draft: pullRequest.draft ?? false,
     headBranch: pullRequest.head.ref,
     headRepository: pullRequest.head.repo?.full_name ?? null,
@@ -272,6 +283,38 @@ export async function fetchGitHubPullRequest(input: {
     merged: pullRequest.merged,
     number: pullRequest.number,
     state: pullRequest.state,
+  };
+}
+
+export async function fetchGitHubPullRequestChangedPaths(input: {
+  changedFileCount: number;
+  installationId: string;
+  pullRequestNumber: number;
+  repositoryName: string;
+  repositoryOwner: string;
+}) {
+  if (input.changedFileCount === 0) return { complete: true, paths: [] };
+  const token = await createInstallationToken(input.installationId);
+  const repository = `${encodeURIComponent(input.repositoryOwner)}/${encodeURIComponent(input.repositoryName)}`;
+  const paths: string[] = [];
+  let fetchedFileCount = 0;
+  for (let page = 1; page <= 30; page += 1) {
+    const files = pullRequestFileListSchema.parse(
+      await githubRequest(
+        `/repos/${repository}/pulls/${input.pullRequestNumber}/files?per_page=100&page=${page}`,
+        { token },
+      ),
+    );
+    fetchedFileCount += files.length;
+    for (const file of files) {
+      paths.push(file.filename);
+      if (file.previous_filename) paths.push(file.previous_filename);
+    }
+    if (files.length < 100 || fetchedFileCount >= input.changedFileCount) break;
+  }
+  return {
+    complete: fetchedFileCount >= input.changedFileCount,
+    paths,
   };
 }
 

--- a/apps/towbar-api/src/areas/github/permissions.test.ts
+++ b/apps/towbar-api/src/areas/github/permissions.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { githubPermissionReadiness } from "./permissions.js";
+
+void test("reports Preview readiness only with every required permission", () => {
+  assert.deepEqual(
+    githubPermissionReadiness({
+      contents: "read",
+      deployments: "write",
+      pull_requests: "write",
+    }),
+    {
+      contents: "read",
+      deployments: "write",
+      preview: "ready",
+      pullRequests: "write",
+    },
+  );
+  assert.equal(
+    githubPermissionReadiness({
+      contents: "read",
+      deployments: "read",
+      pull_requests: "write",
+    }).preview,
+    "missing",
+  );
+  assert.equal(
+    githubPermissionReadiness({ contents: "read" }).preview,
+    "missing",
+  );
+});

--- a/apps/towbar-api/src/areas/github/permissions.ts
+++ b/apps/towbar-api/src/areas/github/permissions.ts
@@ -1,0 +1,34 @@
+export type GitHubPermissionLevel = "none" | "read" | "write";
+
+export type GitHubPermissionReadiness = {
+  contents: GitHubPermissionLevel;
+  deployments: GitHubPermissionLevel;
+  preview: "missing" | "ready";
+  pullRequests: GitHubPermissionLevel;
+};
+
+export function githubPermissionReadiness(
+  permissions: Record<string, string>,
+): GitHubPermissionReadiness {
+  const contents = normalizePermission(permissions.contents);
+  const deployments = normalizePermission(permissions.deployments);
+  const pullRequests = normalizePermission(permissions.pull_requests);
+  return {
+    contents,
+    deployments,
+    preview:
+      canRead(contents) && deployments === "write" && pullRequests === "write"
+        ? "ready"
+        : "missing",
+    pullRequests,
+  };
+}
+
+function normalizePermission(value: string | undefined): GitHubPermissionLevel {
+  if (value === "write" || value === "admin") return "write";
+  return value === "read" ? "read" : "none";
+}
+
+function canRead(permission: GitHubPermissionLevel) {
+  return permission === "read" || permission === "write";
+}

--- a/apps/towbar-api/src/areas/github/service.ts
+++ b/apps/towbar-api/src/areas/github/service.ts
@@ -16,6 +16,7 @@ import {
   getGitHubInstallation,
   listGitHubRepositories,
 } from "./client.js";
+import { githubPermissionReadiness } from "./permissions.js";
 
 export async function getGitHubConnection(workspaceId: string) {
   const [installation] = await getTowbarDatabase()
@@ -31,6 +32,32 @@ export async function getGitHubConnection(workspaceId: string) {
     .where(eq(githubInstallations.workspaceId, workspaceId))
     .limit(1);
   return installation ?? null;
+}
+
+export async function getGitHubConnectionStatus(workspaceId: string) {
+  const connection = await getGitHubConnection(workspaceId);
+  if (!connection) return null;
+  if (connection.suspendedAt) {
+    return {
+      ...connection,
+      permissionReadiness: { status: "unavailable" as const },
+    };
+  }
+  try {
+    const installation = await getGitHubInstallation(connection.installationId);
+    return {
+      ...connection,
+      permissionReadiness: {
+        ...githubPermissionReadiness(installation.permissions),
+        status: "available" as const,
+      },
+    };
+  } catch {
+    return {
+      ...connection,
+      permissionReadiness: { status: "unavailable" as const },
+    };
+  }
 }
 
 export async function createInstallationUrl(input: {

--- a/apps/towbar-api/src/areas/previews/admission-state.test.ts
+++ b/apps/towbar-api/src/areas/previews/admission-state.test.ts
@@ -1,10 +1,19 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { shouldDeferPreviewAdmission } from "./admission-state.js";
+import {
+  isPreviewReleaseCurrent,
+  shouldDeferPreviewAdmission,
+} from "./admission-state.js";
 
 void test("defers a pull request update while cleanup owns the Preview environment", () => {
   assert.equal(shouldDeferPreviewAdmission("deleting"), true);
   assert.equal(shouldDeferPreviewAdmission("deleted"), false);
   assert.equal(shouldDeferPreviewAdmission("cleanup_failed"), false);
+});
+
+void test("keeps an input-equivalent Preview release current", () => {
+  assert.equal(isPreviewReleaseCurrent("same-inputs", "same-inputs"), true);
+  assert.equal(isPreviewReleaseCurrent("old-inputs", "new-inputs"), false);
+  assert.equal(isPreviewReleaseCurrent(undefined, "new-inputs"), false);
 });

--- a/apps/towbar-api/src/areas/previews/admission-state.ts
+++ b/apps/towbar-api/src/areas/previews/admission-state.ts
@@ -1,3 +1,10 @@
 export function shouldDeferPreviewAdmission(status: string | undefined) {
   return status === "deleting";
 }
+
+export function isPreviewReleaseCurrent(
+  currentDeploymentDigest: string | null | undefined,
+  desiredDeploymentDigest: string,
+) {
+  return currentDeploymentDigest === desiredDeploymentDigest;
+}

--- a/apps/towbar-api/src/areas/previews/cleanup.ts
+++ b/apps/towbar-api/src/areas/previews/cleanup.ts
@@ -71,6 +71,44 @@ export async function requestPreviewPullRequestCleanup(input: {
   };
 }
 
+export async function requestPreviewInputMismatchCleanups(input: {
+  appIds: string[];
+  pullRequestNumber: number;
+  sourceId: string;
+}) {
+  if (input.appIds.length === 0) return { cleanupIds: [] as string[] };
+  const reason =
+    "Pull request changes no longer match this App's deployment inputs";
+  const environments = await getTowbarDatabase()
+    .update(previewEnvironments)
+    .set({
+      errorMessage: reason,
+      status: "deleting",
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(previewEnvironments.sourceId, input.sourceId),
+        eq(previewEnvironments.pullRequestNumber, input.pullRequestNumber),
+        inArray(previewEnvironments.appId, input.appIds),
+        inArray(previewEnvironments.status, cleanablePreviewStatuses),
+      ),
+    )
+    .returning({
+      appId: previewEnvironments.appId,
+      id: previewEnvironments.id,
+      serverId: previewEnvironments.serverId,
+    });
+  await queuePreviewCleanup(environments, reason);
+  await publishPreviewPullRequestComment({
+    pullRequestNumber: input.pullRequestNumber,
+    sourceId: input.sourceId,
+  }).catch(() => undefined);
+  return {
+    cleanupIds: environments.map((environment) => environment.id),
+  };
+}
+
 export async function requestPreviewEnvironmentCleanup(input: {
   previewEnvironmentId: string;
   reason?: string;

--- a/apps/towbar-api/src/areas/previews/pull-request.test.ts
+++ b/apps/towbar-api/src/areas/previews/pull-request.test.ts
@@ -11,6 +11,7 @@ import type { GitHubPullRequest } from "../github/client.js";
 const pullRequest: GitHubPullRequest = {
   baseBranch: "main",
   baseRepository: "avgeek-inc/example",
+  changedFileCount: 1,
   draft: false,
   headBranch: "feature/preview",
   headRepository: "avgeek-inc/example",

--- a/apps/towbar-api/src/areas/previews/service.ts
+++ b/apps/towbar-api/src/areas/previews/service.ts
@@ -9,6 +9,7 @@ import {
   previewHostname,
   previewRef,
   previewRuntimeId,
+  shouldDeployForChangedPaths,
 } from "@workspace/towbar-core";
 import {
   deploymentWorkflowId,
@@ -31,6 +32,7 @@ import {
 } from "../../infrastructure/temporal.js";
 import {
   fetchGitHubPullRequest,
+  fetchGitHubPullRequestChangedPaths,
   fetchGitHubRepositoryTree,
   listOpenGitHubPullRequestNumbers,
 } from "../github/client.js";
@@ -39,8 +41,14 @@ import {
   publishPreviewDeploymentStatus,
 } from "../deployments/preview-status.js";
 import { calculateReleaseDeploymentDigest } from "../sources/deployment-digests.js";
-import { shouldDeferPreviewAdmission } from "./admission-state.js";
-import { requestPreviewPullRequestCleanup } from "./cleanup.js";
+import {
+  isPreviewReleaseCurrent,
+  shouldDeferPreviewAdmission,
+} from "./admission-state.js";
+import {
+  requestPreviewInputMismatchCleanups,
+  requestPreviewPullRequestCleanup,
+} from "./cleanup.js";
 import {
   previewPullRequestDisposition,
   previewPullRequestsToReconcile,
@@ -261,7 +269,35 @@ export async function processPreviewPullRequestEvent(
   if (eligible.length === 0) {
     return { cleanupIds: [], deploymentIds: [], retry: false };
   }
-  const repositoryTree = eligible.some(
+  const changedPaths = eligible.some(
+    (candidate) => candidate.config.deploymentInputs.length > 0,
+  )
+    ? await fetchGitHubPullRequestChangedPaths({
+        changedFileCount: pullRequest.changedFileCount,
+        installationId: source.installationId,
+        pullRequestNumber: pullRequest.number,
+        repositoryName: source.repositoryName,
+        repositoryOwner: source.repositoryOwner,
+      })
+    : { complete: true, paths: [] };
+  const relevant = eligible.filter((candidate) =>
+    shouldDeployForChangedPaths({
+      changedPaths,
+      deploymentInputs: candidate.config.deploymentInputs,
+    }),
+  );
+  const relevantAppIds = new Set(relevant.map((candidate) => candidate.appId));
+  const cleanup = await requestPreviewInputMismatchCleanups({
+    appIds: eligible
+      .filter((candidate) => !relevantAppIds.has(candidate.appId))
+      .map((candidate) => candidate.appId),
+    pullRequestNumber: pullRequest.number,
+    sourceId: event.sourceId,
+  });
+  if (relevant.length === 0) {
+    return { ...cleanup, deploymentIds: [], retry: false };
+  }
+  const repositoryTree = relevant.some(
     (candidate) => candidate.config.deploymentInputs.length > 0,
   )
     ? await fetchGitHubRepositoryTree({
@@ -273,7 +309,7 @@ export async function processPreviewPullRequestEvent(
     : undefined;
 
   const admissions = [];
-  for (const candidate of eligible) {
+  for (const candidate of relevant) {
     const hostname = previewHostname({
       appId: candidate.manifestId,
       domain: candidate.config.preview!.domain,
@@ -339,7 +375,7 @@ export async function processPreviewPullRequestEvent(
     sourceId: event.sourceId,
   }).catch(() => undefined);
   return {
-    cleanupIds: [],
+    cleanupIds: cleanup.cleanupIds,
     deploymentIds: admissions
       .map((admission) => admission.deploymentId)
       .filter((id): id is string => Boolean(id)),
@@ -441,7 +477,6 @@ async function admitPreviewDeployment(input: {
 
     const [current] = await transaction
       .select({
-        commitSha: releases.commitSha,
         deploymentDigest: releases.deploymentDigest,
       })
       .from(releases)
@@ -453,8 +488,7 @@ async function admitPreviewDeployment(input: {
       )
       .limit(1);
     if (
-      current?.commitSha === input.commitSha &&
-      current.deploymentDigest === input.deploymentDigest
+      isPreviewReleaseCurrent(current?.deploymentDigest, input.deploymentDigest)
     ) {
       await transaction
         .update(previewEnvironments)

--- a/apps/towbar-api/src/routes/v1/core/github.ts
+++ b/apps/towbar-api/src/routes/v1/core/github.ts
@@ -5,7 +5,7 @@ import {
   completeInstallation,
   createInstallationUrl,
   disconnectGitHub,
-  getGitHubConnection,
+  getGitHubConnectionStatus,
   getWorkspaceGitHubRepositories,
 } from "../../../areas/github/service.js";
 import { readJson } from "../../../http/requests.js";
@@ -22,7 +22,9 @@ const completeSchema = z
 export const githubRoutes = new Hono<TowbarHonoEnvironment>();
 
 githubRoutes.get("/", async (context) => {
-  const connection = await getGitHubConnection(context.get("user").workspaceId);
+  const connection = await getGitHubConnectionStatus(
+    context.get("user").workspaceId,
+  );
   return context.json({ connection });
 });
 

--- a/apps/towbar-web-app/scripts/fixture-api.ts
+++ b/apps/towbar-web-app/scripts/fixture-api.ts
@@ -340,6 +340,13 @@ const githubConnection: GitHubConnection = {
   accountType: "Organization",
   id: "b1111111-1111-4111-8111-111111111111",
   installationId: "12345678",
+  permissionReadiness: {
+    contents: "read",
+    deployments: "write",
+    preview: "ready",
+    pullRequests: "write",
+    status: "available",
+  },
   suspendedAt: null,
   updatedAt: fixtureNow,
 };

--- a/apps/towbar-web-app/src/components/github-settings.tsx
+++ b/apps/towbar-web-app/src/components/github-settings.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import type { GitHubConnection } from "@workspace/towbar-web-client";
 import { Attributes } from "@workspace/web-design-system/data-display/attributes";
 import { EmptyState } from "@workspace/web-design-system/data-display/empty-state";
+import { Alert } from "@workspace/web-design-system/feedback/alert";
 import { TypographyCode } from "@workspace/web-design-system/typography/typography";
 import { QueryError, QueryLoading } from "@workspace/towbar-web-ui/query-state";
 import { StatusBadge } from "@workspace/towbar-web-ui/status-badge";
@@ -45,6 +46,11 @@ export function GitHubSettings() {
   if (callbackError) return <QueryError message={callbackError} />;
   if (installationId && state) return <QueryLoading />;
   const connection = query.data.connection;
+  const previewPermissionState = connection?.permissionReadiness.status;
+  const previewPermissionsReady =
+    connection !== null &&
+    previewPermissionState === "available" &&
+    connection.permissionReadiness.preview === "ready";
   const action = connection ? (
     connection.suspendedAt ? (
       <ActionButton
@@ -80,6 +86,23 @@ export function GitHubSettings() {
   );
   return connection ? (
     <div className="grid gap-4">
+      {!connection.suspendedAt && !previewPermissionsReady ? (
+        <Alert status="warning">
+          <Alert.Indicator />
+          <Alert.Content>
+            <Alert.Title>
+              {previewPermissionState === "unavailable"
+                ? "GitHub permissions could not be verified"
+                : "Preview reporting needs additional permissions"}
+            </Alert.Title>
+            <Alert.Description>
+              {previewPermissionState === "unavailable"
+                ? "Towbar could not confirm the installation permissions. Try again before relying on Preview status reporting."
+                : "Grant Pull requests and Deployments read and write access so Towbar can publish Preview statuses and keep one status comment updated on each pull request."}
+            </Alert.Description>
+          </Alert.Content>
+        </Alert>
+      ) : null}
       <Attributes columns={2} title="GitHub connection" variant="card">
         <Attributes.Item label="Account">
           {connection.accountLogin}
@@ -95,8 +118,23 @@ export function GitHubSettings() {
             status={connection.suspendedAt ? "suspended" : "active"}
           />
         </Attributes.Item>
+        <Attributes.Item label="Preview reporting">
+          <StatusBadge
+            status={previewPermissionsReady ? "ready" : "attention"}
+          />
+        </Attributes.Item>
       </Attributes>
-      <div>{action}</div>
+      <div className="flex flex-wrap gap-3">
+        {!connection.suspendedAt && !previewPermissionsReady ? (
+          <ActionButton
+            action={openGitHubInstallation}
+            success="Opening GitHub"
+          >
+            Review permissions
+          </ActionButton>
+        ) : null}
+        {action}
+      </div>
     </div>
   ) : (
     <EmptyState>
@@ -104,7 +142,8 @@ export function GitHubSettings() {
         <EmptyState.Title>GitHub not connected</EmptyState.Title>
         <EmptyState.Description className="max-w-md text-pretty">
           Install the GitHub App and choose only the repositories Towbar should
-          read. Towbar never requests write access.
+          manage. Towbar writes only Preview deployment statuses and the single
+          status comment it maintains for each pull request.
         </EmptyState.Description>
       </EmptyState.Header>
       <EmptyState.Content>{action}</EmptyState.Content>

--- a/apps/towbar-worker/README.md
+++ b/apps/towbar-worker/README.md
@@ -26,8 +26,10 @@ validation fails.
 
 Preview pull request events use one durable workflow per Source and pull
 request, which coalesces rapid updates to the latest reconciliation. Preview
-deployments share the server coordinator but run below production and
-maintenance priority with their own manifest-bounded concurrency. Preview
+admission honors each App's expanded `autoDeploy.inputs` against the pull
+request changed-file list, so unrelated pull requests do not consume build
+capacity. Deployments share the server coordinator but run below production
+and maintenance priority with their own manifest-bounded concurrency. Preview
 cleanup is durable and targets only the pull request runtime identity.
 
 The coordinator also runs bounded Resource operations. Operations for one

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,8 +33,11 @@ retains only the configured release set.
 
 For an App with Preview enabled, a relevant same-repository pull request event
 signals one durable workflow per Source and pull request. The API reads current
-GitHub state before reconciling, and repeated events coalesce while deployments
-retain immutable snapshots and independent history. Preview runtime identities,
+GitHub state and changed files before reconciling. Apps with path-aware
+`autoDeploy.inputs` are admitted only when the pull request changes a matching
+path; incomplete GitHub file listings fail safe by remaining eligible. Repeated
+events coalesce while deployments retain immutable snapshots and independent
+history. Preview runtime identities,
 containers, releases, Caddy routes, and exact DNS records are isolated from
 production. The per-server coordinator gives production and maintenance work
 priority and applies a separate bounded Preview concurrency. Promotion checks

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,9 +177,16 @@ Towbar reconciles `opened`, `reopened`, `synchronize`, `edited`, and `closed`
 webhooks against the pull request's current GitHub state. This makes duplicate,
 delayed, and out-of-order deliveries safe and keeps branch renames under the
 same PR identity. Pull requests from forks and pull requests targeting another
-base branch are not deployed. A successful `Sync now` also reconciles open
-eligible pull requests and existing Preview environments, so enabling Preview
-after a PR opens or recovering a missed webhook does not require a new commit.
+base branch are not deployed. When an App configures `autoDeploy.inputs`,
+Preview admission uses those same expanded path patterns against the pull
+request's complete changed-file list. An unrelated pull request does not create
+a Preview, and reverting all matching changes cleans up an existing Preview.
+An incomplete GitHub changed-file response remains eligible rather than risking
+a false skip. Apps using plain `autoDeploy: true` remain commit-sensitive and
+Preview every eligible pull request. A successful `Sync now` also reconciles
+open eligible pull requests and existing Preview environments, so enabling
+Preview after a PR opens or recovering a missed webhook does not require a new
+commit.
 Towbar also maintains one comment per Source and pull request with every App's
 build status, Preview URL, and deployment details link. A hidden stable marker
 lets Towbar update the same GitHub comment instead of posting a new comment for

--- a/packages/towbar-core/src/deployment-inputs.test.ts
+++ b/packages/towbar-core/src/deployment-inputs.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   getDeployableDeploymentDigest,
   getSourceInputDigest,
+  shouldDeployForChangedPaths,
 } from "./deployment-inputs.js";
 
 import type { NormalizedApp, NormalizedServer } from "./manifest.js";
@@ -68,6 +69,52 @@ void test("falls back to the commit when no path contract is configured or the t
       deploymentInputs: ["apps/api/**"],
       tree: { complete: false, entries: [] },
     }).fallback,
+    true,
+  );
+});
+
+void test("selects Preview deployments only when pull request paths match", () => {
+  assert.equal(
+    shouldDeployForChangedPaths({
+      changedPaths: {
+        complete: true,
+        paths: ["apps/company-website/src/app/page.tsx"],
+      },
+      deploymentInputs: [
+        "packages/web-design-system/**",
+        "apps/company-website/**",
+      ],
+    }),
+    true,
+  );
+  assert.equal(
+    shouldDeployForChangedPaths({
+      changedPaths: {
+        complete: true,
+        paths: ["apps/internal-hq-web-app/src/app/page.tsx"],
+      },
+      deploymentInputs: [
+        "packages/web-design-system/**",
+        "apps/company-website/**",
+      ],
+    }),
+    false,
+  );
+});
+
+void test("keeps commit-sensitive and incomplete pull requests eligible", () => {
+  assert.equal(
+    shouldDeployForChangedPaths({
+      changedPaths: { complete: true, paths: [] },
+      deploymentInputs: [],
+    }),
+    true,
+  );
+  assert.equal(
+    shouldDeployForChangedPaths({
+      changedPaths: { complete: false, paths: [] },
+      deploymentInputs: ["apps/company-website/**"],
+    }),
     true,
   );
 });

--- a/packages/towbar-core/src/deployment-inputs.ts
+++ b/packages/towbar-core/src/deployment-inputs.ts
@@ -16,23 +16,42 @@ export type RepositoryTree = {
   entries: RepositoryTreeEntry[];
 };
 
+export type RepositoryChangedPaths = {
+  complete: boolean;
+  paths: string[];
+};
+
+export function shouldDeployForChangedPaths(input: {
+  changedPaths: RepositoryChangedPaths;
+  deploymentInputs: string[];
+}) {
+  if (input.deploymentInputs.length === 0 || !input.changedPaths.complete) {
+    return true;
+  }
+  return input.changedPaths.paths.some((path) =>
+    matchesDeploymentInput(path, input.deploymentInputs),
+  );
+}
+
 export function selectDeploymentInputEntries(
   inputs: string[],
   tree: RepositoryTree,
 ) {
   if (!tree.complete) return [];
   return tree.entries
-    .filter((entry) =>
-      inputs.some((input) =>
-        minimatch(entry.path, input, {
-          dot: true,
-          nocomment: true,
-          nonegate: true,
-          nocase: false,
-        }),
-      ),
-    )
+    .filter((entry) => matchesDeploymentInput(entry.path, inputs))
     .sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function matchesDeploymentInput(path: string, inputs: string[]) {
+  return inputs.some((input) =>
+    minimatch(path, input, {
+      dot: true,
+      nocomment: true,
+      nonegate: true,
+      nocase: false,
+    }),
+  );
 }
 
 export function getSourceInputDigest(input: {

--- a/packages/towbar-web-client/src/types.ts
+++ b/packages/towbar-web-client/src/types.ts
@@ -375,6 +375,15 @@ export type GitHubConnection = {
   accountType: string;
   id: string;
   installationId: string;
+  permissionReadiness:
+    | {
+        contents: "none" | "read" | "write";
+        deployments: "none" | "read" | "write";
+        preview: "missing" | "ready";
+        pullRequests: "none" | "read" | "write";
+        status: "available";
+      }
+    | { status: "unavailable" };
   suspendedAt: string | null;
   updatedAt: string;
 };


### PR DESCRIPTION
## Summary

- reuse each app’s expanded `autoDeploy.inputs` to admit Preview deployments only when the pull request changes a matching path
- clean up an existing Preview when cumulative pull request changes no longer match, while treating input-equivalent follow-up commits as current
- surface GitHub App permission readiness in Settings so missing Preview reporting permissions are actionable

## Edge cases

- considers both old and new paths for renamed files
- keeps plain `autoDeploy: true` apps commit-sensitive
- fails open when GitHub cannot return the complete changed-file list, avoiding a false skip
- preserves existing fork, base-branch, server-readiness, cleanup, and concurrency guards

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Rollback

Revert this pull request. Existing Preview environments and production deployments are otherwise unchanged.