### PR TITLE
Harden Preview lifecycle recovery

### DIFF
--- a/apps/towbar-api/src/areas/deployments/preview-status.ts
+++ b/apps/towbar-api/src/areas/deployments/preview-status.ts
@@ -14,6 +14,11 @@ import {
   updateGitHubPreviewDeployment,
 } from "../github/client.js";
 import { publishPreviewPullRequestCommentForDeployment } from "../previews/pr-comment.js";
+import {
+  markPreviewReportDeliveryAttempt,
+  markPreviewReportDeliveryFailed,
+  markPreviewReportDeliverySucceeded,
+} from "../previews/reporting-state.js";
 
 import type { DeploymentState } from "@workspace/towbar-core/temporal";
 
@@ -81,6 +86,7 @@ export async function publishPreviewDeploymentStatus(
       pullRequestNumber: previewEnvironments.pullRequestNumber,
       repositoryName: sources.repositoryName,
       repositoryOwner: sources.repositoryOwner,
+      sourceId: deployments.sourceId,
     })
     .from(deployments)
     .innerJoin(sources, eq(sources.id, deployments.sourceId))
@@ -100,42 +106,55 @@ export async function publishPreviewDeploymentStatus(
     )
     .limit(1);
   if (!deployment?.hostname || !deployment.gitRef) return;
