### PR TITLE
Prevent duplicate Preview PR comments

### DIFF
--- a/apps/towbar-api/src/areas/github/client.test.ts
+++ b/apps/towbar-api/src/areas/github/client.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { classifyGitHubPullRequestComments } from "./client.js";
+
+const marker = "<!-- towbar:preview-status:source-id:42 -->";
+
+void test("keeps the oldest matching app comment and identifies duplicates", () => {
+  const result = classifyGitHubPullRequestComments({
+    appId: "1001",
+    comments: [
+      {
+        body: marker,
+        id: 30,
+        performed_via_github_app: { id: 1001 },
+      },
+      {
+        body: marker,
+        id: 10,
+        performed_via_github_app: { id: 1001 },
+      },
+      {
+        body: marker,
+        id: 5,
+        performed_via_github_app: { id: 2002 },
+      },
+      {
+        body: "<!-- towbar:preview-status:source-id:43 -->",
+        id: 3,
+        performed_via_github_app: { id: 1001 },
+      },
+    ],
+    marker,
+  });
+
+  assert.equal(result.canonical?.id, 10);
+  assert.deepEqual(
+    result.duplicates.map((comment) => comment.id),
+    [30],
+  );
+});
+
+void test("does not adopt a matching marker from another GitHub app", () => {
+  const result = classifyGitHubPullRequestComments({
+    appId: "1001",
+    comments: [
+      {
+        body: marker,
+        id: 10,
+        performed_via_github_app: { id: 2002 },
+      },
+    ],
+    marker,
+  });
+
+  assert.equal(result.canonical, undefined);
+  assert.deepEqual(result.duplicates, []);
+});

--- a/apps/towbar-api/src/areas/github/client.ts
+++ b/apps/towbar-api/src/areas/github/client.ts
@@ -82,6 +82,8 @@ const issueCommentSchema = z.object({
 });
 const issueCommentListSchema = z.array(issueCommentSchema);
 
+type GitHubIssueComment = z.infer<typeof issueCommentSchema>;
+
 const pullRequestFileListSchema = z.array(
   z.object({
     filename: z.string().min(1).max(4_096),
@@ -427,35 +429,62 @@ export async function upsertGitHubPullRequestComment(input: {
   const token = await createInstallationToken(input.installationId);
   const repository = `${encodeURIComponent(input.repositoryOwner)}/${encodeURIComponent(input.repositoryName)}`;
   const appId = requireGitHubEnv().appId;
-  let existing: z.infer<typeof issueCommentSchema> | undefined;
+  const comments: GitHubIssueComment[] = [];
   for (let page = 1; page <= 10; page += 1) {
-    const comments = issueCommentListSchema.parse(
+    const pageComments = issueCommentListSchema.parse(
       await githubRequest(
         `/repos/${repository}/issues/${input.pullRequestNumber}/comments?per_page=100&page=${page}`,
         { token },
       ),
     );
-    existing = comments.find(
+    comments.push(...pageComments);
+    if (pageComments.length < 100) break;
+  }
+  const { canonical, duplicates } = classifyGitHubPullRequestComments({
+    appId,
+    comments,
+    marker: input.marker,
+  });
+  let comment = canonical;
+  if (!comment || comment.body !== input.body) {
+    comment = issueCommentSchema.parse(
+      await githubRequest(
+        comment
+          ? `/repos/${repository}/issues/comments/${comment.id}`
+          : `/repos/${repository}/issues/${input.pullRequestNumber}/comments`,
+        {
+          body: { body: input.body },
+          method: comment ? "PATCH" : "POST",
+          token,
+        },
+      ),
+    );
+  }
+  for (const duplicate of duplicates) {
+    await githubRequest(
+      `/repos/${repository}/issues/comments/${duplicate.id}`,
+      { method: "DELETE", token },
+    );
+  }
+  return String(comment.id);
+}
+
+export function classifyGitHubPullRequestComments(input: {
+  appId: string;
+  comments: GitHubIssueComment[];
+  marker: string;
+}) {
+  const matches = input.comments
+    .filter(
       (comment) =>
         comment.body?.includes(input.marker) === true &&
-        String(comment.performed_via_github_app?.id) === appId,
-    );
-    if (existing || comments.length < 100) break;
-  }
-  if (existing?.body === input.body) return String(existing.id);
-  const comment = issueCommentSchema.parse(
-    await githubRequest(
-      existing
-        ? `/repos/${repository}/issues/comments/${existing.id}`
-        : `/repos/${repository}/issues/${input.pullRequestNumber}/comments`,
-      {
-        body: { body: input.body },
-        method: existing ? "PATCH" : "POST",
-        token,
-      },
-    ),
-  );
-  return String(comment.id);
+        String(comment.performed_via_github_app?.id) === input.appId,
+    )
+    .sort((left, right) => left.id - right.id);
+  return {
+    canonical: matches[0],
+    duplicates: matches.slice(1),
+  };
 }
 
 async function createGitHubAppJwt() {

--- a/apps/towbar-api/src/areas/previews/pr-comment.ts
+++ b/apps/towbar-api/src/areas/previews/pr-comment.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, sql } from "drizzle-orm";
 
 import {
   apps,
@@ -132,18 +132,25 @@ export async function publishPreviewPullRequestComment(input: {
   const marker = previewPullRequestCommentMarker(input);
   await markPreviewReportDeliveryAttempt(input, "comment");
   try {
-    const comment = await upsertGitHubPullRequestComment({
-      body: renderPreviewPullRequestComment({
-        appBaseUrl: getEnv().TOWBAR_APP_BASE_URL,
-        entries,
+    const comment = await database.transaction(async (transaction) => {
+      // GitHub comment creation has no idempotency key, so keep discovery and
+      // creation inside one cross-process critical section.
+      await transaction.execute(
+        sql`select pg_advisory_xact_lock(hashtextextended(${marker}, 0))`,
+      );
+      return await upsertGitHubPullRequestComment({
+        body: renderPreviewPullRequestComment({
+          appBaseUrl: getEnv().TOWBAR_APP_BASE_URL,
+          entries,
+          marker,
+          sourceId: input.sourceId,
+        }),
+        installationId: source.installationId,
         marker,
-        sourceId: input.sourceId,
-      }),
-      installationId: source.installationId,
-      marker,
-      pullRequestNumber: input.pullRequestNumber,
-      repositoryName: source.repositoryName,
-      repositoryOwner: source.repositoryOwner,
+        pullRequestNumber: input.pullRequestNumber,
+        repositoryName: source.repositoryName,
+        repositoryOwner: source.repositoryOwner,
+      });
     });
     await markPreviewReportDeliverySucceeded(input, "comment");
     return comment;


### PR DESCRIPTION
## Root cause

Concurrent Preview state publishers could both list the PR comments before either publisher created the stable Towbar comment. GitHub comment creation has no idempotency key, so both requests created a comment with the same hidden marker.

## Fix

- serialize comment discovery and creation per Source/PR with a PostgreSQL advisory transaction lock
- keep the oldest matching Towbar Connector comment as canonical
- delete any additional matching comments during the next status update
- keep comments from other GitHub Apps out of the deduplication scope

## Verification

- confirmed duplicate comments on monorepo PRs shared the same marker and exact creation timestamp
- added regression tests for canonical selection and GitHub App ownership
- `pnpm verify`