-  let githubDeploymentId = deployment.githubDeploymentId;
-  if (state === "inactive" && !githubDeploymentId) return;
-  if (!githubDeploymentId) {
-    githubDeploymentId = await createGitHubPreviewDeployment({
-      commitSha: deployment.commitSha,
-      environment:
-        `Preview · ${deployment.app.name} · PR #${deployment.pullRequestNumber}`.slice(
-          0,
-          255,
-        ),
-      environmentUrl: `https://${deployment.hostname}`,
-      installationId: deployment.installationId,
-      repositoryName: deployment.repositoryName,
-      repositoryOwner: deployment.repositoryOwner,
-    });
-    await getTowbarDatabase()
-      .update(deployments)
-      .set({ githubDeploymentId, updatedAt: new Date() })
-      .where(
-        and(
-          eq(deployments.id, deploymentId),
-          isNull(deployments.githubDeploymentId),
-        ),
-      );
+  const report = {
+    pullRequestNumber: deployment.pullRequestNumber,
+    sourceId: deployment.sourceId,
+  };
+  await markPreviewReportDeliveryAttempt(report, "deployment");
+  try {
+    let githubDeploymentId = deployment.githubDeploymentId;
+    if (state !== "inactive" || githubDeploymentId) {
+      if (!githubDeploymentId) {
+        githubDeploymentId = await createGitHubPreviewDeployment({
+          commitSha: deployment.commitSha,
+          environment:
+            `Preview · ${deployment.app.name} · PR #${deployment.pullRequestNumber}`.slice(
+              0,
+              255,
+            ),
+          environmentUrl: `https://${deployment.hostname}`,
+          installationId: deployment.installationId,
+          repositoryName: deployment.repositoryName,
+          repositoryOwner: deployment.repositoryOwner,
+        });
+        await getTowbarDatabase()
+          .update(deployments)
+          .set({ githubDeploymentId, updatedAt: new Date() })
+          .where(
+            and(
+              eq(deployments.id, deploymentId),
+              isNull(deployments.githubDeploymentId),
+            ),
+          );
+      }
+      const githubState =
+        state === "inactive" ? "inactive" : previewGitHubDeploymentState(state);
+      if (githubState) {
+        await updateGitHubPreviewDeployment({
+          deploymentId: githubDeploymentId,
+          environmentUrl: `https://${deployment.hostname}`,
+          installationId: deployment.installationId,
+          repositoryName: deployment.repositoryName,
+          repositoryOwner: deployment.repositoryOwner,
+          state: githubState,
+        });
+      }
+    }
+    await markPreviewReportDeliverySucceeded(report, "deployment");
+  } catch (error) {
+    await markPreviewReportDeliveryFailed(report, "deployment", error);
+    throw error;
   }
-  const githubState =
-    state === "inactive" ? "inactive" : previewGitHubDeploymentState(state);
-  if (!githubState) return;
-  await updateGitHubPreviewDeployment({
-    deploymentId: githubDeploymentId,
-    environmentUrl: `https://${deployment.hostname}`,
-    installationId: deployment.installationId,
-    repositoryName: deployment.repositoryName,
-    repositoryOwner: deployment.repositoryOwner,
-    state: githubState,
-  });
 }
 
 function previewGitHubDeploymentState(state: DeploymentState) {

--- a/apps/towbar-api/src/areas/previews/cleanup-retry.test.ts
+++ b/apps/towbar-api/src/areas/previews/cleanup-retry.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { nextPreviewCleanupAttemptAt } from "./cleanup-retry.js";
+
+const now = new Date("2026-08-28T00:00:00.000Z");
+
+void test("backs cleanup retries off and caps the delay", () => {
+  assert.equal(
+    nextPreviewCleanupAttemptAt(1, now).toISOString(),
+    "2026-08-28T00:05:00.000Z",
+  );
+  assert.equal(
+    nextPreviewCleanupAttemptAt(2, now).toISOString(),
+    "2026-08-28T00:15:00.000Z",
+  );
+  assert.equal(
+    nextPreviewCleanupAttemptAt(3, now).toISOString(),
+    "2026-08-28T01:00:00.000Z",
+  );
+  assert.equal(
+    nextPreviewCleanupAttemptAt(99, now).toISOString(),
+    "2026-08-28T06:00:00.000Z",
+  );
+});

--- a/apps/towbar-api/src/areas/previews/cleanup-retry.ts
+++ b/apps/towbar-api/src/areas/previews/cleanup-retry.ts
@@ -1,0 +1,12 @@
+const cleanupRetryDelaysMinutes = [5, 15, 60, 360] as const;
+
+export function nextPreviewCleanupAttemptAt(
+  attempts: number,
+  now = new Date(),
+) {
+  const delay =
+    cleanupRetryDelaysMinutes[
+      Math.min(Math.max(attempts - 1, 0), cleanupRetryDelaysMinutes.length - 1)
+    ] ?? cleanupRetryDelaysMinutes.at(-1)!;
+  return new Date(now.getTime() + delay * 60_000);
+}

--- a/apps/towbar-api/src/areas/previews/cleanup.ts
+++ b/apps/towbar-api/src/areas/previews/cleanup.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull, lt } from "drizzle-orm";
+import { and, eq, inArray, isNull, lt, lte, or, sql } from "drizzle-orm";
 
 import { isNormalizedResource } from "@workspace/towbar-core";
 import {
@@ -24,6 +24,7 @@ import {
   enqueueClaimedPreviewCleanups,
   previewCleanupAdmissionFailureMessage,
 } from "./cleanup-admission.js";
+import { nextPreviewCleanupAttemptAt } from "./cleanup-retry.js";
 import {
   publishPreviewPullRequestComment,
   publishPreviewPullRequestCommentForEnvironment,
@@ -41,12 +42,16 @@ export async function requestPreviewPullRequestCleanup(input: {
   reason: string;
   sourceId: string;
 }) {
+  const now = new Date();
   const environments = await getTowbarDatabase()
     .update(previewEnvironments)
     .set({
+      cleanupAttempts: sql`${previewEnvironments.cleanupAttempts} + 1`,
       errorMessage: input.reason,
+      lastCleanupAttemptAt: now,
+      nextCleanupAttemptAt: null,
       status: "deleting",
-      updatedAt: new Date(),
+      updatedAt: now,
     })
     .where(
       and(
@@ -77,14 +82,18 @@ export async function requestPreviewInputMismatchCleanups(input: {
   sourceId: string;
 }) {
   if (input.appIds.length === 0) return { cleanupIds: [] as string[] };
+  const now = new Date();
   const reason =
     "Pull request changes no longer match this App's deployment inputs";
   const environments = await getTowbarDatabase()
     .update(previewEnvironments)
     .set({
+      cleanupAttempts: sql`${previewEnvironments.cleanupAttempts} + 1`,
       errorMessage: reason,
+      lastCleanupAttemptAt: now,
+      nextCleanupAttemptAt: null,
       status: "deleting",
-      updatedAt: new Date(),
+      updatedAt: now,
     })
     .where(
       and(
@@ -114,9 +123,16 @@ export async function requestPreviewEnvironmentCleanup(input: {
   reason?: string;
   workspaceId: string;
 }) {
+  const now = new Date();
   const environments = await getTowbarDatabase()
     .update(previewEnvironments)
-    .set({ status: "deleting", updatedAt: new Date() })
+    .set({
+      cleanupAttempts: sql`${previewEnvironments.cleanupAttempts} + 1`,
+      lastCleanupAttemptAt: now,
+      nextCleanupAttemptAt: null,
+      status: "deleting",
+      updatedAt: now,
+    })
     .where(
       and(
         eq(previewEnvironments.id, input.previewEnvironmentId),
@@ -142,11 +158,30 @@ export async function requestPreviewEnvironmentCleanup(input: {
 export async function requestExpiredPreviewCleanups(now = new Date()) {
   const environments = await getTowbarDatabase()
     .update(previewEnvironments)
-    .set({ status: "deleting", updatedAt: now })
+    .set({
+      cleanupAttempts: sql`${previewEnvironments.cleanupAttempts} + 1`,
+      lastCleanupAttemptAt: now,
+      nextCleanupAttemptAt: null,
+      status: "deleting",
+      updatedAt: now,
+    })
     .where(
-      and(
-        lt(previewEnvironments.expiresAt, now),
-        inArray(previewEnvironments.status, cleanablePreviewStatuses),
+      or(
+        and(
+          lt(previewEnvironments.expiresAt, now),
+          inArray(previewEnvironments.status, [
+            "building",
+            "healthy",
+            "failed",
+          ]),
+        ),
+        and(
+          eq(previewEnvironments.status, "cleanup_failed"),
+          or(
+            isNull(previewEnvironments.nextCleanupAttemptAt),
+            lte(previewEnvironments.nextCleanupAttemptAt, now),
+          ),
+        ),
       ),
     )
     .returning({
@@ -162,6 +197,7 @@ export async function requestExpiredPreviewCleanups(now = new Date()) {
 }
 
 export async function requestDisabledPreviewCleanups(sourceId: string) {
+  const now = new Date();
   const activeEnvironments = await getTowbarDatabase()
     .select({
       appId: previewEnvironments.appId,
@@ -189,7 +225,13 @@ export async function requestDisabledPreviewCleanups(sourceId: string) {
     }
     const [claimed] = await getTowbarDatabase()
       .update(previewEnvironments)
-      .set({ status: "deleting", updatedAt: new Date() })
+      .set({
+        cleanupAttempts: sql`${previewEnvironments.cleanupAttempts} + 1`,
+        lastCleanupAttemptAt: now,
+        nextCleanupAttemptAt: null,
+        status: "deleting",
+        updatedAt: now,
+      })
       .where(
         and(
           eq(previewEnvironments.id, environment.id),
@@ -284,12 +326,22 @@ async function markPreviewCleanupAdmissionFailed(
   environment: { id: string },
   error: unknown,
 ) {
+  const [preview] = await getTowbarDatabase()
+    .select({ cleanupAttempts: previewEnvironments.cleanupAttempts })
+    .from(previewEnvironments)
+    .where(eq(previewEnvironments.id, environment.id))
+    .limit(1);
+  const now = new Date();
   await getTowbarDatabase()
     .update(previewEnvironments)
     .set({
       errorMessage: previewCleanupAdmissionFailureMessage(error),
+      nextCleanupAttemptAt: nextPreviewCleanupAttemptAt(
+        preview?.cleanupAttempts ?? 1,
+        now,
+      ),
       status: "cleanup_failed",
-      updatedAt: new Date(),
+      updatedAt: now,
     })
     .where(
       and(
@@ -379,6 +431,7 @@ export async function recordPreviewCleanupResult(
   const now = new Date();
   const [environment] = await getTowbarDatabase()
     .select({
+      cleanupAttempts: previewEnvironments.cleanupAttempts,
       latestDeploymentId: previewEnvironments.latestDeploymentId,
       pullRequestNumber: previewEnvironments.pullRequestNumber,
       sourceId: previewEnvironments.sourceId,
@@ -392,6 +445,9 @@ export async function recordPreviewCleanupResult(
       .set({
         deletedAt: input.succeeded ? now : null,
         errorMessage: input.errorMessage?.slice(0, 1_000) ?? null,
+        nextCleanupAttemptAt: input.succeeded
+          ? null
+          : nextPreviewCleanupAttemptAt(environment?.cleanupAttempts ?? 1, now),
         status: input.succeeded ? "deleted" : "cleanup_failed",
         updatedAt: now,
       })

--- a/apps/towbar-api/src/areas/previews/pr-comment.test.ts
+++ b/apps/towbar-api/src/areas/previews/pr-comment.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  combinePreviewPullRequestCommentEntries,
   previewPullRequestCommentMarker,
   renderPreviewPullRequestComment,
 } from "./pr-comment.js";
@@ -31,6 +32,14 @@ void test("renders all app previews in one status table", () => {
         hostname: "admin-pr-42.preview.example.com",
       },
       {
+        appName: "Docs",
+        deploymentId: null,
+        deploymentState: null,
+        environmentStatus: null,
+        hostname: null,
+        skippedReason: "no matching changes",
+      },
+      {
         appName: "Website",
         deploymentId: "41111111-1111-4111-8111-111111111111",
         deploymentState: "succeeded",
@@ -43,6 +52,7 @@ void test("renders all app previews in one status table", () => {
   });
   assert.match(body, /Admin \\| Console \| 🟡 Building/u);
   assert.match(body, /Website \| 🟢 Ready/u);
+  assert.match(body, /Docs \| ⚪ Skipped — no matching changes/u);
   assert.match(
     body,
     /\[Open preview\]\(https:\/\/website-pr-42\.preview\.example\.com\)/u,
@@ -74,4 +84,45 @@ void test("shows cleanup and failure states without exposing error details", () 
   });
   assert.match(body, /API \| ⚪ Cleaned up/u);
   assert.match(body, /Worker \| 🔴 Failed/u);
+});
+
+void test("shows cleanup before replacing a deleted environment with skipped", () => {
+  const skipped = [
+    {
+      appId: "app-1",
+      appName: "Website",
+      reason: "no matching changes",
+    },
+  ];
+  const deleting = combinePreviewPullRequestCommentEntries(
+    [
+      {
+        appId: "app-1",
+        appName: "Website",
+        deploymentId: null,
+        deploymentState: null,
+        environmentStatus: "deleting",
+        hostname: "website-pr-42.preview.example.com",
+      },
+    ],
+    skipped,
+  );
+  assert.equal(deleting.length, 1);
+  assert.equal(deleting[0]?.environmentStatus, "deleting");
+
+  const deleted = combinePreviewPullRequestCommentEntries(
+    [
+      {
+        appId: "app-1",
+        appName: "Website",
+        deploymentId: null,
+        deploymentState: null,
+        environmentStatus: "deleted",
+        hostname: "website-pr-42.preview.example.com",
+      },
+    ],
+    skipped,
+  );
+  assert.equal(deleted.length, 1);
+  assert.equal(deleted[0]?.skippedReason, "no matching changes");
 });

--- a/apps/towbar-api/src/areas/previews/pr-comment.ts
+++ b/apps/towbar-api/src/areas/previews/pr-comment.ts
@@ -5,12 +5,19 @@ import {
   deployments,
   githubInstallations,
   previewEnvironments,
+  previewPullRequestReports,
   sources,
 } from "@workspace/towbar-database/schema";
 
 import { getEnv } from "../../env.js";
 import { getTowbarDatabase } from "../../infrastructure/database.js";
 import { upsertGitHubPullRequestComment } from "../github/client.js";
+import {
+  type PreviewSkippedApp,
+  markPreviewReportDeliveryAttempt,
+  markPreviewReportDeliveryFailed,
+  markPreviewReportDeliverySucceeded,
+} from "./reporting-state.js";
 
 import type { DeploymentState } from "@workspace/towbar-core/temporal";
 
@@ -57,8 +64,9 @@ export type PreviewPullRequestCommentEntry = {
   appName: string;
   deploymentId: string | null;
   deploymentState: DeploymentState | null;
-  environmentStatus: PreviewEnvironmentStatus;
-  hostname: string;
+  environmentStatus: PreviewEnvironmentStatus | null;
+  hostname: string | null;
+  skippedReason?: string;
 };
 
 export async function publishPreviewPullRequestComment(input: {
@@ -66,7 +74,7 @@ export async function publishPreviewPullRequestComment(input: {
   sourceId: string;
 }) {
   const database = getTowbarDatabase();
-  const [[source], environments] = await Promise.all([
+  const [[source], environments, [report]] = await Promise.all([
     database
       .select({
         installationId: githubInstallations.installationId,
@@ -82,6 +90,7 @@ export async function publishPreviewPullRequestComment(input: {
       .limit(1),
     database
       .select({
+        appId: previewEnvironments.appId,
         appName: apps.name,
         deploymentId: previewEnvironments.latestDeploymentId,
         deploymentState: deployments.state,
@@ -101,22 +110,78 @@ export async function publishPreviewPullRequestComment(input: {
         ),
       )
       .orderBy(asc(apps.name)),
+    database
+      .select({ skippedApps: previewPullRequestReports.skippedApps })
+      .from(previewPullRequestReports)
+      .where(
+        and(
+          eq(previewPullRequestReports.sourceId, input.sourceId),
+          eq(
+            previewPullRequestReports.pullRequestNumber,
+            input.pullRequestNumber,
+          ),
+        ),
+      )
+      .limit(1),
   ]);
-  if (!source || environments.length === 0) return null;
+  const entries = combinePreviewPullRequestCommentEntries(
+    environments,
+    report?.skippedApps ?? [],
+  );
+  if (!source || entries.length === 0) return null;
   const marker = previewPullRequestCommentMarker(input);
-  return await upsertGitHubPullRequestComment({
-    body: renderPreviewPullRequestComment({
-      appBaseUrl: getEnv().TOWBAR_APP_BASE_URL,
-      entries: environments,
+  await markPreviewReportDeliveryAttempt(input, "comment");
+  try {
+    const comment = await upsertGitHubPullRequestComment({
+      body: renderPreviewPullRequestComment({
+        appBaseUrl: getEnv().TOWBAR_APP_BASE_URL,
+        entries,
+        marker,
+        sourceId: input.sourceId,
+      }),
+      installationId: source.installationId,
       marker,
-      sourceId: input.sourceId,
-    }),
-    installationId: source.installationId,
-    marker,
-    pullRequestNumber: input.pullRequestNumber,
-    repositoryName: source.repositoryName,
-    repositoryOwner: source.repositoryOwner,
-  });
+      pullRequestNumber: input.pullRequestNumber,
+      repositoryName: source.repositoryName,
+      repositoryOwner: source.repositoryOwner,
+    });
+    await markPreviewReportDeliverySucceeded(input, "comment");
+    return comment;
+  } catch (error) {
+    await markPreviewReportDeliveryFailed(input, "comment", error);
+    throw error;
+  }
+}
+
+export function combinePreviewPullRequestCommentEntries(
+  environments: Array<PreviewPullRequestCommentEntry & { appId: string }>,
+  skippedApps: PreviewSkippedApp[],
+) {
+  const skippedAppIds = new Set(skippedApps.map((app) => app.appId));
+  const activeEnvironmentAppIds = new Set(
+    environments
+      .filter((environment) => environment.environmentStatus !== "deleted")
+      .map((environment) => environment.appId),
+  );
+  return [
+    ...environments
+      .filter(
+        (environment) =>
+          environment.environmentStatus !== "deleted" ||
+          !skippedAppIds.has(environment.appId),
+      )
+      .map(({ appId: _appId, ...environment }) => environment),
+    ...skippedApps
+      .filter((app) => !activeEnvironmentAppIds.has(app.appId))
+      .map((app) => ({
+        appName: app.appName,
+        deploymentId: null,
+        deploymentState: null,
+        environmentStatus: null,
+        hostname: null,
+        skippedReason: app.reason,
+      })),
+  ].sort((left, right) => left.appName.localeCompare(right.appName));
 }
 
 export async function publishPreviewPullRequestCommentForDeployment(
@@ -176,7 +241,7 @@ export function renderPreviewPullRequestComment(input: {
       : null;
     const status = previewCommentStatus(entry);
     const preview =
-      entry.environmentStatus === "healthy"
+      entry.environmentStatus === "healthy" && entry.hostname
         ? `[Open preview](https://${entry.hostname})`
         : "—";
     return `| ${escapeMarkdownTableCell(entry.appName)} | ${status} | ${preview} | ${deploymentUrl ? `[View details](${deploymentUrl})` : "—"} |`;
@@ -201,8 +266,13 @@ export function renderPreviewPullRequestComment(input: {
 }
 
 function previewCommentStatus(entry: PreviewPullRequestCommentEntry) {
+  if (entry.skippedReason) {
+    return `⚪ Skipped — ${escapeMarkdownTableCell(entry.skippedReason)}`;
+  }
   return (
-    environmentCommentStatuses[entry.environmentStatus] ??
+    (entry.environmentStatus
+      ? environmentCommentStatuses[entry.environmentStatus]
+      : undefined) ??
     (entry.deploymentState
       ? deploymentCommentStatuses[entry.deploymentState]
       : "🟡 Preparing")

--- a/apps/towbar-api/src/areas/previews/reconciliation-scheduler.ts
+++ b/apps/towbar-api/src/areas/previews/reconciliation-scheduler.ts
@@ -1,0 +1,108 @@
+import { and, eq, isNull, ne } from "drizzle-orm";
+
+import { isNormalizedResource } from "@workspace/towbar-core";
+import {
+  apps,
+  githubInstallations,
+  previewEnvironments,
+  previewPullRequestReports,
+  sources,
+} from "@workspace/towbar-database/schema";
+
+import { getTowbarDatabase } from "../../infrastructure/database.js";
+import { enqueuePreviewPullRequestEvent } from "../../infrastructure/temporal.js";
+import { listOpenGitHubPullRequestNumbers } from "../github/client.js";
+import { previewPullRequestsToReconcile } from "./pull-request.js";
+
+export async function scheduleSourcePreviewReconciliations(sourceId: string) {
+  const database = getTowbarDatabase();
+  const [[source], appRows] = await Promise.all([
+    database
+      .select({
+        branch: sources.branch,
+        installationId: githubInstallations.installationId,
+        repositoryName: sources.repositoryName,
+        repositoryOwner: sources.repositoryOwner,
+        status: sources.status,
+      })
+      .from(sources)
+      .innerJoin(
+        githubInstallations,
+        eq(githubInstallations.id, sources.githubInstallationId),
+      )
+      .where(eq(sources.id, sourceId))
+      .limit(1),
+    database
+      .select({ config: apps.config })
+      .from(apps)
+      .where(
+        and(
+          eq(apps.sourceId, sourceId),
+          eq(apps.kind, "app"),
+          isNull(apps.archivedAt),
+        ),
+      ),
+  ]);
+  if (
+    !source ||
+    source.status !== "active" ||
+    !appRows.some(
+      (app) =>
+        !isNormalizedResource(app.config) &&
+        app.config.preview?.enabled === true,
+    )
+  ) {
+    return { pullRequestNumbers: [] };
+  }
+
+  const [openPullRequestNumbers, existingEnvironments, existingReports] =
+    await Promise.all([
+      listOpenGitHubPullRequestNumbers({
+        baseBranch: source.branch,
+        installationId: source.installationId,
+        repositoryName: source.repositoryName,
+        repositoryOwner: source.repositoryOwner,
+      }),
+      database
+        .selectDistinct({
+          pullRequestNumber: previewEnvironments.pullRequestNumber,
+        })
+        .from(previewEnvironments)
+        .where(
+          and(
+            eq(previewEnvironments.sourceId, sourceId),
+            ne(previewEnvironments.status, "deleted"),
+          ),
+        ),
+      database
+        .selectDistinct({
+          pullRequestNumber: previewPullRequestReports.pullRequestNumber,
+        })
+        .from(previewPullRequestReports)
+        .where(
+          and(
+            eq(previewPullRequestReports.sourceId, sourceId),
+            isNull(previewPullRequestReports.closedAt),
+          ),
+        ),
+    ]);
+  const pullRequestNumbers = previewPullRequestsToReconcile(
+    openPullRequestNumbers,
+    [
+      ...existingEnvironments.map(
+        (environment) => environment.pullRequestNumber,
+      ),
+      ...existingReports.map((report) => report.pullRequestNumber),
+    ],
+  );
+  for (let index = 0; index < pullRequestNumbers.length; index += 10) {
+    await Promise.all(
+      pullRequestNumbers
+        .slice(index, index + 10)
+        .map((pullRequestNumber) =>
+          enqueuePreviewPullRequestEvent({ pullRequestNumber, sourceId }),
+        ),
+    );
+  }
+  return { pullRequestNumbers };
+}

--- a/apps/towbar-api/src/areas/previews/reporting-retry.ts
+++ b/apps/towbar-api/src/areas/previews/reporting-retry.ts
@@ -1,0 +1,86 @@
+import { and, eq } from "drizzle-orm";
+
+import {
+  deployments,
+  previewEnvironments,
+} from "@workspace/towbar-database/schema";
+
+import { getTowbarDatabase } from "../../infrastructure/database.js";
+import { publishPreviewDeploymentStatus } from "../deployments/preview-status.js";
+import { publishPreviewPullRequestComment } from "./pr-comment.js";
+import {
+  listFailedPreviewReports,
+  markPreviewReportDeliveryFailed,
+  markPreviewReportDeliverySucceeded,
+} from "./reporting-state.js";
+
+import type { DeploymentState } from "@workspace/towbar-core/temporal";
+
+export async function retryFailedPreviewReporting(workspaceId: string) {
+  const reports = await listFailedPreviewReports(workspaceId);
+  const results = [];
+  for (const report of reports) {
+    const errors: string[] = [];
+    if (report.deploymentDeliveryStatus === "failed") {
+      const latestDeployments = await getTowbarDatabase()
+        .select({
+          deploymentId: deployments.id,
+          environmentStatus: previewEnvironments.status,
+          state: deployments.state,
+        })
+        .from(previewEnvironments)
+        .innerJoin(
+          deployments,
+          eq(deployments.id, previewEnvironments.latestDeploymentId),
+        )
+        .where(
+          and(
+            eq(previewEnvironments.sourceId, report.sourceId),
+            eq(previewEnvironments.pullRequestNumber, report.pullRequestNumber),
+          ),
+        );
+      for (const deployment of latestDeployments) {
+        try {
+          await publishPreviewDeploymentStatus(
+            deployment.deploymentId,
+            deployment.environmentStatus === "deleted"
+              ? "inactive"
+              : (deployment.state as DeploymentState),
+          );
+        } catch (error) {
+          errors.push(
+            error instanceof Error ? error.message : "GitHub request failed",
+          );
+        }
+      }
+      if (errors.length === 0) {
+        await markPreviewReportDeliverySucceeded(report, "deployment");
+      } else {
+        await markPreviewReportDeliveryFailed(
+          report,
+          "deployment",
+          new Error(errors.join("; ")),
+        );
+      }
+    }
+    if (report.commentDeliveryStatus === "failed") {
+      try {
+        await publishPreviewPullRequestComment(report);
+      } catch (error) {
+        errors.push(
+          error instanceof Error ? error.message : "GitHub request failed",
+        );
+      }
+    }
+    results.push({
+      pullRequestNumber: report.pullRequestNumber,
+      sourceId: report.sourceId,
+      succeeded: errors.length === 0,
+    });
+  }
+  return {
+    attempted: results.length,
+    failed: results.filter((result) => !result.succeeded).length,
+    succeeded: results.filter((result) => result.succeeded).length,
+  };
+}

--- a/apps/towbar-api/src/areas/previews/reporting-state.test.ts
+++ b/apps/towbar-api/src/areas/previews/reporting-state.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { previewReportingErrorMessage } from "./reporting-state.js";
+
+void test("bounds and redacts Preview reporting errors", () => {
+  const message = previewReportingErrorMessage(
+    new Error(`Bearer secret-token token=top-secret ${"x".repeat(1_100)}`),
+  );
+  assert.doesNotMatch(message, /secret-token|top-secret/u);
+  assert.match(message, /Bearer \[redacted\] token=\[redacted\]/u);
+  assert.equal(message.length, 1_000);
+});

--- a/apps/towbar-api/src/areas/previews/reporting-state.ts
+++ b/apps/towbar-api/src/areas/previews/reporting-state.ts
@@ -1,0 +1,227 @@
+import { and, count, desc, eq, or } from "drizzle-orm";
+
+import { previewPullRequestReports } from "@workspace/towbar-database/schema";
+
+import { getTowbarDatabase } from "../../infrastructure/database.js";
+
+export type PreviewReportDelivery = "comment" | "deployment";
+export type PreviewSkippedApp = {
+  appId: string;
+  appName: string;
+  reason: string;
+};
+
+export async function recordPreviewPullRequestPlan(input: {
+  branch: string;
+  hasDeployments: boolean;
+  latestCommitSha: string;
+  pullRequestNumber: number;
+  skippedApps: PreviewSkippedApp[];
+  sourceId: string;
+  workspaceId: string;
+}) {
+  const now = new Date();
+  const [report] = await getTowbarDatabase()
+    .insert(previewPullRequestReports)
+    .values({
+      branch: input.branch,
+      closedAt: null,
+      commentDeliveryError: null,
+      commentDeliveryStatus: "pending",
+      deploymentDeliveryError: null,
+      deploymentDeliveryStatus: input.hasDeployments ? "pending" : "published",
+      deploymentPublishedAt: input.hasDeployments ? null : now,
+      latestCommitSha: input.latestCommitSha,
+      pullRequestNumber: input.pullRequestNumber,
+      skippedApps: input.skippedApps,
+      sourceId: input.sourceId,
+      updatedAt: now,
+      workspaceId: input.workspaceId,
+    })
+    .onConflictDoUpdate({
+      target: [
+        previewPullRequestReports.sourceId,
+        previewPullRequestReports.pullRequestNumber,
+      ],
+      set: {
+        branch: input.branch,
+        closedAt: null,
+        commentDeliveryError: null,
+        commentDeliveryStatus: "pending",
+        latestCommitSha: input.latestCommitSha,
+        skippedApps: input.skippedApps,
+        updatedAt: now,
+      },
+    })
+    .returning({ id: previewPullRequestReports.id });
+  return report;
+}
+
+export async function closePreviewPullRequestReport(input: {
+  pullRequestNumber: number;
+  sourceId: string;
+}) {
+  const now = new Date();
+  await getTowbarDatabase()
+    .update(previewPullRequestReports)
+    .set({ closedAt: now, updatedAt: now })
+    .where(reportIdentity(input));
+}
+
+export async function markPreviewReportDeliveryAttempt(
+  input: { pullRequestNumber: number; sourceId: string },
+  delivery: PreviewReportDelivery,
+) {
+  const now = new Date();
+  await getTowbarDatabase()
+    .update(previewPullRequestReports)
+    .set(
+      delivery === "comment"
+        ? {
+            commentDeliveryError: null,
+            commentDeliveryStatus: "pending",
+            commentLastAttemptedAt: now,
+            updatedAt: now,
+          }
+        : {
+            deploymentDeliveryError: null,
+            deploymentDeliveryStatus: "pending",
+            deploymentLastAttemptedAt: now,
+            updatedAt: now,
+          },
+    )
+    .where(reportIdentity(input));
+}
+
+export async function markPreviewReportDeliverySucceeded(
+  input: { pullRequestNumber: number; sourceId: string },
+  delivery: PreviewReportDelivery,
+) {
+  const now = new Date();
+  await getTowbarDatabase()
+    .update(previewPullRequestReports)
+    .set(
+      delivery === "comment"
+        ? {
+            commentDeliveryError: null,
+            commentDeliveryStatus: "published",
+            commentPublishedAt: now,
+            updatedAt: now,
+          }
+        : {
+            deploymentDeliveryError: null,
+            deploymentDeliveryStatus: "published",
+            deploymentPublishedAt: now,
+            updatedAt: now,
+          },
+    )
+    .where(reportIdentity(input));
+}
+
+export async function markPreviewReportDeliveryFailed(
+  input: { pullRequestNumber: number; sourceId: string },
+  delivery: PreviewReportDelivery,
+  error: unknown,
+) {
+  const now = new Date();
+  const message = previewReportingErrorMessage(error);
+  await getTowbarDatabase()
+    .update(previewPullRequestReports)
+    .set(
+      delivery === "comment"
+        ? {
+            commentDeliveryError: message,
+            commentDeliveryStatus: "failed",
+            updatedAt: now,
+          }
+        : {
+            deploymentDeliveryError: message,
+            deploymentDeliveryStatus: "failed",
+            updatedAt: now,
+          },
+    )
+    .where(reportIdentity(input));
+  return message;
+}
+
+export async function getPreviewReportingHealth(workspaceId: string) {
+  const database = getTowbarDatabase();
+  const failureFilter = and(
+    eq(previewPullRequestReports.workspaceId, workspaceId),
+    or(
+      eq(previewPullRequestReports.commentDeliveryStatus, "failed"),
+      eq(previewPullRequestReports.deploymentDeliveryStatus, "failed"),
+    ),
+  );
+  const [[summary], failures] = await Promise.all([
+    database
+      .select({ failedCount: count() })
+      .from(previewPullRequestReports)
+      .where(failureFilter),
+    database
+      .select({
+        commentDeliveryError: previewPullRequestReports.commentDeliveryError,
+        deploymentDeliveryError:
+          previewPullRequestReports.deploymentDeliveryError,
+        pullRequestNumber: previewPullRequestReports.pullRequestNumber,
+        sourceId: previewPullRequestReports.sourceId,
+        updatedAt: previewPullRequestReports.updatedAt,
+      })
+      .from(previewPullRequestReports)
+      .where(failureFilter)
+      .orderBy(desc(previewPullRequestReports.updatedAt))
+      .limit(1),
+  ]);
+  const latest = failures[0];
+  return {
+    failedCount: summary?.failedCount ?? 0,
+    lastError:
+      latest?.commentDeliveryError ?? latest?.deploymentDeliveryError ?? null,
+    lastFailedAt: latest?.updatedAt ?? null,
+  };
+}
+
+export async function listFailedPreviewReports(
+  workspaceId: string,
+  limit = 50,
+) {
+  return await getTowbarDatabase()
+    .select({
+      commentDeliveryStatus: previewPullRequestReports.commentDeliveryStatus,
+      deploymentDeliveryStatus:
+        previewPullRequestReports.deploymentDeliveryStatus,
+      pullRequestNumber: previewPullRequestReports.pullRequestNumber,
+      sourceId: previewPullRequestReports.sourceId,
+    })
+    .from(previewPullRequestReports)
+    .where(
+      and(
+        eq(previewPullRequestReports.workspaceId, workspaceId),
+        or(
+          eq(previewPullRequestReports.commentDeliveryStatus, "failed"),
+          eq(previewPullRequestReports.deploymentDeliveryStatus, "failed"),
+        ),
+      ),
+    )
+    .orderBy(desc(previewPullRequestReports.updatedAt))
+    .limit(limit);
+}
+
+export function previewReportingErrorMessage(error: unknown) {
+  const message =
+    error instanceof Error ? error.message : "GitHub request failed";
+  return message
+    .replace(/Bearer\s+[^\s]+/giu, "Bearer [redacted]")
+    .replace(/(token|secret|password)=([^&\s]+)/giu, "$1=[redacted]")
+    .slice(0, 1_000);
+}
+
+function reportIdentity(input: {
+  pullRequestNumber: number;
+  sourceId: string;
+}) {
+  return and(
+    eq(previewPullRequestReports.sourceId, input.sourceId),
+    eq(previewPullRequestReports.pullRequestNumber, input.pullRequestNumber),
+  );
+}

--- a/apps/towbar-api/src/areas/previews/service.ts
+++ b/apps/towbar-api/src/areas/previews/service.ts
@@ -26,15 +26,11 @@ import {
 } from "@workspace/towbar-database/schema";
 
 import { getTowbarDatabase } from "../../infrastructure/database.js";
-import {
-  enqueueDeployment,
-  enqueuePreviewPullRequestEvent,
-} from "../../infrastructure/temporal.js";
+import { enqueueDeployment } from "../../infrastructure/temporal.js";
 import {
   fetchGitHubPullRequest,
   fetchGitHubPullRequestChangedPaths,
   fetchGitHubRepositoryTree,
-  listOpenGitHubPullRequestNumbers,
 } from "../github/client.js";
 import {
   propagatePreviewDeploymentState,
@@ -49,11 +45,12 @@ import {
   requestPreviewInputMismatchCleanups,
   requestPreviewPullRequestCleanup,
 } from "./cleanup.js";
-import {
-  previewPullRequestDisposition,
-  previewPullRequestsToReconcile,
-} from "./pull-request.js";
+import { previewPullRequestDisposition } from "./pull-request.js";
 import { publishPreviewPullRequestComment } from "./pr-comment.js";
+import {
+  closePreviewPullRequestReport,
+  recordPreviewPullRequestPlan,
+} from "./reporting-state.js";
 
 import type { PreviewPullRequestEvent } from "@workspace/towbar-core/temporal";
 import type { NormalizedApp } from "@workspace/towbar-core";
@@ -66,81 +63,7 @@ const terminalStates = [
   "succeeded_with_warnings",
 ] satisfies Array<(typeof deployments.$inferSelect)["state"]>;
 
-export async function scheduleSourcePreviewReconciliations(sourceId: string) {
-  const database = getTowbarDatabase();
-  const [[source], appRows] = await Promise.all([
-    database
-      .select({
-        branch: sources.branch,
-        installationId: githubInstallations.installationId,
-        repositoryName: sources.repositoryName,
-        repositoryOwner: sources.repositoryOwner,
-        status: sources.status,
-      })
-      .from(sources)
-      .innerJoin(
-        githubInstallations,
-        eq(githubInstallations.id, sources.githubInstallationId),
-      )
-      .where(eq(sources.id, sourceId))
-      .limit(1),
-    database
-      .select({ config: apps.config })
-      .from(apps)
-      .where(
-        and(
-          eq(apps.sourceId, sourceId),
-          eq(apps.kind, "app"),
-          isNull(apps.archivedAt),
-        ),
-      ),
-  ]);
-  if (
-    !source ||
-    source.status !== "active" ||
-    !appRows.some(
-      (app) =>
-        !isNormalizedResource(app.config) &&
-        app.config.preview?.enabled === true,
-    )
-  ) {
-    return { pullRequestNumbers: [] };
-  }
-
-  const [openPullRequestNumbers, existingEnvironments] = await Promise.all([
-    listOpenGitHubPullRequestNumbers({
-      baseBranch: source.branch,
-      installationId: source.installationId,
-      repositoryName: source.repositoryName,
-      repositoryOwner: source.repositoryOwner,
-    }),
-    database
-      .selectDistinct({
-        pullRequestNumber: previewEnvironments.pullRequestNumber,
-      })
-      .from(previewEnvironments)
-      .where(
-        and(
-          eq(previewEnvironments.sourceId, sourceId),
-          ne(previewEnvironments.status, "deleted"),
-        ),
-      ),
-  ]);
-  const pullRequestNumbers = previewPullRequestsToReconcile(
-    openPullRequestNumbers,
-    existingEnvironments.map((environment) => environment.pullRequestNumber),
-  );
-  for (let index = 0; index < pullRequestNumbers.length; index += 10) {
-    await Promise.all(
-      pullRequestNumbers
-        .slice(index, index + 10)
-        .map((pullRequestNumber) =>
-          enqueuePreviewPullRequestEvent({ pullRequestNumber, sourceId }),
-        ),
-    );
-  }
-  return { pullRequestNumbers };
-}
+export { scheduleSourcePreviewReconciliations } from "./reconciliation-scheduler.js";
 
 export async function listPreviewEnvironments(input: {
   appId?: string;
@@ -152,6 +75,7 @@ export async function listPreviewEnvironments(input: {
       appId: previewEnvironments.appId,
       appName: apps.name,
       branch: previewEnvironments.branch,
+      cleanupAttempts: previewEnvironments.cleanupAttempts,
       createdAt: previewEnvironments.createdAt,
       errorMessage: previewEnvironments.errorMessage,
       expiresAt: previewEnvironments.expiresAt,
@@ -160,6 +84,7 @@ export async function listPreviewEnvironments(input: {
       id: previewEnvironments.id,
       latestCommitSha: previewEnvironments.latestCommitSha,
       latestDeploymentId: previewEnvironments.latestDeploymentId,
+      nextCleanupAttemptAt: previewEnvironments.nextCleanupAttemptAt,
       pullRequestNumber: previewEnvironments.pullRequestNumber,
       repositoryName: sources.repositoryName,
       repositoryOwner: sources.repositoryOwner,
@@ -225,6 +150,10 @@ export async function processPreviewPullRequestEvent(
     sourceBranch: source.branch,
   });
   if (disposition.action === "cleanup") {
+    await closePreviewPullRequestReport({
+      pullRequestNumber: event.pullRequestNumber,
+      sourceId: event.sourceId,
+    });
     return {
       ...(await requestPreviewPullRequestCleanup({
         pullRequestNumber: event.pullRequestNumber,
@@ -241,6 +170,7 @@ export async function processPreviewPullRequestEvent(
   const candidates = await database
     .select({
       appId: apps.id,
+      appName: apps.name,
       config: apps.config,
       manifestId: apps.manifestId,
       server: servers.config,
@@ -287,6 +217,21 @@ export async function processPreviewPullRequestEvent(
     }),
   );
   const relevantAppIds = new Set(relevant.map((candidate) => candidate.appId));
+  await recordPreviewPullRequestPlan({
+    branch: pullRequest.headBranch,
+    hasDeployments: relevant.length > 0,
+    latestCommitSha: pullRequest.headSha,
+    pullRequestNumber: pullRequest.number,
+    skippedApps: eligible
+      .filter((candidate) => !relevantAppIds.has(candidate.appId))
+      .map((candidate) => ({
+        appId: candidate.appId,
+        appName: candidate.appName,
+        reason: "no matching changes",
+      })),
+    sourceId: event.sourceId,
+    workspaceId: source.workspaceId,
+  });
   const cleanup = await requestPreviewInputMismatchCleanups({
     appIds: eligible
       .filter((candidate) => !relevantAppIds.has(candidate.appId))
@@ -295,6 +240,10 @@ export async function processPreviewPullRequestEvent(
     sourceId: event.sourceId,
   });
   if (relevant.length === 0) {
+    await publishPreviewPullRequestComment({
+      pullRequestNumber: pullRequest.number,
+      sourceId: event.sourceId,
+    }).catch(() => undefined);
     return { ...cleanup, deploymentIds: [], retry: false };
   }
   const repositoryTree = relevant.some(

--- a/apps/towbar-api/src/routes/v1/core/github.ts
+++ b/apps/towbar-api/src/routes/v1/core/github.ts
@@ -8,6 +8,8 @@ import {
   getGitHubConnectionStatus,
   getWorkspaceGitHubRepositories,
 } from "../../../areas/github/service.js";
+import { retryFailedPreviewReporting } from "../../../areas/previews/reporting-retry.js";
+import { getPreviewReportingHealth } from "../../../areas/previews/reporting-state.js";
 import { readJson } from "../../../http/requests.js";
 
 import type { TowbarHonoEnvironment } from "../../../http/types.js";
@@ -22,10 +24,19 @@ const completeSchema = z
 export const githubRoutes = new Hono<TowbarHonoEnvironment>();
 
 githubRoutes.get("/", async (context) => {
-  const connection = await getGitHubConnectionStatus(
+  const workspaceId = context.get("user").workspaceId;
+  const [connection, previewReporting] = await Promise.all([
+    getGitHubConnectionStatus(workspaceId),
+    getPreviewReportingHealth(workspaceId),
+  ]);
+  return context.json({ connection, previewReporting });
+});
+
+githubRoutes.post("/actions/retry-preview-reporting", async (context) => {
+  const result = await retryFailedPreviewReporting(
     context.get("user").workspaceId,
   );
-  return context.json({ connection });
+  return context.json(result);
 });
 
 githubRoutes.post("/actions/installation-url", async (context) => {

--- a/apps/towbar-web-app/scripts/fixture-api.ts
+++ b/apps/towbar-web-app/scripts/fixture-api.ts
@@ -21,6 +21,7 @@ import type {
   GitHubRepository,
   OrphanItem,
   PreviewEnvironment,
+  PreviewReportingHealth,
   Release,
   Resource,
   ResourceOperation,
@@ -281,6 +282,7 @@ const previews: PreviewEnvironment[] = [
     appId: apps[1]!.id,
     appName: apps[1]!.name,
     branch: "feature/preview-fixture",
+    cleanupAttempts: 0,
     createdAt: fixtureNow,
     errorMessage: null,
     expiresAt: "2026-08-25T09:00:00.000Z",
@@ -289,10 +291,31 @@ const previews: PreviewEnvironment[] = [
     id: fixtureIds.preview,
     latestCommitSha: commitSha,
     latestDeploymentId: previewDeployment.id,
+    nextCleanupAttemptAt: null,
     pullRequestNumber: 42,
     pullRequestUrl: "https://github.com/avgeek-inc/towbar/pull/42",
     sourceId: source.id,
     status: "healthy",
+    updatedAt: fixtureNow,
+  },
+  {
+    appId: apps[1]!.id,
+    appName: apps[1]!.name,
+    branch: "fix/preview-cleanup",
+    cleanupAttempts: 2,
+    createdAt: fixtureNow,
+    errorMessage: "The server could not be reached over SSH",
+    expiresAt: "2026-08-25T09:00:00.000Z",
+    gitRef: "refs/heads/fix/preview-cleanup",
+    hostname: "example-website-pr-43.preview.example.com",
+    id: "b1111111-1111-4111-8111-222222222222",
+    latestCommitSha: "e".repeat(40),
+    latestDeploymentId: null,
+    nextCleanupAttemptAt: "2026-08-28T04:15:00.000Z",
+    pullRequestNumber: 43,
+    pullRequestUrl: "https://github.com/avgeek-inc/towbar/pull/43",
+    sourceId: source.id,
+    status: "cleanup_failed",
     updatedAt: fixtureNow,
   },
 ];
@@ -349,6 +372,12 @@ const githubConnection: GitHubConnection = {
   },
   suspendedAt: null,
   updatedAt: fixtureNow,
+};
+
+const previewReporting: PreviewReportingHealth = {
+  failedCount: 1,
+  lastError: "GitHub temporarily rejected the Preview status update",
+  lastFailedAt: fixtureNow,
 };
 
 const githubRepositories: GitHubRepository[] = [
@@ -814,6 +843,19 @@ export function createFixtureApiServer() {
     }
     if (
       request.method === "POST" &&
+      path === "/v1/core/github/actions/retry-preview-reporting"
+    ) {
+      previewReporting.failedCount = 0;
+      previewReporting.lastError = null;
+      previewReporting.lastFailedAt = null;
+      return writeJson(response, 200, {
+        attempted: 1,
+        failed: 0,
+        succeeded: 1,
+      });
+    }
+    if (
+      request.method === "POST" &&
       path === `/v1/core/servers/${fixtureIds.server}/host-keys/actions/trust`
     ) {
       const hostKeys = hostKeysByServer.get(fixtureIds.server)!;
@@ -971,7 +1013,13 @@ function getFixturePayload(
       "/v1/core/sessions",
       { currentSessionId: userSessions[0]!.id, sessions: userSessions },
     ],
-    ["/v1/core/github", { connection: githubConnection }],
+    [
+      "/v1/core/github",
+      {
+        connection: githubConnection,
+        previewReporting,
+      },
+    ],
     ["/v1/core/github/repositories", { repositories: githubRepositories }],
     ["/v1/core/sources", { sources: [source] }],
     ["/v1/core/apps", { apps }],

--- a/apps/towbar-web-app/src/components/github-settings.tsx
+++ b/apps/towbar-web-app/src/components/github-settings.tsx
@@ -2,7 +2,10 @@
 
 import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import type { GitHubConnection } from "@workspace/towbar-web-client";
+import type {
+  GitHubConnection,
+  PreviewReportingHealth,
+} from "@workspace/towbar-web-client";
 import { Attributes } from "@workspace/web-design-system/data-display/attributes";
 import { EmptyState } from "@workspace/web-design-system/data-display/empty-state";
 import { Alert } from "@workspace/web-design-system/feedback/alert";
@@ -18,9 +21,10 @@ export function GitHubSettings() {
   const params = useSearchParams();
   const completed = useRef(false);
   const [callbackError, setCallbackError] = useState<string>();
-  const query = useApiQuery<{ connection: GitHubConnection | null }>(
-    "/v1/core/github",
-  );
+  const query = useApiQuery<{
+    connection: GitHubConnection | null;
+    previewReporting: PreviewReportingHealth;
+  }>("/v1/core/github");
   const installationId = params.get("installation_id");
   const state = params.get("state");
   useEffect(() => {
@@ -46,6 +50,7 @@ export function GitHubSettings() {
   if (callbackError) return <QueryError message={callbackError} />;
   if (installationId && state) return <QueryLoading />;
   const connection = query.data.connection;
+  const previewReporting = query.data.previewReporting;
   const previewPermissionState = connection?.permissionReadiness.status;
   const previewPermissionsReady =
     connection !== null &&
@@ -86,6 +91,42 @@ export function GitHubSettings() {
   );
   return connection ? (
     <div className="grid gap-4">
+      {previewReporting.failedCount > 0 ? (
+        <Alert status="warning">
+          <Alert.Indicator />
+          <Alert.Content>
+            <Alert.Title>Preview reporting needs retry</Alert.Title>
+            <Alert.Description>
+              GitHub did not receive every Preview status or pull request
+              comment update. Deployments and cleanup continue independently.
+              {previewReporting.lastError
+                ? ` Last error: ${previewReporting.lastError}`
+                : ""}
+            </Alert.Description>
+            <div className="mt-3">
+              <ActionButton
+                action={async () => {
+                  const result = await api.post<{
+                    attempted: number;
+                    failed: number;
+                    succeeded: number;
+                  }>("/v1/core/github/actions/retry-preview-reporting");
+                  if (result.failed > 0) {
+                    throw new Error(
+                      `${result.failed} Preview report${result.failed === 1 ? "" : "s"} still could not reach GitHub`,
+                    );
+                  }
+                  return result;
+                }}
+                pendingLabel="Retrying…"
+                success="Preview reporting retried"
+              >
+                Retry reporting
+              </ActionButton>
+            </div>
+          </Alert.Content>
+        </Alert>
+      ) : null}
       {!connection.suspendedAt && !previewPermissionsReady ? (
         <Alert status="warning">
           <Alert.Indicator />

--- a/apps/towbar-web-app/src/components/preview-environments.tsx
+++ b/apps/towbar-web-app/src/components/preview-environments.tsx
@@ -69,16 +69,19 @@ export function PreviewEnvironments({
       key: "url",
       header: "URL",
       className: "min-w-64",
-      cell: (preview) => (
-        <a
-          className="focus-visible:ring-focus inline-flex rounded-md underline decoration-muted underline-offset-4 outline-none hover:decoration-current focus-visible:ring-2"
-          href={`https://${preview.hostname}`}
-          rel="noreferrer"
-          target="_blank"
-        >
-          {preview.hostname}
-        </a>
-      ),
+      cell: (preview) =>
+        preview.status === "healthy" ? (
+          <a
+            className="focus-visible:ring-focus inline-flex rounded-md underline decoration-muted underline-offset-4 outline-none hover:decoration-current focus-visible:ring-2"
+            href={`https://${preview.hostname}`}
+            rel="noreferrer"
+            target="_blank"
+          >
+            {preview.hostname}
+          </a>
+        ) : (
+          preview.hostname
+        ),
     },
     {
       key: "commit",
@@ -99,8 +102,23 @@ export function PreviewEnvironments({
     {
       key: "status",
       header: "Status",
-      className: "whitespace-nowrap",
-      cell: (preview) => <StatusBadge status={preview.status} />,
+      className: "min-w-56",
+      cell: (preview) => (
+        <div className="flex flex-col items-start gap-1">
+          <StatusBadge status={preview.status} />
+          {preview.status === "cleanup_failed" && preview.errorMessage ? (
+            <span className="line-clamp-2 text-sm text-danger">
+              {preview.errorMessage}
+            </span>
+          ) : null}
+          {preview.status === "cleanup_failed" &&
+          preview.nextCleanupAttemptAt ? (
+            <span className="text-sm text-muted">
+              Automatic retry {formatDate(preview.nextCleanupAttemptAt)}
+            </span>
+          ) : null}
+        </div>
+      ),
     },
     {
       key: "actions",
@@ -115,23 +133,35 @@ export function PreviewEnvironments({
               Deployment
             </InlineLink>
           ) : null}
-          <ActionButton
-            action={() =>
-              api.post(`/v1/core/previews/${preview.id}/actions/delete`)
-            }
-            confirm={{
-              actionLabel: "Delete Preview",
-              description:
-                "Towbar will remove this pull request's container, image, route, and DNS record. A later commit can create it again while the pull request remains open and Preview is enabled.",
-              title: `Delete Preview for PR #${preview.pullRequestNumber}?`,
-            }}
-            isDisabled={preview.status === "deleting"}
-            pendingLabel="Queueing…"
-            success="Preview cleanup queued"
-            variant="danger"
-          >
-            Delete
-          </ActionButton>
+          {preview.status === "cleanup_failed" ? (
+            <ActionButton
+              action={() =>
+                api.post(`/v1/core/previews/${preview.id}/actions/delete`)
+              }
+              pendingLabel="Queueing…"
+              success="Preview cleanup retry queued"
+            >
+              Retry cleanup
+            </ActionButton>
+          ) : (
+            <ActionButton
+              action={() =>
+                api.post(`/v1/core/previews/${preview.id}/actions/delete`)
+              }
+              confirm={{
+                actionLabel: "Delete Preview",
+                description:
+                  "Towbar will remove this pull request's container, image, route, and DNS record. A later commit can create it again while the pull request remains open and Preview is enabled.",
+                title: `Delete Preview for PR #${preview.pullRequestNumber}?`,
+              }}
+              isDisabled={preview.status === "deleting"}
+              pendingLabel="Queueing…"
+              success="Preview cleanup queued"
+              variant="danger"
+            >
+              Delete
+            </ActionButton>
+          )}
         </div>
       ),
     },

--- a/packages/towbar-database/drizzle/0027_robust_nextwave.sql
+++ b/packages/towbar-database/drizzle/0027_robust_nextwave.sql
@@ -1,0 +1,30 @@
+CREATE TYPE "public"."towbar_preview_report_delivery_status" AS ENUM('pending', 'published', 'failed');--> statement-breakpoint
+CREATE TABLE "towbar_preview_pull_request_reports" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"workspace_id" uuid NOT NULL,
+	"source_id" uuid NOT NULL,
+	"pull_request_number" integer NOT NULL,
+	"branch" varchar(255) NOT NULL,
+	"latest_commit_sha" varchar(64) NOT NULL,
+	"skipped_apps" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"comment_delivery_status" "towbar_preview_report_delivery_status" DEFAULT 'pending' NOT NULL,
+	"comment_delivery_error" varchar(1000),
+	"comment_last_attempted_at" timestamp with time zone,
+	"comment_published_at" timestamp with time zone,
+	"deployment_delivery_status" "towbar_preview_report_delivery_status" DEFAULT 'pending' NOT NULL,
+	"deployment_delivery_error" varchar(1000),
+	"deployment_last_attempted_at" timestamp with time zone,
+	"deployment_published_at" timestamp with time zone,
+	"closed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "towbar_preview_environments" ADD COLUMN "cleanup_attempts" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "towbar_preview_environments" ADD COLUMN "last_cleanup_attempt_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "towbar_preview_environments" ADD COLUMN "next_cleanup_attempt_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "towbar_preview_pull_request_reports" ADD CONSTRAINT "towbar_preview_pull_request_reports_workspace_id_towbar_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."towbar_workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "towbar_preview_pull_request_reports" ADD CONSTRAINT "towbar_preview_pull_request_reports_source_id_towbar_sources_id_fk" FOREIGN KEY ("source_id") REFERENCES "public"."towbar_sources"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_towbar_preview_report_source_pr" ON "towbar_preview_pull_request_reports" USING btree ("source_id","pull_request_number");--> statement-breakpoint
+CREATE INDEX "idx_towbar_preview_report_workspace_comment" ON "towbar_preview_pull_request_reports" USING btree ("workspace_id","comment_delivery_status");--> statement-breakpoint
+CREATE INDEX "idx_towbar_preview_report_workspace_deployment" ON "towbar_preview_pull_request_reports" USING btree ("workspace_id","deployment_delivery_status");

--- a/packages/towbar-database/drizzle/meta/0027_snapshot.json
+++ b/packages/towbar-database/drizzle/meta/0027_snapshot.json
@@ -1,0 +1,3850 @@
+{
+  "id": "e3009601-9d40-4307-9c7f-199dbe37995c",
+  "prevId": "67bc9dc2-42c6-47cb-942a-39676bbd1d2d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.towbar_apps": {
+      "name": "towbar_apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_id": {
+          "name": "manifest_id",
+          "type": "varchar(63)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "towbar_deployable_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'app'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_digest": {
+          "name": "config_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_digest": {
+          "name": "deployment_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_input_digest": {
+          "name": "source_input_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_apps_source_manifest_id": {
+          "name": "uq_towbar_apps_source_manifest_id",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "manifest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_apps_workspace": {
+          "name": "idx_towbar_apps_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_apps_server": {
+          "name": "idx_towbar_apps_server",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_apps_archived_at": {
+          "name": "idx_towbar_apps_archived_at",
+          "columns": [
+            {
+              "expression": "archived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_apps_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_apps_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_apps",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_apps_source_id_towbar_sources_id_fk": {
+          "name": "towbar_apps_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_apps",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_apps_server_id_towbar_servers_id_fk": {
+          "name": "towbar_apps_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_apps",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_audit_events": {
+      "name": "towbar_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_audit_workspace_created": {
+          "name": "idx_towbar_audit_workspace_created",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_audit_events_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_audit_events_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_audit_events",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_audit_events_actor_user_id_towbar_users_id_fk": {
+          "name": "towbar_audit_events_actor_user_id_towbar_users_id_fk",
+          "tableFrom": "towbar_audit_events",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_auth_rate_limit_buckets": {
+      "name": "towbar_auth_rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_auth_rate_limit_expires": {
+          "name": "idx_towbar_auth_rate_limit_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_deployable_runtime_states": {
+      "name": "towbar_deployable_runtime_states",
+      "schema": "",
+      "columns": {
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "desired_state": {
+          "name": "desired_state",
+          "type": "towbar_runtime_desired_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "observed_state": {
+          "name": "observed_state",
+          "type": "towbar_runtime_observed_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "health_status": {
+          "name": "health_status",
+          "type": "towbar_runtime_health_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "drift_status": {
+          "name": "drift_status",
+          "type": "towbar_runtime_drift_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "drift_reasons": {
+          "name": "drift_reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "observed_container_name": {
+          "name": "observed_container_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_image": {
+          "name": "observed_image",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_check_id": {
+          "name": "last_check_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_runtime_drift": {
+          "name": "idx_towbar_runtime_drift",
+          "columns": [
+            {
+              "expression": "drift_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_deployable_runtime_states_app_id_towbar_apps_id_fk": {
+          "name": "towbar_deployable_runtime_states_app_id_towbar_apps_id_fk",
+          "tableFrom": "towbar_deployable_runtime_states",
+          "tableTo": "towbar_apps",
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_deployable_runtime_states_last_check_id_towbar_server_checks_id_fk": {
+          "name": "towbar_deployable_runtime_states_last_check_id_towbar_server_checks_id_fk",
+          "tableFrom": "towbar_deployable_runtime_states",
+          "tableTo": "towbar_server_checks",
+          "columnsFrom": ["last_check_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_deployment_log_chunks": {
+      "name": "towbar_deployment_log_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stream": {
+          "name": "stream",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_deployment_logs_sequence": {
+          "name": "uq_towbar_deployment_logs_sequence",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_deployment_logs_created": {
+          "name": "idx_towbar_deployment_logs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_deployment_log_chunks_deployment_id_towbar_deployments_id_fk": {
+          "name": "towbar_deployment_log_chunks_deployment_id_towbar_deployments_id_fk",
+          "tableFrom": "towbar_deployment_log_chunks",
+          "tableTo": "towbar_deployments",
+          "columnsFrom": ["deployment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_deployment_steps": {
+      "name": "towbar_deployment_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "towbar_deployment_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_deployment_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_deployment_steps_sequence": {
+          "name": "uq_towbar_deployment_steps_sequence",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_deployment_steps_deployment_id_towbar_deployments_id_fk": {
+          "name": "towbar_deployment_steps_deployment_id_towbar_deployments_id_fk",
+          "tableFrom": "towbar_deployment_steps",
+          "tableTo": "towbar_deployments",
+          "columnsFrom": ["deployment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_deployments": {
+      "name": "towbar_deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "temporal_workflow_id": {
+          "name": "temporal_workflow_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "towbar_deployment_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deploy'"
+        },
+        "environment": {
+          "name": "environment",
+          "type": "towbar_deployment_environment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "git_ref": {
+          "name": "git_ref",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_deployment_id": {
+          "name": "github_deployment_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_environment_id": {
+          "name": "preview_environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployable_kind": {
+          "name": "deployable_kind",
+          "type": "towbar_deployable_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'app'"
+        },
+        "state": {
+          "name": "state",
+          "type": "towbar_deployment_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_digest": {
+          "name": "config_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_digest": {
+          "name": "deployment_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_input_digest": {
+          "name": "source_input_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_digest": {
+          "name": "manifest_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_snapshot": {
+          "name": "app_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_snapshot": {
+          "name": "server_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollback_release_snapshot": {
+          "name": "rollback_release_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_deployments_idempotency": {
+          "name": "uq_towbar_deployments_idempotency",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_towbar_deployments_workflow_id": {
+          "name": "uq_towbar_deployments_workflow_id",
+          "columns": [
+            {
+              "expression": "temporal_workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_deployments_app_created": {
+          "name": "idx_towbar_deployments_app_created",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_deployments_server_state": {
+          "name": "idx_towbar_deployments_server_state",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_deployments_preview_created": {
+          "name": "idx_towbar_deployments_preview_created",
+          "columns": [
+            {
+              "expression": "preview_environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_deployments_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_deployments_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_deployments",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_deployments_source_id_towbar_sources_id_fk": {
+          "name": "towbar_deployments_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_deployments",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "towbar_deployments_app_id_towbar_apps_id_fk": {
+          "name": "towbar_deployments_app_id_towbar_apps_id_fk",
+          "tableFrom": "towbar_deployments",
+          "tableTo": "towbar_apps",
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "towbar_deployments_server_id_towbar_servers_id_fk": {
+          "name": "towbar_deployments_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_deployments",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "towbar_deployments_requested_by_towbar_users_id_fk": {
+          "name": "towbar_deployments_requested_by_towbar_users_id_fk",
+          "tableFrom": "towbar_deployments",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["requested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "towbar_deployments_preview_environment_id_towbar_preview_environments_id_fk": {
+          "name": "towbar_deployments_preview_environment_id_towbar_preview_environments_id_fk",
+          "tableFrom": "towbar_deployments",
+          "tableTo": "towbar_preview_environments",
+          "columnsFrom": ["preview_environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_towbar_deployments_rollback_snapshot": {
+          "name": "chk_towbar_deployments_rollback_snapshot",
+          "value": "(\"towbar_deployments\".\"kind\" = 'deploy' AND \"towbar_deployments\".\"rollback_release_snapshot\" IS NULL) OR (\"towbar_deployments\".\"kind\" = 'rollback' AND \"towbar_deployments\".\"rollback_release_snapshot\" IS NOT NULL)"
+        },
+        "chk_towbar_deployments_environment": {
+          "name": "chk_towbar_deployments_environment",
+          "value": "(\"towbar_deployments\".\"environment\" = 'production' AND \"towbar_deployments\".\"preview_environment_id\" IS NULL AND \"towbar_deployments\".\"git_ref\" IS NULL AND \"towbar_deployments\".\"hostname\" IS NULL) OR (\"towbar_deployments\".\"environment\" = 'preview' AND \"towbar_deployments\".\"preview_environment_id\" IS NOT NULL AND \"towbar_deployments\".\"git_ref\" IS NOT NULL AND \"towbar_deployments\".\"hostname\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.towbar_github_installations": {
+      "name": "towbar_github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_github_installation_id": {
+          "name": "uq_towbar_github_installation_id",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_towbar_github_installations_workspace": {
+          "name": "uq_towbar_github_installations_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_github_installations_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_github_installations_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_github_installations",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_github_webhook_deliveries": {
+      "name": "towbar_github_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_digest": {
+          "name": "payload_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_towbar_webhooks_accepted_at": {
+          "name": "idx_towbar_webhooks_accepted_at",
+          "columns": [
+            {
+              "expression": "accepted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_github_webhook_deliveries_source_id_towbar_sources_id_fk": {
+          "name": "towbar_github_webhook_deliveries_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_github_webhook_deliveries",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_password_credentials": {
+      "name": "towbar_password_credentials",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_reset_fingerprint": {
+          "name": "operator_reset_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "towbar_password_credentials_user_id_towbar_users_id_fk": {
+          "name": "towbar_password_credentials_user_id_towbar_users_id_fk",
+          "tableFrom": "towbar_password_credentials",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_preview_environments": {
+      "name": "towbar_preview_environments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "git_ref": {
+          "name": "git_ref",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_id": {
+          "name": "runtime_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_commit_sha": {
+          "name": "latest_commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_deployment_id": {
+          "name": "latest_deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_preview_environment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'building'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_attempts": {
+          "name": "cleanup_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_cleanup_attempt_at": {
+          "name": "last_cleanup_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_cleanup_attempt_at": {
+          "name": "next_cleanup_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_preview_environment_ref": {
+          "name": "uq_towbar_preview_environment_ref",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "git_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_towbar_preview_environment_hostname": {
+          "name": "uq_towbar_preview_environment_hostname",
+          "columns": [
+            {
+              "expression": "hostname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_preview_environment_source_status": {
+          "name": "idx_towbar_preview_environment_source_status",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_preview_environment_expires": {
+          "name": "idx_towbar_preview_environment_expires",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_preview_environments_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_preview_environments_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_preview_environments",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_preview_environments_source_id_towbar_sources_id_fk": {
+          "name": "towbar_preview_environments_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_preview_environments",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_preview_environments_app_id_towbar_apps_id_fk": {
+          "name": "towbar_preview_environments_app_id_towbar_apps_id_fk",
+          "tableFrom": "towbar_preview_environments",
+          "tableTo": "towbar_apps",
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_preview_environments_server_id_towbar_servers_id_fk": {
+          "name": "towbar_preview_environments_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_preview_environments",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_preview_pull_request_reports": {
+      "name": "towbar_preview_pull_request_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_commit_sha": {
+          "name": "latest_commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skipped_apps": {
+          "name": "skipped_apps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "comment_delivery_status": {
+          "name": "comment_delivery_status",
+          "type": "towbar_preview_report_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "comment_delivery_error": {
+          "name": "comment_delivery_error",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_last_attempted_at": {
+          "name": "comment_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_published_at": {
+          "name": "comment_published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_delivery_status": {
+          "name": "deployment_delivery_status",
+          "type": "towbar_preview_report_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "deployment_delivery_error": {
+          "name": "deployment_delivery_error",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_last_attempted_at": {
+          "name": "deployment_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_published_at": {
+          "name": "deployment_published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_preview_report_source_pr": {
+          "name": "uq_towbar_preview_report_source_pr",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pull_request_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_preview_report_workspace_comment": {
+          "name": "idx_towbar_preview_report_workspace_comment",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "comment_delivery_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_preview_report_workspace_deployment": {
+          "name": "idx_towbar_preview_report_workspace_deployment",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deployment_delivery_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_preview_pull_request_reports_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_preview_pull_request_reports_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_preview_pull_request_reports",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_preview_pull_request_reports_source_id_towbar_sources_id_fk": {
+          "name": "towbar_preview_pull_request_reports_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_preview_pull_request_reports",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_releases": {
+      "name": "towbar_releases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "towbar_deployment_environment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "git_ref": {
+          "name": "git_ref",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_environment_id": {
+          "name": "preview_environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_release_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_digest": {
+          "name": "config_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_digest": {
+          "name": "deployment_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_input_digest": {
+          "name": "source_input_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_tag": {
+          "name": "image_tag",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_towbar_releases_deployment": {
+          "name": "uq_towbar_releases_deployment",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_releases_app_status": {
+          "name": "idx_towbar_releases_app_status",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_releases_preview_status": {
+          "name": "idx_towbar_releases_preview_status",
+          "columns": [
+            {
+              "expression": "preview_environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_releases_app_id_towbar_apps_id_fk": {
+          "name": "towbar_releases_app_id_towbar_apps_id_fk",
+          "tableFrom": "towbar_releases",
+          "tableTo": "towbar_apps",
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_releases_deployment_id_towbar_deployments_id_fk": {
+          "name": "towbar_releases_deployment_id_towbar_deployments_id_fk",
+          "tableFrom": "towbar_releases",
+          "tableTo": "towbar_deployments",
+          "columnsFrom": ["deployment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "towbar_releases_preview_environment_id_towbar_preview_environments_id_fk": {
+          "name": "towbar_releases_preview_environment_id_towbar_preview_environments_id_fk",
+          "tableFrom": "towbar_releases",
+          "tableTo": "towbar_preview_environments",
+          "columnsFrom": ["preview_environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_towbar_releases_environment": {
+          "name": "chk_towbar_releases_environment",
+          "value": "(\"towbar_releases\".\"environment\" = 'production' AND \"towbar_releases\".\"preview_environment_id\" IS NULL AND \"towbar_releases\".\"git_ref\" IS NULL) OR (\"towbar_releases\".\"environment\" = 'preview' AND \"towbar_releases\".\"preview_environment_id\" IS NOT NULL AND \"towbar_releases\".\"git_ref\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.towbar_request_nonces": {
+      "name": "towbar_request_nonces",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_request_nonces_expires": {
+          "name": "idx_towbar_request_nonces_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pk_towbar_request_nonces": {
+          "name": "pk_towbar_request_nonces",
+          "columns": ["scope", "nonce"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_resource_operations": {
+      "name": "towbar_resource_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "temporal_workflow_id": {
+          "name": "temporal_workflow_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "towbar_resource_operation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "towbar_resource_operation_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_snapshot": {
+          "name": "app_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_snapshot": {
+          "name": "server_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_resource_operations_idempotency": {
+          "name": "uq_towbar_resource_operations_idempotency",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_towbar_resource_operations_workflow": {
+          "name": "uq_towbar_resource_operations_workflow",
+          "columns": [
+            {
+              "expression": "temporal_workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_resource_operations_resource_created": {
+          "name": "idx_towbar_resource_operations_resource_created",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_resource_operations_server_state": {
+          "name": "idx_towbar_resource_operations_server_state",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_resource_operations_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_resource_operations_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_resource_operations",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_resource_operations_source_id_towbar_sources_id_fk": {
+          "name": "towbar_resource_operations_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_resource_operations",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_resource_operations_resource_id_towbar_apps_id_fk": {
+          "name": "towbar_resource_operations_resource_id_towbar_apps_id_fk",
+          "tableFrom": "towbar_resource_operations",
+          "tableTo": "towbar_apps",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_resource_operations_server_id_towbar_servers_id_fk": {
+          "name": "towbar_resource_operations_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_resource_operations",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_resource_operations_requested_by_towbar_users_id_fk": {
+          "name": "towbar_resource_operations_requested_by_towbar_users_id_fk",
+          "tableFrom": "towbar_resource_operations",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["requested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_server_checks": {
+      "name": "towbar_server_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_check_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_server_checks_server": {
+          "name": "idx_towbar_server_checks_server",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_server_checks_server_id_towbar_servers_id_fk": {
+          "name": "towbar_server_checks_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_server_checks",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_server_checks_requested_by_towbar_users_id_fk": {
+          "name": "towbar_server_checks_requested_by_towbar_users_id_fk",
+          "tableFrom": "towbar_server_checks",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["requested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_server_preparations": {
+      "name": "towbar_server_preparations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_digest": {
+          "name": "config_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_check_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_server_preparations_server_created": {
+          "name": "idx_towbar_server_preparations_server_created",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_towbar_server_preparations_active": {
+          "name": "uq_towbar_server_preparations_active",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"towbar_server_preparations\".\"status\" in ('queued', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_server_preparations_server_id_towbar_servers_id_fk": {
+          "name": "towbar_server_preparations_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_server_preparations",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_server_preparations_requested_by_towbar_users_id_fk": {
+          "name": "towbar_server_preparations_requested_by_towbar_users_id_fk",
+          "tableFrom": "towbar_server_preparations",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["requested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_servers": {
+      "name": "towbar_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_ip": {
+          "name": "canonical_ip",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_digest": {
+          "name": "config_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prepared_at": {
+          "name": "prepared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prepared_config_digest": {
+          "name": "prepared_config_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_servers_source_ip": {
+          "name": "uq_towbar_servers_source_ip",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "canonical_ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_servers_workspace": {
+          "name": "idx_towbar_servers_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_servers_archived_at": {
+          "name": "idx_towbar_servers_archived_at",
+          "columns": [
+            {
+              "expression": "archived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_servers_source_id_towbar_sources_id_fk": {
+          "name": "towbar_servers_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_servers",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_servers_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_servers_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_servers",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_sessions": {
+      "name": "towbar_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_sessions_token_hash": {
+          "name": "uq_towbar_sessions_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_sessions_user_id": {
+          "name": "idx_towbar_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_sessions_expires_at": {
+          "name": "idx_towbar_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_sessions_user_id_towbar_users_id_fk": {
+          "name": "towbar_sessions_user_id_towbar_users_id_fk",
+          "tableFrom": "towbar_sessions",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_source_aws_credentials": {
+      "name": "towbar_source_aws_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_payload": {
+          "name": "encrypted_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_key_suffix": {
+          "name": "access_key_suffix",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "towbar_credential_verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unverified'"
+        },
+        "verification_message": {
+          "name": "verification_message",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_aws_credentials_source": {
+          "name": "uq_towbar_aws_credentials_source",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_aws_credentials_workspace": {
+          "name": "idx_towbar_aws_credentials_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_source_aws_credentials_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_source_aws_credentials_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_source_aws_credentials",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_source_aws_credentials_source_id_towbar_sources_id_fk": {
+          "name": "towbar_source_aws_credentials_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_source_aws_credentials",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_source_syncs": {
+      "name": "towbar_source_syncs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_source_sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_digest": {
+          "name": "manifest_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_manifest": {
+          "name": "raw_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_manifest": {
+          "name": "normalized_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciliation": {
+          "name": "reconciliation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issues": {
+          "name": "issues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_source_syncs_source_created": {
+          "name": "idx_towbar_source_syncs_source_created",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_source_syncs_source_id_towbar_sources_id_fk": {
+          "name": "towbar_source_syncs_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_source_syncs",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_source_syncs_requested_by_towbar_users_id_fk": {
+          "name": "towbar_source_syncs_requested_by_towbar_users_id_fk",
+          "tableFrom": "towbar_source_syncs",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["requested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_sources": {
+      "name": "towbar_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_owner": {
+          "name": "repository_owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_name": {
+          "name": "repository_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_source_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "latest_commit_sha": {
+          "name": "latest_commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_manifest_digest": {
+          "name": "latest_manifest_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_successful_sync_id": {
+          "name": "latest_successful_sync_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_sources_repository_branch": {
+          "name": "uq_towbar_sources_repository_branch",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_sources_workspace": {
+          "name": "idx_towbar_sources_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_sources_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_sources_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_sources",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_sources_github_installation_id_towbar_github_installations_id_fk": {
+          "name": "towbar_sources_github_installation_id_towbar_github_installations_id_fk",
+          "tableFrom": "towbar_sources",
+          "tableTo": "towbar_github_installations",
+          "columnsFrom": ["github_installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_ssh_host_keys": {
+      "name": "towbar_ssh_host_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trusted_by": {
+          "name": "trusted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_ssh_host_keys_active": {
+          "name": "uq_towbar_ssh_host_keys_active",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_ssh_host_keys_server_id_towbar_servers_id_fk": {
+          "name": "towbar_ssh_host_keys_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_ssh_host_keys",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_ssh_host_keys_trusted_by_towbar_users_id_fk": {
+          "name": "towbar_ssh_host_keys_trusted_by_towbar_users_id_fk",
+          "tableFrom": "towbar_ssh_host_keys",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["trusted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_system_health_signals": {
+      "name": "towbar_system_health_signals",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "component": {
+          "name": "component",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_system_health_workspace": {
+          "name": "idx_towbar_system_health_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "component",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_system_health_signals_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_system_health_signals_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_system_health_signals",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_users": {
+      "name": "towbar_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_users_email": {
+          "name": "uq_towbar_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_workspace_members": {
+      "name": "towbar_workspace_members",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "towbar_workspace_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_workspace_members_user_id": {
+          "name": "idx_towbar_workspace_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_workspace_members_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_workspace_members_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_workspace_members",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_workspace_members_user_id_towbar_users_id_fk": {
+          "name": "towbar_workspace_members_user_id_towbar_users_id_fk",
+          "tableFrom": "towbar_workspace_members",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pk_towbar_workspace_members": {
+          "name": "pk_towbar_workspace_members",
+          "columns": ["workspace_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_workspaces": {
+      "name": "towbar_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_workspaces_slug": {
+          "name": "uq_towbar_workspaces_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.towbar_check_status": {
+      "name": "towbar_check_status",
+      "schema": "public",
+      "values": ["queued", "running", "succeeded", "failed"]
+    },
+    "public.towbar_credential_verification_status": {
+      "name": "towbar_credential_verification_status",
+      "schema": "public",
+      "values": ["unverified", "verified", "failed"]
+    },
+    "public.towbar_deployable_kind": {
+      "name": "towbar_deployable_kind",
+      "schema": "public",
+      "values": ["app", "image", "postgres", "redis"]
+    },
+    "public.towbar_deployment_environment": {
+      "name": "towbar_deployment_environment",
+      "schema": "public",
+      "values": ["production", "preview"]
+    },
+    "public.towbar_deployment_kind": {
+      "name": "towbar_deployment_kind",
+      "schema": "public",
+      "values": ["deploy", "rollback"]
+    },
+    "public.towbar_deployment_state": {
+      "name": "towbar_deployment_state",
+      "schema": "public",
+      "values": [
+        "queued",
+        "waiting_for_server",
+        "preparing",
+        "validating_credentials",
+        "checking_server",
+        "fetching_source",
+        "resolving_secrets",
+        "transferring",
+        "building",
+        "running_pre_deploy",
+        "starting_candidate",
+        "checking_health",
+        "configuring_routing",
+        "provisioning_tls",
+        "checking_public_endpoint",
+        "switching_traffic",
+        "running_post_deploy",
+        "cleaning_up",
+        "succeeded",
+        "succeeded_with_warnings",
+        "skipped",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.towbar_deployment_step_status": {
+      "name": "towbar_deployment_step_status",
+      "schema": "public",
+      "values": ["waiting", "running", "succeeded", "failed", "skipped"]
+    },
+    "public.towbar_preview_environment_status": {
+      "name": "towbar_preview_environment_status",
+      "schema": "public",
+      "values": [
+        "building",
+        "healthy",
+        "failed",
+        "deleting",
+        "cleanup_failed",
+        "deleted"
+      ]
+    },
+    "public.towbar_preview_report_delivery_status": {
+      "name": "towbar_preview_report_delivery_status",
+      "schema": "public",
+      "values": ["pending", "published", "failed"]
+    },
+    "public.towbar_release_status": {
+      "name": "towbar_release_status",
+      "schema": "public",
+      "values": ["current", "previous", "superseded"]
+    },
+    "public.towbar_resource_operation_state": {
+      "name": "towbar_resource_operation_state",
+      "schema": "public",
+      "values": ["queued", "running", "succeeded", "failed"]
+    },
+    "public.towbar_resource_operation_type": {
+      "name": "towbar_resource_operation_type",
+      "schema": "public",
+      "values": [
+        "backup",
+        "capture_logs",
+        "cleanup_orphans",
+        "restart",
+        "restore",
+        "start",
+        "stop"
+      ]
+    },
+    "public.towbar_runtime_desired_state": {
+      "name": "towbar_runtime_desired_state",
+      "schema": "public",
+      "values": ["running", "stopped"]
+    },
+    "public.towbar_runtime_drift_state": {
+      "name": "towbar_runtime_drift_state",
+      "schema": "public",
+      "values": ["drifted", "in_sync", "unknown"]
+    },
+    "public.towbar_runtime_health_state": {
+      "name": "towbar_runtime_health_state",
+      "schema": "public",
+      "values": ["healthy", "none", "starting", "unhealthy", "unknown"]
+    },
+    "public.towbar_runtime_observed_state": {
+      "name": "towbar_runtime_observed_state",
+      "schema": "public",
+      "values": ["missing", "running", "stopped", "unknown"]
+    },
+    "public.towbar_source_status": {
+      "name": "towbar_source_status",
+      "schema": "public",
+      "values": ["active", "archived"]
+    },
+    "public.towbar_source_sync_status": {
+      "name": "towbar_source_sync_status",
+      "schema": "public",
+      "values": ["queued", "running", "succeeded", "failed"]
+    },
+    "public.towbar_workspace_role": {
+      "name": "towbar_workspace_role",
+      "schema": "public",
+      "values": ["owner", "member"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/towbar-database/drizzle/meta/_journal.json
+++ b/packages/towbar-database/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1787864031826,
       "tag": "0026_ancient_trish_tilby",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1787895424959,
+      "tag": "0027_robust_nextwave",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/towbar-database/src/schema/index.ts
+++ b/packages/towbar-database/src/schema/index.ts
@@ -85,6 +85,10 @@ export const previewEnvironmentStatusEnum = pgEnum(
   "towbar_preview_environment_status",
   ["building", "healthy", "failed", "deleting", "cleanup_failed", "deleted"],
 );
+export const previewReportDeliveryStatusEnum = pgEnum(
+  "towbar_preview_report_delivery_status",
+  ["pending", "published", "failed"],
+);
 export const resourceOperationTypeEnum = pgEnum(
   "towbar_resource_operation_type",
   [
@@ -563,6 +567,13 @@ export const previewEnvironments = pgTable(
       .default("building")
       .notNull(),
     errorMessage: varchar("error_message", { length: 1_000 }),
+    cleanupAttempts: integer("cleanup_attempts").default(0).notNull(),
+    lastCleanupAttemptAt: timestamp("last_cleanup_attempt_at", {
+      withTimezone: true,
+    }),
+    nextCleanupAttemptAt: timestamp("next_cleanup_attempt_at", {
+      withTimezone: true,
+    }),
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true })
@@ -586,6 +597,73 @@ export const previewEnvironments = pgTable(
     index("idx_towbar_preview_environment_expires").on(
       table.status,
       table.expiresAt,
+    ),
+  ],
+);
+
+export const previewPullRequestReports = pgTable(
+  "towbar_preview_pull_request_reports",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    workspaceId: uuid("workspace_id")
+      .notNull()
+      .references(() => workspaces.id, { onDelete: "cascade" }),
+    sourceId: uuid("source_id")
+      .notNull()
+      .references(() => sources.id, { onDelete: "cascade" }),
+    pullRequestNumber: integer("pull_request_number").notNull(),
+    branch: varchar("branch", { length: 255 }).notNull(),
+    latestCommitSha: varchar("latest_commit_sha", { length: 64 }).notNull(),
+    skippedApps: jsonb("skipped_apps")
+      .$type<Array<{ appId: string; appName: string; reason: string }>>()
+      .default([])
+      .notNull(),
+    commentDeliveryStatus: previewReportDeliveryStatusEnum(
+      "comment_delivery_status",
+    )
+      .default("pending")
+      .notNull(),
+    commentDeliveryError: varchar("comment_delivery_error", { length: 1_000 }),
+    commentLastAttemptedAt: timestamp("comment_last_attempted_at", {
+      withTimezone: true,
+    }),
+    commentPublishedAt: timestamp("comment_published_at", {
+      withTimezone: true,
+    }),
+    deploymentDeliveryStatus: previewReportDeliveryStatusEnum(
+      "deployment_delivery_status",
+    )
+      .default("pending")
+      .notNull(),
+    deploymentDeliveryError: varchar("deployment_delivery_error", {
+      length: 1_000,
+    }),
+    deploymentLastAttemptedAt: timestamp("deployment_last_attempted_at", {
+      withTimezone: true,
+    }),
+    deploymentPublishedAt: timestamp("deployment_published_at", {
+      withTimezone: true,
+    }),
+    closedAt: timestamp("closed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("uq_towbar_preview_report_source_pr").on(
+      table.sourceId,
+      table.pullRequestNumber,
+    ),
+    index("idx_towbar_preview_report_workspace_comment").on(
+      table.workspaceId,
+      table.commentDeliveryStatus,
+    ),
+    index("idx_towbar_preview_report_workspace_deployment").on(
+      table.workspaceId,
+      table.deploymentDeliveryStatus,
     ),
   ],
 );

--- a/packages/towbar-web-client/src/types.ts
+++ b/packages/towbar-web-client/src/types.ts
@@ -330,6 +330,7 @@ export type PreviewEnvironment = {
   appId: string;
   appName: string;
   branch: string;
+  cleanupAttempts: number;
   createdAt: string;
   errorMessage: string | null;
   expiresAt: string;
@@ -338,6 +339,7 @@ export type PreviewEnvironment = {
   id: string;
   latestCommitSha: string;
   latestDeploymentId: string | null;
+  nextCleanupAttemptAt: string | null;
   pullRequestNumber: number;
   pullRequestUrl: string;
   sourceId: string;
@@ -386,6 +388,12 @@ export type GitHubConnection = {
     | { status: "unavailable" };
   suspendedAt: string | null;
   updatedAt: string;
+};
+
+export type PreviewReportingHealth = {
+  failedCount: number;
+  lastError: string | null;
+  lastFailedAt: string | null;
 };
 
 export type GitHubRepository = {


### PR DESCRIPTION
## Summary

- publish path-aware skipped apps in the stable Preview PR status comment
- persist GitHub deployment-status and comment delivery failures, with an operator retry in GitHub settings
- automatically retry failed Preview cleanup with bounded backoff and expose cleanup errors and retry controls in context
- reconcile open pull requests so missed close/merge webhooks still converge safely

## Verification

- `pnpm verify`
- local fixture QA: GitHub reporting retry clears the warning after success
- local fixture QA: failed Preview cleanup shows its reason and scheduled retry; manual retry enters Deleting