### PR TITLE
TW-13 Add deployment plans and GitHub checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to Towbar are documented in this file. This project follows
 
 ## [Unreleased]
 
+### Added
+
+- Immutable, side-effect-free deployment plans compare a candidate commit with
+  active Source state, classify create/update/archive/restore/no-op changes,
+  and validate domains, servers, capacity, secret references, and operation
+  conflicts without resolving secret values.
+- Deployment-relevant pull requests publish one idempotent GitHub Check linked
+  to the full Towbar plan; unmatched input patterns omit irrelevant rows.
+
 ## [1.1.1] - 2026-08-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,11 +17,15 @@ truth and runs deployments through durable Temporal workflows.
   Resources, domains, and deployment policy.
 - Builds run on the target host, without requiring a container registry.
 - AWS Secrets Manager values are resolved just in time and stay out of Git.
+- Immutable deployment plans compare a candidate commit with active Source
+  state before any mutation, including explicit no-op rows and validation.
 - SSH host-key pinning, server preparation, queued deployments, control-plane
   diagnostics, and runtime capacity checks are built in.
 - Opt-in pull request Previews use stable URLs, isolated secrets, one live PR
   status comment, and automatic cleanup without changing production health or
   release history.
+- Deployment-relevant pull requests publish one idempotent GitHub Check linked
+  to the complete plan in Towbar.
 - PostgreSQL and Temporal provide persistent state and durable execution.
 
 ## Quick start

--- a/apps/towbar-api/README.md
+++ b/apps/towbar-api/README.md
@@ -61,6 +61,14 @@ the pull request, and keeps production runtime health unchanged. Pull request
 merge or closure, retargeting, TTL expiry, manifest disablement, and owner
 deletion converge on the same cleanup admission path.
 
+The same eligible pull request reconciliation creates an immutable deployment
+plan before Preview admission. Planning reads the PR head manifest, current
+Source inventory, repository input digests, server observations, credential
+metadata, and active operation state without resolving secret values or
+enqueueing work. The API publishes one completed GitHub Check per Source and
+head commit and links it to the full plan. Repeated deliveries update the
+existing Check; planning failures do not block Preview reconciliation.
+
 AWS credentials and Servers are Source-scoped. Server identity is
 `(source_id, canonical_ip)`, allowing independent Sources to target the same IP
 without sharing configuration or trust records. Deleting a Source permanently

--- a/apps/towbar-api/src/areas/aws/service.ts
+++ b/apps/towbar-api/src/areas/aws/service.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import {
+  DescribeSecretCommand,
   GetSecretValueCommand,
   PutSecretValueCommand,
   SecretsManagerClient,
@@ -174,6 +175,40 @@ export async function resolveAwsSecret(input: {
   const { client, reference } = await createSecretsManagerContext(input);
   try {
     return (await readAwsSecretValue(client, reference.reference)).value;
+  } finally {
+    client.destroy();
+  }
+}
+
+export async function inspectAwsSecretReferences(input: {
+  secretReferences: string[];
+  sourceId: string;
+  workspaceId: string;
+}) {
+  const credential = await getDecryptedAwsCredential(input);
+  const client = new SecretsManagerClient({
+    credentials: createAwsSdkCredentials(credential.payload),
+    region: credential.region,
+  });
+  try {
+    return await Promise.all(
+      [...new Set(input.secretReferences)]
+        .sort((left, right) => left.localeCompare(right))
+        .map(async (secretReference) => {
+          const reference = parseSecretReference(secretReference);
+          if (reference.provider !== "aws") {
+            return { available: false, reference: secretReference };
+          }
+          try {
+            await client.send(
+              new DescribeSecretCommand({ SecretId: reference.reference }),
+            );
+            return { available: true, reference: secretReference };
+          } catch {
+            return { available: false, reference: secretReference };
+          }
+        }),
+    );
   } finally {
     client.destroy();
   }

--- a/apps/towbar-api/src/areas/github/client.test.ts
+++ b/apps/towbar-api/src/areas/github/client.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { classifyGitHubPullRequestComments } from "./client.js";
+import {
+  classifyGitHubCheckRuns,
+  classifyGitHubPullRequestComments,
+} from "./client.js";
 
 const marker = "<!-- towbar:preview-status:source-id:42 -->";
 
@@ -55,4 +58,28 @@ void test("does not adopt a matching marker from another GitHub app", () => {
 
   assert.equal(result.canonical, undefined);
   assert.deepEqual(result.duplicates, []);
+});
+
+void test("reuses the Check Run with the matching immutable plan ID", () => {
+  const result = classifyGitHubCheckRuns({
+    checkRuns: [
+      { external_id: "old-plan", id: 10, name: "Towbar deployment plan" },
+      { external_id: "current-plan", id: 30, name: "Towbar deployment plan" },
+    ],
+    externalId: "current-plan",
+  });
+
+  assert.equal(result.canonical?.id, 30);
+});
+
+void test("adopts the oldest Check Run for the same commit and name", () => {
+  const result = classifyGitHubCheckRuns({
+    checkRuns: [
+      { external_id: "other-plan", id: 30, name: "Towbar deployment plan" },
+      { external_id: null, id: 10, name: "Towbar deployment plan" },
+    ],
+    externalId: "current-plan",
+  });
+
+  assert.equal(result.canonical?.id, 10);
 });

--- a/apps/towbar-api/src/areas/github/client.ts
+++ b/apps/towbar-api/src/areas/github/client.ts
@@ -71,6 +71,14 @@ const gitTreeSchema = z.object({
 });
 
 const githubDeploymentSchema = z.object({ id: z.number().int().positive() });
+const githubCheckRunSchema = z.object({
+  external_id: z.string().nullable(),
+  id: z.number().int().positive(),
+  name: z.string(),
+});
+const githubCheckRunListSchema = z.object({
+  check_runs: z.array(githubCheckRunSchema),
+});
 
 const issueCommentSchema = z.object({
   body: z.string().nullable(),
@@ -83,6 +91,7 @@ const issueCommentSchema = z.object({
 const issueCommentListSchema = z.array(issueCommentSchema);
 
 type GitHubIssueComment = z.infer<typeof issueCommentSchema>;
+type GitHubCheckRun = z.infer<typeof githubCheckRunSchema>;
 
 const pullRequestFileListSchema = z.array(
   z.object({
@@ -196,10 +205,21 @@ export async function fetchGitHubSourceSnapshot(input: {
   }
   const reference = referenceSchema.parse(referenceValue);
   const commitSha = reference.object.sha;
+  return await fetchGitHubManifestSnapshot({ ...input, commitSha });
+}
+
+export async function fetchGitHubManifestSnapshot(input: {
+  commitSha: string;
+  installationId: string;
+  repositoryName: string;
+  repositoryOwner: string;
+}) {
+  const token = await createInstallationToken(input.installationId);
+  const repository = `${encodeURIComponent(input.repositoryOwner)}/${encodeURIComponent(input.repositoryName)}`;
   let contentValue: unknown;
   try {
     contentValue = await githubRequest(
-      `/repos/${repository}/contents/.towbar/deployment.yml?ref=${commitSha}`,
+      `/repos/${repository}/contents/.towbar/deployment.yml?ref=${input.commitSha}`,
       { token },
     );
   } catch (error) {
@@ -207,7 +227,7 @@ export async function fetchGitHubSourceSnapshot(input: {
       throw new HttpError(
         422,
         "MANIFEST_NOT_FOUND",
-        `Add .towbar/deployment.yml to branch '${input.branch}' in ${input.repositoryOwner}/${input.repositoryName}, then sync again.`,
+        `Add .towbar/deployment.yml to commit '${input.commitSha.slice(0, 12)}' in ${input.repositoryOwner}/${input.repositoryName}.`,
       );
     }
     throw error;
@@ -221,7 +241,7 @@ export async function fetchGitHubSourceSnapshot(input: {
     );
   }
   return {
-    commitSha,
+    commitSha: input.commitSha,
     manifestSource: Buffer.from(
       content.content.replaceAll("\n", ""),
       "base64",
@@ -416,6 +436,66 @@ export async function updateGitHubPreviewDeployment(input: {
       token,
     },
   );
+}
+
+export async function upsertGitHubCheckRun(input: {
+  conclusion: "failure" | "neutral" | "success";
+  detailsUrl: string;
+  externalId: string;
+  headSha: string;
+  installationId: string;
+  name: string;
+  output: { summary: string; text?: string; title: string };
+  repositoryName: string;
+  repositoryOwner: string;
+}) {
+  const token = await createInstallationToken(input.installationId);
+  const repository = `${encodeURIComponent(input.repositoryOwner)}/${encodeURIComponent(input.repositoryName)}`;
+  const checks = githubCheckRunListSchema.parse(
+    await githubRequest(
+      `/repos/${repository}/commits/${encodeURIComponent(input.headSha)}/check-runs?check_name=${encodeURIComponent(input.name)}&filter=all&per_page=100`,
+      { token },
+    ),
+  ).check_runs;
+  const canonical = classifyGitHubCheckRuns({
+    checkRuns: checks,
+    externalId: input.externalId,
+  }).canonical;
+  const body = {
+    conclusion: input.conclusion,
+    details_url: input.detailsUrl,
+    external_id: input.externalId,
+    name: input.name,
+    output: input.output,
+    status: "completed",
+  };
+  const check = githubCheckRunSchema.parse(
+    await githubRequest(
+      canonical
+        ? `/repos/${repository}/check-runs/${canonical.id}`
+        : `/repos/${repository}/check-runs`,
+      {
+        body: canonical ? body : { ...body, head_sha: input.headSha },
+        method: canonical ? "PATCH" : "POST",
+        token,
+      },
+    ),
+  );
+  return String(check.id);
+}
+
+export function classifyGitHubCheckRuns(input: {
+  checkRuns: GitHubCheckRun[];
+  externalId: string;
+}) {
+  const ordered = [...input.checkRuns].sort(
+    (left, right) => left.id - right.id,
+  );
+  return {
+    canonical:
+      ordered.find((check) => check.external_id === input.externalId) ??
+      ordered[0],
+  };
 }
 
 export async function upsertGitHubPullRequestComment(input: {

--- a/apps/towbar-api/src/areas/github/permissions.test.ts
+++ b/apps/towbar-api/src/areas/github/permissions.test.ts
@@ -6,13 +6,16 @@ import { githubPermissionReadiness } from "./permissions.js";
 void test("reports Preview readiness only with every required permission", () => {
   assert.deepEqual(
     githubPermissionReadiness({
+      checks: "write",
       contents: "read",
       deployments: "write",
       pull_requests: "write",
     }),
     {
+      checks: "write",
       contents: "read",
       deployments: "write",
+      planning: "ready",
       preview: "ready",
       pullRequests: "write",
     },
@@ -27,6 +30,10 @@ void test("reports Preview readiness only with every required permission", () =>
   );
   assert.equal(
     githubPermissionReadiness({ contents: "read" }).preview,
+    "missing",
+  );
+  assert.equal(
+    githubPermissionReadiness({ checks: "read", contents: "read" }).planning,
     "missing",
   );
 });

--- a/apps/towbar-api/src/areas/github/permissions.ts
+++ b/apps/towbar-api/src/areas/github/permissions.ts
@@ -1,8 +1,10 @@
 export type GitHubPermissionLevel = "none" | "read" | "write";
 
 export type GitHubPermissionReadiness = {
+  checks: GitHubPermissionLevel;
   contents: GitHubPermissionLevel;
   deployments: GitHubPermissionLevel;
+  planning: "missing" | "ready";
   preview: "missing" | "ready";
   pullRequests: GitHubPermissionLevel;
 };
@@ -10,12 +12,15 @@ export type GitHubPermissionReadiness = {
 export function githubPermissionReadiness(
   permissions: Record<string, string>,
 ): GitHubPermissionReadiness {
+  const checks = normalizePermission(permissions.checks);
   const contents = normalizePermission(permissions.contents);
   const deployments = normalizePermission(permissions.deployments);
   const pullRequests = normalizePermission(permissions.pull_requests);
   return {
+    checks,
     contents,
     deployments,
+    planning: canRead(contents) && checks === "write" ? "ready" : "missing",
     preview:
       canRead(contents) && deployments === "write" && pullRequests === "write"
         ? "ready"

--- a/apps/towbar-api/src/areas/plans/github-check.test.ts
+++ b/apps/towbar-api/src/areas/plans/github-check.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { renderDeploymentPlanGitHubCheck } from "./github-check.js";
+
+void test("renders a no-op pull request as one neutral GitHub Check", () => {
+  const rendered = renderDeploymentPlanGitHubCheck({
+    plan: {
+      checks: [],
+      items: [],
+      status: "ready",
+      summary: { archive: 0, create: 0, no_op: 0, restore: 0, update: 0 },
+    },
+  });
+  assert.equal(rendered.conclusion, "neutral");
+  assert.match(rendered.output.summary, /No deployment changes/u);
+  assert.match(rendered.output.text, /No deployment-relevant changes/u);
+});
+
+void test("renders blocking checks without leaking values", () => {
+  const rendered = renderDeploymentPlanGitHubCheck({
+    plan: {
+      checks: [
+        {
+          code: "secret_bindings_unavailable",
+          message: "Configure Source AWS credentials",
+          references: ["aws:source/build"],
+          status: "failed",
+        },
+      ],
+      items: [],
+      status: "blocked",
+      summary: { archive: 0, create: 0, no_op: 0, restore: 0, update: 0 },
+    },
+  });
+  assert.equal(rendered.conclusion, "failure");
+  assert.match(rendered.output.text, /Configure Source AWS credentials/u);
+  assert.equal(rendered.output.text.includes("aws:source/build"), false);
+});

--- a/apps/towbar-api/src/areas/plans/github-check.ts
+++ b/apps/towbar-api/src/areas/plans/github-check.ts
@@ -1,0 +1,189 @@
+import { eq, sql } from "drizzle-orm";
+
+import {
+  deploymentPlanGithubChecks,
+  deploymentPlans,
+  githubInstallations,
+  sources,
+} from "@workspace/towbar-database/schema";
+
+import { getEnv } from "../../env.js";
+import { notFound } from "../../http/errors.js";
+import { getTowbarDatabase } from "../../infrastructure/database.js";
+import { upsertGitHubCheckRun } from "../github/client.js";
+
+import type { DeploymentPlan } from "@workspace/towbar-core";
+
+export const deploymentPlanCheckName = "Towbar deployment plan";
+const maximumReportedRows = 50;
+
+export function renderDeploymentPlanGitHubCheck(input: {
+  plan: DeploymentPlan;
+}) {
+  const changed = input.plan.items.filter((item) => item.action !== "no_op");
+  const summary =
+    input.plan.status === "blocked"
+      ? `${input.plan.checks.filter((check) => check.status === "failed").length} blocking validation issue(s) found.`
+      : changed.length === 0
+        ? "No deployment changes are required."
+        : `${changed.length} deployment change(s) are ready for review.`;
+  const itemRows = input.plan.items
+    .slice(0, maximumReportedRows)
+    .map(
+      (item) =>
+        `| ${label(item.action)} | ${label(item.entityKind)} | ${escapeCell(item.name)} | ${escapeCell(item.reasons.join("; "))} |`,
+    );
+  const checkRows = input.plan.checks
+    .slice(0, maximumReportedRows)
+    .map(
+      (check) =>
+        `| ${check.status === "passed" ? "Pass" : check.status === "warning" ? "Warning" : "Block"} | ${escapeCell(check.message)} |`,
+    );
+  return {
+    conclusion:
+      input.plan.status === "blocked"
+        ? ("failure" as const)
+        : input.plan.items.length === 0
+          ? ("neutral" as const)
+          : ("success" as const),
+    output: {
+      summary,
+      text: [
+        "## Planned changes",
+        ...(itemRows.length > 0
+          ? [
+              "| Action | Kind | Name | Reason |",
+              "| --- | --- | --- | --- |",
+              ...itemRows,
+              ...(input.plan.items.length > maximumReportedRows
+                ? [
+                    `| … | … | ${input.plan.items.length - maximumReportedRows} more | Open the Towbar plan for the complete comparison. |`,
+                  ]
+                : []),
+            ]
+          : ["No deployment-relevant changes matched this pull request."]),
+        "",
+        "## Validation",
+        ...(checkRows.length > 0
+          ? [
+              "| Result | Check |",
+              "| --- | --- |",
+              ...checkRows,
+              ...(input.plan.checks.length > maximumReportedRows
+                ? [
+                    `| … | ${input.plan.checks.length - maximumReportedRows} more validation results are available in Towbar. |`,
+                  ]
+                : []),
+            ]
+          : ["No additional validation checks were required."]),
+      ].join("\n"),
+      title:
+        input.plan.status === "blocked"
+          ? "Deployment plan blocked"
+          : "Deployment plan ready",
+    },
+  };
+}
+
+export async function publishDeploymentPlanGitHubCheck(planId: string) {
+  const database = getTowbarDatabase();
+  try {
+    const result = await database.transaction(async (transaction) => {
+      const [row] = await transaction
+        .select({
+          installationId: githubInstallations.installationId,
+          plan: deploymentPlans.plan,
+          planId: deploymentPlans.id,
+          repositoryName: sources.repositoryName,
+          repositoryOwner: sources.repositoryOwner,
+          sourceId: sources.id,
+          targetCommitSha: deploymentPlans.targetCommitSha,
+        })
+        .from(deploymentPlans)
+        .innerJoin(sources, eq(sources.id, deploymentPlans.sourceId))
+        .innerJoin(
+          githubInstallations,
+          eq(githubInstallations.id, sources.githubInstallationId),
+        )
+        .where(eq(deploymentPlans.id, planId))
+        .limit(1);
+      if (!row) throw notFound("Deployment plan");
+      await transaction.execute(
+        sql`select pg_advisory_xact_lock(hashtextextended(${`deployment-plan-check:${row.sourceId}:${row.targetCommitSha}`}, 0))`,
+      );
+      const rendered = renderDeploymentPlanGitHubCheck({ plan: row.plan });
+      const checkRunId = await upsertGitHubCheckRun({
+        ...rendered,
+        detailsUrl: `${getEnv().TOWBAR_APP_BASE_URL}/sources/${row.sourceId}/plans/${row.planId}`,
+        externalId: row.planId,
+        headSha: row.targetCommitSha,
+        installationId: row.installationId,
+        name: deploymentPlanCheckName,
+        repositoryName: row.repositoryName,
+        repositoryOwner: row.repositoryOwner,
+      });
+      const now = new Date();
+      await transaction
+        .insert(deploymentPlanGithubChecks)
+        .values({
+          checkRunId,
+          lastAttemptedAt: now,
+          planId,
+          publishedAt: now,
+          status: "published",
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          set: {
+            checkRunId,
+            errorMessage: null,
+            lastAttemptedAt: now,
+            publishedAt: now,
+            status: "published",
+            updatedAt: now,
+          },
+          target: deploymentPlanGithubChecks.planId,
+        });
+      return { checkRunId };
+    });
+    return result;
+  } catch (error) {
+    const now = new Date();
+    await database
+      .insert(deploymentPlanGithubChecks)
+      .values({
+        errorMessage:
+          error instanceof Error
+            ? error.message
+            : "GitHub Check delivery failed",
+        lastAttemptedAt: now,
+        planId,
+        status: "failed",
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        set: {
+          errorMessage:
+            error instanceof Error
+              ? error.message
+              : "GitHub Check delivery failed",
+          lastAttemptedAt: now,
+          status: "failed",
+          updatedAt: now,
+        },
+        target: deploymentPlanGithubChecks.planId,
+      });
+    throw error;
+  }
+}
+
+function label(value: string) {
+  return value
+    .replaceAll("_", " ")
+    .replace(/^./u, (character) => character.toUpperCase());
+}
+
+function escapeCell(value: string) {
+  const normalized = value.replaceAll("|", "\\|").replaceAll("\n", " ");
+  return normalized.length > 500 ? `${normalized.slice(0, 497)}…` : normalized;
+}

--- a/apps/towbar-api/src/areas/plans/service.ts
+++ b/apps/towbar-api/src/areas/plans/service.ts
@@ -25,10 +25,7 @@ import {
 import { conflict, notFound } from "../../http/errors.js";
 import { getTowbarDatabase } from "../../infrastructure/database.js";
 import { inspectAwsSecretReferences } from "../aws/service.js";
-import {
-  fetchGitHubManifestSnapshot,
-  fetchGitHubSourceSnapshot,
-} from "../github/client.js";
+import { fetchGitHubManifestSnapshot } from "../github/client.js";
 import { listSourceCapacity } from "../servers/capacity.js";
 import {
   calculateDesiredDeploymentDigests,
@@ -65,24 +62,6 @@ const publicPlanSelection = {
   trigger: deploymentPlans.trigger,
 };
 
-export async function createManualDeploymentPlan(input: {
-  requestedBy: string;
-  sourceId: string;
-  workspaceId: string;
-}) {
-  const source = await getPlanningSource(input.sourceId, input.workspaceId);
-  const snapshot = await fetchGitHubSourceSnapshot(source);
-  return await createAndPersistDeploymentPlan({
-    branch: source.branch,
-    candidate: snapshot,
-    pullRequestNumber: null,
-    repositoryChanges: undefined,
-    requestedBy: input.requestedBy,
-    source,
-    trigger: "manual",
-  });
-}
-
 export async function createPullRequestDeploymentPlan(input: {
   pullRequest: GitHubPullRequest;
   repositoryChanges: RepositoryChangedPaths;
@@ -105,21 +84,17 @@ export async function createPullRequestDeploymentPlan(input: {
       }),
       plan: buildBlockedDeploymentPlan(planChecksFromCandidateError(error)),
       pullRequestNumber: input.pullRequest.number,
-      requestedBy: null,
       source,
       targetCommitSha: input.pullRequest.headSha,
       targetManifestDigest: null,
-      trigger: "pull_request",
     });
   }
-  return await createAndPersistDeploymentPlan({
+  return await createAndPersistPullRequestDeploymentPlan({
     branch: input.pullRequest.headBranch,
     candidate,
     pullRequestNumber: input.pullRequest.number,
     repositoryChanges: input.repositoryChanges,
-    requestedBy: null,
     source,
-    trigger: "pull_request",
   });
 }
 
@@ -138,7 +113,12 @@ export async function listDeploymentPlans(input: {
       deploymentPlanGithubChecks,
       eq(deploymentPlanGithubChecks.planId, deploymentPlans.id),
     )
-    .where(eq(deploymentPlans.sourceId, input.sourceId))
+    .where(
+      and(
+        eq(deploymentPlans.sourceId, input.sourceId),
+        eq(deploymentPlans.trigger, "pull_request"),
+      ),
+    )
     .orderBy(desc(deploymentPlans.createdAt), desc(deploymentPlans.id));
 }
 
@@ -171,14 +151,12 @@ export async function getDeploymentPlan(input: {
   return plan;
 }
 
-async function createAndPersistDeploymentPlan(input: {
+async function createAndPersistPullRequestDeploymentPlan(input: {
   branch: string;
   candidate: { commitSha: string; manifestSource: string };
-  pullRequestNumber: number | null;
-  repositoryChanges: RepositoryChangedPaths | undefined;
-  requestedBy: string | null;
+  pullRequestNumber: number;
+  repositoryChanges: RepositoryChangedPaths;
   source: PlanningSource;
-  trigger: "manual" | "pull_request";
 }) {
   const candidateDigest = digestValue(input.candidate.manifestSource);
   let targetManifestDigest: string | null = null;
@@ -215,7 +193,7 @@ async function createAndPersistDeploymentPlan(input: {
       currentResources: current.resources,
       currentServers: current.servers,
       desired: parsed.manifest,
-      mode: input.trigger === "manual" ? "full" : "pull_request",
+      mode: "pull_request",
       repositoryChanges: input.repositoryChanges,
       targetDeploymentDigests: new Map(
         [...targetDigests].map(([id, digest]) => [id, digest.deploymentDigest]),
@@ -230,11 +208,9 @@ async function createAndPersistDeploymentPlan(input: {
     candidateDigest,
     plan,
     pullRequestNumber: input.pullRequestNumber,
-    requestedBy: input.requestedBy,
     source: input.source,
     targetCommitSha: input.candidate.commitSha,
     targetManifestDigest,
-    trigger: input.trigger,
   });
 }
 
@@ -242,12 +218,10 @@ async function persistDeploymentPlan(input: {
   branch: string;
   candidateDigest: string;
   plan: DeploymentPlan;
-  pullRequestNumber: number | null;
-  requestedBy: string | null;
+  pullRequestNumber: number;
   source: PlanningSource;
   targetCommitSha: string;
   targetManifestDigest: string | null;
-  trigger: "manual" | "pull_request";
 }) {
   const identityDigest = digestValue({
     candidateDigest: input.candidateDigest,
@@ -258,7 +232,7 @@ async function persistDeploymentPlan(input: {
     sourceId: input.source.id,
     targetCommitSha: input.targetCommitSha,
     targetManifestDigest: input.targetManifestDigest,
-    trigger: input.trigger,
+    trigger: "pull_request",
   });
   const database = getTowbarDatabase();
   const [inserted] = await database
@@ -271,12 +245,12 @@ async function persistDeploymentPlan(input: {
       identityDigest,
       plan: input.plan,
       pullRequestNumber: input.pullRequestNumber,
-      requestedBy: input.requestedBy,
+      requestedBy: null,
       sourceId: input.source.id,
       status: input.plan.status,
       targetCommitSha: input.targetCommitSha,
       targetManifestDigest: input.targetManifestDigest,
-      trigger: input.trigger,
+      trigger: "pull_request",
       workspaceId: input.source.workspaceId,
     })
     .onConflictDoNothing()
@@ -296,12 +270,10 @@ async function persistDeploymentPlan(input: {
         .limit(1)
     )[0];
   if (!persisted) throw new Error("Unable to persist deployment plan");
-  if (input.trigger === "pull_request") {
-    await database
-      .insert(deploymentPlanGithubChecks)
-      .values({ planId: persisted.id })
-      .onConflictDoNothing();
-  }
+  await database
+    .insert(deploymentPlanGithubChecks)
+    .values({ planId: persisted.id })
+    .onConflictDoNothing();
   return persisted;
 }
 

--- a/apps/towbar-api/src/areas/plans/service.ts
+++ b/apps/towbar-api/src/areas/plans/service.ts
@@ -1,0 +1,526 @@
+import { and, desc, eq, inArray, isNull, ne, notInArray } from "drizzle-orm";
+
+import {
+  ManifestValidationError,
+  buildBlockedDeploymentPlan,
+  buildDeploymentPlan,
+  digestValue,
+  parseDeploymentManifest,
+} from "@workspace/towbar-core";
+import {
+  apps,
+  deploymentPlanGithubChecks,
+  deploymentPlans,
+  deployments,
+  githubInstallations,
+  resourceOperations,
+  serverChecks,
+  serverPreparations,
+  servers,
+  sourceAwsCredentials,
+  sourceSyncs,
+  sources,
+} from "@workspace/towbar-database/schema";
+
+import { conflict, notFound } from "../../http/errors.js";
+import { getTowbarDatabase } from "../../infrastructure/database.js";
+import { inspectAwsSecretReferences } from "../aws/service.js";
+import {
+  fetchGitHubManifestSnapshot,
+  fetchGitHubSourceSnapshot,
+} from "../github/client.js";
+import { listSourceCapacity } from "../servers/capacity.js";
+import {
+  calculateDesiredDeploymentDigests,
+  fetchRepositoryTreeForDeploymentInputs,
+} from "../sources/deployment-digests.js";
+import {
+  assertStableDeployableKinds,
+  loadCurrentInventory,
+} from "../sources/inventory.js";
+import {
+  buildDeploymentPlanValidationChecks,
+  collectSecretReferences,
+} from "./validation.js";
+
+import type {
+  DeploymentPlan,
+  DeploymentPlanCheck,
+  RepositoryChangedPaths,
+} from "@workspace/towbar-core";
+import type { GitHubPullRequest } from "../github/client.js";
+
+const publicPlanSelection = {
+  branch: deploymentPlans.branch,
+  createdAt: deploymentPlans.createdAt,
+  currentCommitSha: deploymentPlans.currentCommitSha,
+  currentManifestDigest: deploymentPlans.currentManifestDigest,
+  id: deploymentPlans.id,
+  plan: deploymentPlans.plan,
+  pullRequestNumber: deploymentPlans.pullRequestNumber,
+  sourceId: deploymentPlans.sourceId,
+  status: deploymentPlans.status,
+  targetCommitSha: deploymentPlans.targetCommitSha,
+  targetManifestDigest: deploymentPlans.targetManifestDigest,
+  trigger: deploymentPlans.trigger,
+};
+
+export async function createManualDeploymentPlan(input: {
+  requestedBy: string;
+  sourceId: string;
+  workspaceId: string;
+}) {
+  const source = await getPlanningSource(input.sourceId, input.workspaceId);
+  const snapshot = await fetchGitHubSourceSnapshot(source);
+  return await createAndPersistDeploymentPlan({
+    branch: source.branch,
+    candidate: snapshot,
+    pullRequestNumber: null,
+    repositoryChanges: undefined,
+    requestedBy: input.requestedBy,
+    source,
+    trigger: "manual",
+  });
+}
+
+export async function createPullRequestDeploymentPlan(input: {
+  pullRequest: GitHubPullRequest;
+  repositoryChanges: RepositoryChangedPaths;
+  sourceId: string;
+  workspaceId: string;
+}) {
+  const source = await getPlanningSource(input.sourceId, input.workspaceId);
+  let candidate: { commitSha: string; manifestSource: string };
+  try {
+    candidate = await fetchGitHubManifestSnapshot({
+      ...source,
+      commitSha: input.pullRequest.headSha,
+    });
+  } catch (error) {
+    return await persistDeploymentPlan({
+      branch: input.pullRequest.headBranch,
+      candidateDigest: digestValue({
+        commitSha: input.pullRequest.headSha,
+        manifestAvailable: false,
+      }),
+      plan: buildBlockedDeploymentPlan(planChecksFromCandidateError(error)),
+      pullRequestNumber: input.pullRequest.number,
+      requestedBy: null,
+      source,
+      targetCommitSha: input.pullRequest.headSha,
+      targetManifestDigest: null,
+      trigger: "pull_request",
+    });
+  }
+  return await createAndPersistDeploymentPlan({
+    branch: input.pullRequest.headBranch,
+    candidate,
+    pullRequestNumber: input.pullRequest.number,
+    repositoryChanges: input.repositoryChanges,
+    requestedBy: null,
+    source,
+    trigger: "pull_request",
+  });
+}
+
+export async function listDeploymentPlans(input: {
+  sourceId: string;
+  workspaceId: string;
+}) {
+  await assertSourceAccess(input.sourceId, input.workspaceId);
+  return await getTowbarDatabase()
+    .select({
+      ...publicPlanSelection,
+      githubCheckStatus: deploymentPlanGithubChecks.status,
+    })
+    .from(deploymentPlans)
+    .leftJoin(
+      deploymentPlanGithubChecks,
+      eq(deploymentPlanGithubChecks.planId, deploymentPlans.id),
+    )
+    .where(eq(deploymentPlans.sourceId, input.sourceId))
+    .orderBy(desc(deploymentPlans.createdAt), desc(deploymentPlans.id));
+}
+
+export async function getDeploymentPlan(input: {
+  planId: string;
+  sourceId: string;
+  workspaceId: string;
+}) {
+  const [plan] = await getTowbarDatabase()
+    .select({
+      ...publicPlanSelection,
+      githubCheckError: deploymentPlanGithubChecks.errorMessage,
+      githubCheckRunId: deploymentPlanGithubChecks.checkRunId,
+      githubCheckStatus: deploymentPlanGithubChecks.status,
+    })
+    .from(deploymentPlans)
+    .leftJoin(
+      deploymentPlanGithubChecks,
+      eq(deploymentPlanGithubChecks.planId, deploymentPlans.id),
+    )
+    .where(
+      and(
+        eq(deploymentPlans.id, input.planId),
+        eq(deploymentPlans.sourceId, input.sourceId),
+        eq(deploymentPlans.workspaceId, input.workspaceId),
+      ),
+    )
+    .limit(1);
+  if (!plan) throw notFound("Deployment plan");
+  return plan;
+}
+
+async function createAndPersistDeploymentPlan(input: {
+  branch: string;
+  candidate: { commitSha: string; manifestSource: string };
+  pullRequestNumber: number | null;
+  repositoryChanges: RepositoryChangedPaths | undefined;
+  requestedBy: string | null;
+  source: PlanningSource;
+  trigger: "manual" | "pull_request";
+}) {
+  const candidateDigest = digestValue(input.candidate.manifestSource);
+  let targetManifestDigest: string | null = null;
+  let plan: DeploymentPlan;
+  try {
+    const parsed = parseDeploymentManifest(input.candidate.manifestSource);
+    targetManifestDigest = parsed.digest;
+    const [current, context, repositoryTree] = await Promise.all([
+      loadCurrentInventory(input.source.id),
+      loadValidationContext(input.source, parsed.manifest),
+      fetchRepositoryTreeForDeploymentInputs({
+        commitSha: input.candidate.commitSha,
+        manifestApps: parsed.manifest.apps,
+        repository: input.source,
+      }),
+    ]);
+    const checks = buildDeploymentPlanValidationChecks({
+      context,
+      manifest: parsed.manifest,
+    });
+    try {
+      assertStableDeployableKinds(current, parsed.manifest);
+    } catch (error) {
+      checks.push(planCheckFromError(error, "deployable_kind"));
+    }
+    const targetDigests = calculateDesiredDeploymentDigests({
+      commitSha: input.candidate.commitSha,
+      manifest: parsed.manifest,
+      repositoryTree,
+    });
+    plan = buildDeploymentPlan({
+      checks,
+      currentApps: current.apps,
+      currentResources: current.resources,
+      currentServers: current.servers,
+      desired: parsed.manifest,
+      mode: input.trigger === "manual" ? "full" : "pull_request",
+      repositoryChanges: input.repositoryChanges,
+      targetDeploymentDigests: new Map(
+        [...targetDigests].map(([id, digest]) => [id, digest.deploymentDigest]),
+      ),
+    });
+  } catch (error) {
+    plan = buildBlockedDeploymentPlan(planChecksFromCandidateError(error));
+  }
+
+  return await persistDeploymentPlan({
+    branch: input.branch,
+    candidateDigest,
+    plan,
+    pullRequestNumber: input.pullRequestNumber,
+    requestedBy: input.requestedBy,
+    source: input.source,
+    targetCommitSha: input.candidate.commitSha,
+    targetManifestDigest,
+    trigger: input.trigger,
+  });
+}
+
+async function persistDeploymentPlan(input: {
+  branch: string;
+  candidateDigest: string;
+  plan: DeploymentPlan;
+  pullRequestNumber: number | null;
+  requestedBy: string | null;
+  source: PlanningSource;
+  targetCommitSha: string;
+  targetManifestDigest: string | null;
+  trigger: "manual" | "pull_request";
+}) {
+  const identityDigest = digestValue({
+    candidateDigest: input.candidateDigest,
+    currentCommitSha: input.source.latestCommitSha,
+    currentManifestDigest: input.source.latestManifestDigest,
+    plan: input.plan,
+    pullRequestNumber: input.pullRequestNumber,
+    sourceId: input.source.id,
+    targetCommitSha: input.targetCommitSha,
+    targetManifestDigest: input.targetManifestDigest,
+    trigger: input.trigger,
+  });
+  const database = getTowbarDatabase();
+  const [inserted] = await database
+    .insert(deploymentPlans)
+    .values({
+      branch: input.branch,
+      candidateDigest: input.candidateDigest,
+      currentCommitSha: input.source.latestCommitSha,
+      currentManifestDigest: input.source.latestManifestDigest,
+      identityDigest,
+      plan: input.plan,
+      pullRequestNumber: input.pullRequestNumber,
+      requestedBy: input.requestedBy,
+      sourceId: input.source.id,
+      status: input.plan.status,
+      targetCommitSha: input.targetCommitSha,
+      targetManifestDigest: input.targetManifestDigest,
+      trigger: input.trigger,
+      workspaceId: input.source.workspaceId,
+    })
+    .onConflictDoNothing()
+    .returning(publicPlanSelection);
+  const persisted =
+    inserted ??
+    (
+      await database
+        .select(publicPlanSelection)
+        .from(deploymentPlans)
+        .where(
+          and(
+            eq(deploymentPlans.sourceId, input.source.id),
+            eq(deploymentPlans.identityDigest, identityDigest),
+          ),
+        )
+        .limit(1)
+    )[0];
+  if (!persisted) throw new Error("Unable to persist deployment plan");
+  if (input.trigger === "pull_request") {
+    await database
+      .insert(deploymentPlanGithubChecks)
+      .values({ planId: persisted.id })
+      .onConflictDoNothing();
+  }
+  return persisted;
+}
+
+async function getPlanningSource(sourceId: string, workspaceId: string) {
+  const [source] = await getTowbarDatabase()
+    .select({
+      branch: sources.branch,
+      id: sources.id,
+      installationId: githubInstallations.installationId,
+      latestCommitSha: sources.latestCommitSha,
+      latestManifestDigest: sources.latestManifestDigest,
+      repositoryName: sources.repositoryName,
+      repositoryOwner: sources.repositoryOwner,
+      status: sources.status,
+      workspaceId: sources.workspaceId,
+    })
+    .from(sources)
+    .innerJoin(
+      githubInstallations,
+      eq(githubInstallations.id, sources.githubInstallationId),
+    )
+    .where(and(eq(sources.id, sourceId), eq(sources.workspaceId, workspaceId)))
+    .limit(1);
+  if (!source) throw notFound("Source");
+  if (source.status === "archived") {
+    throw conflict("Archived Sources cannot be planned");
+  }
+  return source;
+}
+
+type PlanningSource = Awaited<ReturnType<typeof getPlanningSource>>;
+
+async function assertSourceAccess(sourceId: string, workspaceId: string) {
+  const [source] = await getTowbarDatabase()
+    .select({ id: sources.id })
+    .from(sources)
+    .where(and(eq(sources.id, sourceId), eq(sources.workspaceId, workspaceId)))
+    .limit(1);
+  if (!source) throw notFound("Source");
+}
+
+async function loadValidationContext(
+  source: PlanningSource,
+  manifest: Parameters<typeof collectSecretReferences>[0],
+) {
+  const database = getTowbarDatabase();
+  const [domainRows, serverRows, credentialRows, capacities, operations] =
+    await Promise.all([
+      database
+        .select({ config: apps.config, manifestId: apps.manifestId })
+        .from(apps)
+        .where(
+          and(
+            eq(apps.workspaceId, source.workspaceId),
+            ne(apps.sourceId, source.id),
+            isNull(apps.archivedAt),
+          ),
+        ),
+      database
+        .select({
+          config: servers.config,
+          configDigest: servers.configDigest,
+          ip: servers.canonicalIp,
+          preparedAt: servers.preparedAt,
+          preparedConfigDigest: servers.preparedConfigDigest,
+        })
+        .from(servers)
+        .where(eq(servers.sourceId, source.id)),
+      database
+        .select({ status: sourceAwsCredentials.verificationStatus })
+        .from(sourceAwsCredentials)
+        .where(eq(sourceAwsCredentials.sourceId, source.id))
+        .limit(1),
+      listSourceCapacity(source.workspaceId, source.id),
+      loadActiveOperationDescriptions(source.id),
+    ]);
+  const credentialStatus = credentialRows[0]?.status ?? null;
+  const secretReferences = collectSecretReferences(manifest);
+  const secretBindings =
+    credentialStatus === "verified" && secretReferences.length > 0
+      ? await inspectAwsSecretReferences({
+          secretReferences,
+          sourceId: source.id,
+          workspaceId: source.workspaceId,
+        })
+      : [];
+  return {
+    activeOperationDescriptions: operations,
+    capacities,
+    credentialStatus,
+    existingDomainClaims: domainRows.flatMap((row) =>
+      row.config.domains
+        ? [
+            {
+              domain: row.config.domains.primary,
+              manifestId: row.manifestId,
+            },
+            ...row.config.domains.redirects.map((redirect) => ({
+              domain: redirect.host,
+              manifestId: row.manifestId,
+            })),
+          ]
+        : [],
+    ),
+    materializedServers: serverRows,
+    secretBindings,
+    sourceBranch: source.branch,
+  };
+}
+
+async function loadActiveOperationDescriptions(sourceId: string) {
+  const database = getTowbarDatabase();
+  const [
+    activeDeployments,
+    activeOperations,
+    activeSyncs,
+    activeChecks,
+    activePreparations,
+  ] = await Promise.all([
+    database
+      .select({ id: deployments.id })
+      .from(deployments)
+      .where(
+        and(
+          eq(deployments.sourceId, sourceId),
+          notInArray(deployments.state, [
+            "cancelled",
+            "failed",
+            "skipped",
+            "succeeded",
+            "succeeded_with_warnings",
+          ]),
+        ),
+      )
+      .limit(1),
+    database
+      .select({ id: resourceOperations.id })
+      .from(resourceOperations)
+      .where(
+        and(
+          eq(resourceOperations.sourceId, sourceId),
+          inArray(resourceOperations.state, ["queued", "running"]),
+        ),
+      )
+      .limit(1),
+    database
+      .select({ id: sourceSyncs.id })
+      .from(sourceSyncs)
+      .where(
+        and(
+          eq(sourceSyncs.sourceId, sourceId),
+          inArray(sourceSyncs.status, ["queued", "running"]),
+        ),
+      )
+      .limit(1),
+    database
+      .select({ id: serverChecks.id })
+      .from(serverChecks)
+      .innerJoin(servers, eq(servers.id, serverChecks.serverId))
+      .where(
+        and(
+          eq(servers.sourceId, sourceId),
+          inArray(serverChecks.status, ["queued", "running"]),
+        ),
+      )
+      .limit(1),
+    database
+      .select({ id: serverPreparations.id })
+      .from(serverPreparations)
+      .innerJoin(servers, eq(servers.id, serverPreparations.serverId))
+      .where(
+        and(
+          eq(servers.sourceId, sourceId),
+          inArray(serverPreparations.status, ["queued", "running"]),
+        ),
+      )
+      .limit(1),
+  ]);
+  return [
+    ...(activeDeployments.length
+      ? ["Wait for the active deployment to finish before executing this plan"]
+      : []),
+    ...(activeOperations.length
+      ? [
+          "Wait for the active Resource operation to finish before executing this plan",
+        ]
+      : []),
+    ...(activeSyncs.length
+      ? ["Wait for the active Source sync to finish before executing this plan"]
+      : []),
+    ...(activeChecks.length
+      ? [
+          "Wait for the active server check to finish before executing this plan",
+        ]
+      : []),
+    ...(activePreparations.length
+      ? [
+          "Wait for the active server preparation to finish before executing this plan",
+        ]
+      : []),
+  ];
+}
+
+function planChecksFromCandidateError(error: unknown): DeploymentPlanCheck[] {
+  if (error instanceof ManifestValidationError) {
+    return error.issues.map((issue) => ({
+      code: "manifest_schema",
+      message: `${issue.path.join(".") || "manifest"}: ${issue.message}`,
+      status: "failed",
+    }));
+  }
+  return [planCheckFromError(error, "candidate_unavailable")];
+}
+
+function planCheckFromError(error: unknown, code: string): DeploymentPlanCheck {
+  return {
+    code,
+    message:
+      error instanceof Error ? error.message : "Candidate validation failed",
+    status: "failed",
+  };
+}

--- a/apps/towbar-api/src/areas/plans/validation.test.ts
+++ b/apps/towbar-api/src/areas/plans/validation.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  digestValue,
+  normalizeDeploymentManifest,
+} from "@workspace/towbar-core";
+
+import {
+  buildDeploymentPlanValidationChecks,
+  collectSecretReferences,
+  parseDockerMemoryBytes,
+} from "./validation.js";
+
+const manifest = normalizeDeploymentManifest({
+  version: 1,
+  source: { branch: "main" },
+  servers: [
+    {
+      ip: "192.0.2.10",
+      secrets: { login: "aws:source/server-login" },
+      ssh: { username: "deploy" },
+    },
+  ],
+  apps: [
+    {
+      id: "website",
+      name: "Website",
+      server: "192.0.2.10",
+      container: { port: 3000 },
+      context: ".",
+      dockerfile: "Dockerfile",
+      health: { path: "/health" },
+    },
+  ],
+});
+
+void test("collects sorted secret names without resolving values", () => {
+  assert.deepEqual(
+    collectSecretReferences({ second: "aws:z", first: ["aws:a", "plain"] }),
+    ["aws:a", "aws:z"],
+  );
+});
+
+void test("parses normalized Docker memory limits", () => {
+  assert.equal(parseDockerMemoryBytes("512m"), 512 * 1_024 ** 2);
+  assert.equal(parseDockerMemoryBytes("1g"), 1_024 ** 3);
+});
+
+void test("returns actionable checks without secret values", () => {
+  const checks = buildDeploymentPlanValidationChecks({
+    context: {
+      activeOperationDescriptions: [
+        "Wait for the active Source sync to finish",
+      ],
+      capacities: [],
+      credentialStatus: null,
+      existingDomainClaims: [],
+      materializedServers: [],
+      secretBindings: [],
+      sourceBranch: "main",
+    },
+    manifest,
+  });
+  assert.equal(
+    checks.some((check) => check.code === "server_not_materialized"),
+    true,
+  );
+  assert.equal(
+    checks.some((check) => check.code === "secret_bindings_unavailable"),
+    true,
+  );
+  assert.equal(
+    checks.some((check) => check.code === "operation_conflict"),
+    true,
+  );
+  assert.equal(JSON.stringify(checks).includes("server-login"), true);
+});
+
+void test("blocks secret bindings that cannot be described by name", () => {
+  const checks = buildDeploymentPlanValidationChecks({
+    context: {
+      activeOperationDescriptions: [],
+      capacities: [],
+      credentialStatus: "verified",
+      existingDomainClaims: [],
+      materializedServers: [],
+      secretBindings: [
+        { available: false, reference: "aws:source/server-login" },
+      ],
+      sourceBranch: "main",
+    },
+    manifest,
+  });
+
+  assert.deepEqual(
+    checks.find((check) => check.code === "secret_binding_unavailable"),
+    {
+      code: "secret_binding_unavailable",
+      entityKind: "source",
+      message:
+        "Secret binding 'aws:source/server-login' was not found or cannot be described by the Source AWS credentials",
+      references: ["aws:source/server-login"],
+      status: "failed",
+    },
+  );
+});
+
+void test("keeps preparation valid for scheduler-only server changes", () => {
+  const currentServer = manifest.servers[0]!;
+  const desired = structuredClone(manifest);
+  desired.servers[0]!.buildConcurrency = 4;
+  const currentDigest = digestValue(currentServer);
+  const checks = buildDeploymentPlanValidationChecks({
+    context: {
+      activeOperationDescriptions: [],
+      capacities: [],
+      credentialStatus: "verified",
+      existingDomainClaims: [],
+      materializedServers: [
+        {
+          config: currentServer,
+          configDigest: currentDigest,
+          ip: currentServer.ip,
+          preparedAt: new Date(),
+          preparedConfigDigest: currentDigest,
+        },
+      ],
+      secretBindings: [
+        { available: true, reference: "aws:source/server-login" },
+      ],
+      sourceBranch: "main",
+    },
+    manifest: desired,
+  });
+
+  assert.equal(
+    checks.some((check) => check.code === "server_not_ready"),
+    false,
+  );
+  assert.equal(
+    checks.some((check) => check.code === "server_ready"),
+    true,
+  );
+});

--- a/apps/towbar-api/src/areas/plans/validation.ts
+++ b/apps/towbar-api/src/areas/plans/validation.ts
@@ -1,0 +1,315 @@
+import { requiresServerPreparation } from "@workspace/towbar-core";
+
+import type {
+  DeploymentPlanCheck,
+  NormalizedDeploymentManifest,
+  NormalizedServer,
+  RuntimeCapacity,
+} from "@workspace/towbar-core";
+
+export type DeploymentPlanValidationContext = {
+  activeOperationDescriptions: string[];
+  capacities: RuntimeCapacity[];
+  credentialStatus: "failed" | "unverified" | "verified" | null;
+  existingDomainClaims: Array<{ domain: string; manifestId: string }>;
+  materializedServers: Array<{
+    config: NormalizedServer;
+    configDigest: string;
+    ip: string;
+    preparedAt: Date | null;
+    preparedConfigDigest: string | null;
+  }>;
+  secretBindings: Array<{ available: boolean; reference: string }>;
+  sourceBranch: string;
+};
+
+export function buildDeploymentPlanValidationChecks(input: {
+  context: DeploymentPlanValidationContext;
+  manifest: NormalizedDeploymentManifest;
+}): DeploymentPlanCheck[] {
+  return [
+    {
+      code: "manifest_schema",
+      message: "The candidate manifest matches the Towbar v1 schema",
+      status: "passed",
+    },
+    ...validateSourceBranch(input),
+    ...validateDomains(input),
+    ...validateServers(input),
+    ...validateSecretBindings(input),
+    ...validateOperationConflicts(input.context.activeOperationDescriptions),
+  ];
+}
+
+export function collectSecretReferences(value: unknown) {
+  const references = new Set<string>();
+  visitStrings(value, (candidate) => {
+    if (candidate.startsWith("aws:")) references.add(candidate);
+  });
+  return [...references].sort((left, right) => left.localeCompare(right));
+}
+
+export function parseDockerMemoryBytes(value: string) {
+  const match = /^(\d+(?:\.\d+)?)([bkmg])$/iu.exec(value.trim());
+  if (!match) return null;
+  const amount = Number(match[1]);
+  const exponent = { b: 0, g: 3, k: 1, m: 2 }[
+    match[2]!.toLowerCase() as "b" | "g" | "k" | "m"
+  ];
+  return amount * 1_024 ** exponent;
+}
+
+function validateSourceBranch(input: {
+  context: DeploymentPlanValidationContext;
+  manifest: NormalizedDeploymentManifest;
+}): DeploymentPlanCheck[] {
+  if (input.manifest.source.branch === input.context.sourceBranch) return [];
+  return [
+    {
+      code: "source_branch_mismatch",
+      entityKind: "source",
+      message: `Candidate source.branch '${input.manifest.source.branch}' does not match configured branch '${input.context.sourceBranch}'`,
+      status: "failed",
+    },
+  ];
+}
+
+function validateDomains(input: {
+  context: DeploymentPlanValidationContext;
+  manifest: NormalizedDeploymentManifest;
+}) {
+  const claims = new Map(
+    input.context.existingDomainClaims.map((claim) => [claim.domain, claim]),
+  );
+  return deployables(input.manifest).flatMap<DeploymentPlanCheck>(
+    (deployable) =>
+      deployable.domains
+        ? [
+            deployable.domains.primary,
+            ...deployable.domains.redirects.map((redirect) => redirect.host),
+          ].flatMap((domain) => {
+            const claim = claims.get(domain);
+            return claim
+              ? [
+                  {
+                    code: "domain_conflict",
+                    entityId: deployable.id,
+                    entityKind:
+                      deployable.kind && deployable.kind !== "app"
+                        ? ("resource" as const)
+                        : ("app" as const),
+                    message: `Domain '${domain}' is already claimed by '${claim.manifestId}'`,
+                    references: [domain],
+                    status: "failed" as const,
+                  },
+                ]
+              : [];
+          })
+        : [],
+  );
+}
+
+function validateServers(input: {
+  context: DeploymentPlanValidationContext;
+  manifest: NormalizedDeploymentManifest;
+}) {
+  const materialized = new Map(
+    input.context.materializedServers.map((server) => [server.ip, server]),
+  );
+  const capacities = new Map(
+    input.context.capacities.map((capacity) => [capacity.ip, capacity]),
+  );
+  return input.manifest.servers.flatMap<DeploymentPlanCheck>((server) => {
+    const checks: DeploymentPlanCheck[] = [];
+    const current = materialized.get(server.ip);
+    if (!current) {
+      checks.push({
+        code: "server_not_materialized",
+        entityId: server.ip,
+        entityKind: "server",
+        message:
+          "Sync this Source, trust its SSH host key, and prepare the new server before deployment",
+        status: "failed",
+      });
+      return checks;
+    }
+    if (
+      !current.preparedAt ||
+      current.preparedConfigDigest !== current.configDigest ||
+      requiresServerPreparation(current.config, server)
+    ) {
+      checks.push({
+        code: "server_not_ready",
+        entityId: server.ip,
+        entityKind: "server",
+        message:
+          "The server must be prepared for the candidate configuration before deployment",
+        status: "failed",
+      });
+    } else {
+      checks.push({
+        code: "server_ready",
+        entityId: server.ip,
+        entityKind: "server",
+        message: "The server is prepared for the candidate configuration",
+        status: "passed",
+      });
+    }
+    checks.push(
+      ...capacityChecks(input.manifest, server.ip, capacities.get(server.ip)),
+    );
+    return checks;
+  });
+}
+
+function capacityChecks(
+  manifest: NormalizedDeploymentManifest,
+  serverIp: string,
+  capacity: RuntimeCapacity | undefined,
+): DeploymentPlanCheck[] {
+  if (!capacity) {
+    return [
+      {
+        code: "capacity_unavailable",
+        entityId: serverIp,
+        entityKind: "server",
+        message:
+          "Run a server check to validate host capacity before deployment",
+        status: "warning",
+      },
+    ];
+  }
+  const checks: DeploymentPlanCheck[] = [];
+  if (capacity.status === "critical" || capacity.status === "attention") {
+    checks.push({
+      code: "capacity_health",
+      entityId: serverIp,
+      entityKind: "server",
+      message:
+        capacity.status === "critical"
+          ? "The latest server check reports critical capacity or health pressure"
+          : "The latest server check recommends reviewing host capacity",
+      status: capacity.status === "critical" ? "failed" : "warning",
+    });
+  } else if (capacity.status === "unknown") {
+    checks.push({
+      code: "capacity_unknown",
+      entityId: serverIp,
+      entityKind: "server",
+      message: "Run a fresh server check to validate host capacity",
+      status: "warning",
+    });
+  }
+
+  const declared = deployables(manifest)
+    .filter((deployable) => deployable.server === serverIp)
+    .reduce(
+      (total, deployable) => {
+        const resources = deployable.container.resources;
+        if (!resources) return total;
+        return {
+          cpus: total.cpus + resources.cpus,
+          memoryBytes:
+            total.memoryBytes + (parseDockerMemoryBytes(resources.memory) ?? 0),
+        };
+      },
+      { cpus: 0, memoryBytes: 0 },
+    );
+  if (capacity.cpu && declared.cpus > capacity.cpu.logicalCount) {
+    checks.push({
+      code: "cpu_capacity_exceeded",
+      entityId: serverIp,
+      entityKind: "server",
+      message: `Declared container CPU limits (${declared.cpus}) exceed ${capacity.cpu.logicalCount} logical CPUs`,
+      status: "failed",
+    });
+  }
+  if (capacity.memory && declared.memoryBytes > capacity.memory.totalBytes) {
+    checks.push({
+      code: "memory_capacity_exceeded",
+      entityId: serverIp,
+      entityKind: "server",
+      message: "Declared container memory limits exceed total host memory",
+      status: "failed",
+    });
+  }
+  if (checks.length === 0) {
+    checks.push({
+      code: "capacity_available",
+      entityId: serverIp,
+      entityKind: "server",
+      message: "The latest server check has sufficient declared capacity",
+      status: "passed",
+    });
+  }
+  return checks;
+}
+
+function validateSecretBindings(input: {
+  context: DeploymentPlanValidationContext;
+  manifest: NormalizedDeploymentManifest;
+}): DeploymentPlanCheck[] {
+  const references = collectSecretReferences(input.manifest);
+  if (references.length === 0) return [];
+  if (input.context.credentialStatus !== "verified") {
+    return [
+      {
+        code: "secret_bindings_unavailable",
+        entityKind: "source",
+        message:
+          "Configure and verify Source AWS credentials before using the declared secret bindings",
+        references,
+        status: "failed",
+      },
+    ];
+  }
+  const unavailable = input.context.secretBindings.filter(
+    (binding) => !binding.available,
+  );
+  if (unavailable.length > 0) {
+    return unavailable.map((binding) => ({
+      code: "secret_binding_unavailable",
+      entityKind: "source" as const,
+      message: `Secret binding '${binding.reference}' was not found or cannot be described by the Source AWS credentials`,
+      references: [binding.reference],
+      status: "failed" as const,
+    }));
+  }
+  return [
+    {
+      code: "secret_bindings_declared",
+      entityKind: "source",
+      message: `${references.length} secret binding${references.length === 1 ? " is" : "s are"} declared by name; values were not resolved`,
+      references,
+      status: "passed",
+    },
+  ];
+}
+
+function validateOperationConflicts(descriptions: string[]) {
+  return [...descriptions]
+    .sort((left, right) => left.localeCompare(right))
+    .map<DeploymentPlanCheck>((description) => ({
+      code: "operation_conflict",
+      entityKind: "source",
+      message: description,
+      status: "failed",
+    }));
+}
+
+function deployables(manifest: NormalizedDeploymentManifest) {
+  return [...manifest.apps, ...(manifest.resources ?? [])];
+}
+
+function visitStrings(value: unknown, callback: (value: string) => void) {
+  if (typeof value === "string") {
+    callback(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) visitStrings(item, callback);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  for (const item of Object.values(value)) visitStrings(item, callback);
+}

--- a/apps/towbar-api/src/areas/previews/service.ts
+++ b/apps/towbar-api/src/areas/previews/service.ts
@@ -37,6 +37,8 @@ import {
   publishPreviewDeploymentStatus,
 } from "../deployments/preview-status.js";
 import { calculateReleaseDeploymentDigest } from "../sources/deployment-digests.js";
+import { publishDeploymentPlanGitHubCheck } from "../plans/github-check.js";
+import { createPullRequestDeploymentPlan } from "../plans/service.js";
 import {
   isPreviewReleaseCurrent,
   shouldDeferPreviewAdmission,
@@ -163,6 +165,25 @@ export async function processPreviewPullRequestEvent(
       retry: false,
     };
   }
+  const changedPaths = await fetchGitHubPullRequestChangedPaths({
+    changedFileCount: pullRequest.changedFileCount,
+    installationId: source.installationId,
+    pullRequestNumber: pullRequest.number,
+    repositoryName: source.repositoryName,
+    repositoryOwner: source.repositoryOwner,
+  });
+  try {
+    const plan = await createPullRequestDeploymentPlan({
+      pullRequest,
+      repositoryChanges: changedPaths,
+      sourceId: event.sourceId,
+      workspaceId: source.workspaceId,
+    });
+    await publishDeploymentPlanGitHubCheck(plan.id);
+  } catch {
+    // Planning and GitHub reporting are observational. Preview reconciliation
+    // remains independent and records its own result.
+  }
   if (!source.latestManifestDigest) {
     return { cleanupIds: [], deploymentIds: [], retry: false };
   }
@@ -199,17 +220,6 @@ export async function processPreviewPullRequestEvent(
   if (eligible.length === 0) {
     return { cleanupIds: [], deploymentIds: [], retry: false };
   }
-  const changedPaths = eligible.some(
-    (candidate) => candidate.config.deploymentInputs.length > 0,
-  )
-    ? await fetchGitHubPullRequestChangedPaths({
-        changedFileCount: pullRequest.changedFileCount,
-        installationId: source.installationId,
-        pullRequestNumber: pullRequest.number,
-        repositoryName: source.repositoryName,
-        repositoryOwner: source.repositoryOwner,
-      })
-    : { complete: true, paths: [] };
   const relevant = eligible.filter((candidate) =>
     shouldDeployForChangedPaths({
       changedPaths,

--- a/apps/towbar-api/src/areas/sources/inventory.ts
+++ b/apps/towbar-api/src/areas/sources/inventory.ts
@@ -6,7 +6,7 @@ import { conflict } from "../../http/errors.js";
 import { getTowbarDatabase } from "../../infrastructure/database.js";
 
 import type {
-  MaterializedManifestEntity,
+  MaterializedDeploymentPlanEntity,
   NormalizedApp,
   NormalizedDeploymentManifest,
   NormalizedResource,
@@ -20,6 +20,7 @@ export async function loadCurrentInventory(sourceId: string) {
       archivedAt: apps.archivedAt,
       config: apps.config,
       configDigest: apps.configDigest,
+      deploymentDigest: apps.deploymentDigest,
       id: apps.id,
       identity: apps.manifestId,
     })
@@ -38,12 +39,12 @@ export async function loadCurrentInventory(sourceId: string) {
   return {
     apps: currentApps.filter(
       (app) => app.config.kind === "app" || !app.config.kind,
-    ) as Array<MaterializedManifestEntity<NormalizedApp>>,
+    ) as Array<MaterializedDeploymentPlanEntity<NormalizedApp>>,
     resources: currentApps.filter(
       (app) => app.config.kind && app.config.kind !== "app",
-    ) as Array<MaterializedManifestEntity<NormalizedResource>>,
+    ) as Array<MaterializedDeploymentPlanEntity<NormalizedResource>>,
     servers: currentServers as Array<
-      MaterializedManifestEntity<NormalizedServer>
+      MaterializedDeploymentPlanEntity<NormalizedServer>
     >,
   };
 }

--- a/apps/towbar-api/src/routes/v1/core/sources.ts
+++ b/apps/towbar-api/src/routes/v1/core/sources.ts
@@ -23,6 +23,11 @@ import { listSourceCapacity } from "../../../areas/servers/capacity.js";
 import { listSourceServers } from "../../../areas/servers/service.js";
 import { listSourceBackups } from "../../../areas/resource-operations/service.js";
 import { listPreviewEnvironments } from "../../../areas/previews/service.js";
+import {
+  createManualDeploymentPlan,
+  getDeploymentPlan,
+  listDeploymentPlans,
+} from "../../../areas/plans/service.js";
 import { forbidden } from "../../../http/errors.js";
 import { readJson } from "../../../http/requests.js";
 import {
@@ -189,6 +194,27 @@ sourceRoutes.get("/:sourceId/previews", async (context) => {
   });
 });
 
+sourceRoutes.get("/:sourceId/plans", async (context) => {
+  const user = context.get("user");
+  return context.json({
+    plans: await listDeploymentPlans({
+      sourceId: context.req.param("sourceId"),
+      workspaceId: user.workspaceId,
+    }),
+  });
+});
+
+sourceRoutes.get("/:sourceId/plans/:planId", async (context) => {
+  const user = context.get("user");
+  return context.json({
+    plan: await getDeploymentPlan({
+      planId: context.req.param("planId"),
+      sourceId: context.req.param("sourceId"),
+      workspaceId: user.workspaceId,
+    }),
+  });
+});
+
 sourceRoutes.get("/:sourceId/manifest", async (context) =>
   context.json({
     manifest: await getSourceManifest(
@@ -206,6 +232,16 @@ sourceRoutes.post("/:sourceId/actions/preview-sync", async (context) =>
     ),
   ),
 );
+
+sourceRoutes.post("/:sourceId/actions/plan", async (context) => {
+  const user = context.get("user");
+  const plan = await createManualDeploymentPlan({
+    requestedBy: user.id,
+    sourceId: context.req.param("sourceId"),
+    workspaceId: user.workspaceId,
+  });
+  return context.json({ plan }, 201);
+});
 
 sourceRoutes.post("/:sourceId/actions/sync", async (context) => {
   const user = context.get("user");

--- a/apps/towbar-api/src/routes/v1/core/sources.ts
+++ b/apps/towbar-api/src/routes/v1/core/sources.ts
@@ -24,7 +24,6 @@ import { listSourceServers } from "../../../areas/servers/service.js";
 import { listSourceBackups } from "../../../areas/resource-operations/service.js";
 import { listPreviewEnvironments } from "../../../areas/previews/service.js";
 import {
-  createManualDeploymentPlan,
   getDeploymentPlan,
   listDeploymentPlans,
 } from "../../../areas/plans/service.js";
@@ -232,16 +231,6 @@ sourceRoutes.post("/:sourceId/actions/preview-sync", async (context) =>
     ),
   ),
 );
-
-sourceRoutes.post("/:sourceId/actions/plan", async (context) => {
-  const user = context.get("user");
-  const plan = await createManualDeploymentPlan({
-    requestedBy: user.id,
-    sourceId: context.req.param("sourceId"),
-    workspaceId: user.workspaceId,
-  });
-  return context.json({ plan }, 201);
-});
 
 sourceRoutes.post("/:sourceId/actions/sync", async (context) => {
   const user = context.get("user");

--- a/apps/towbar-web-app/README.md
+++ b/apps/towbar-web-app/README.md
@@ -39,6 +39,11 @@ list only Source-scoped orphan candidates from the latest check; owner-confirmed
 cleanup is destructive and persistent volumes are never removed automatically.
 Trusted SSH host keys can be explicitly untrusted from the Server's Host Keys
 tab after confirmation.
+Source pages also expose immutable deployment plans. Operators can generate a
+manual, read-only comparison against the configured branch, or open a
+pull-request plan from its GitHub Check. The plan detail shows current and
+target identities, validation, create/update/archive/restore/no-op rows,
+changed field names, and matched repository paths without secret values.
 
 ## Local UI fixture
 
@@ -51,5 +56,6 @@ NEXT_PUBLIC_TOWBAR_API_BASE_URL=http://127.0.0.1:4420 pnpm --filter towbar-web-a
 ```
 
 The fixture covers every authenticated page, including nested Source, App,
-Resource, Server, Deployment, and Source Sync routes. It listens on port 4420
-to remain isolated from the normal Towbar API development port.
+Resource, Server, Deployment, Deployment Plan, and Source Sync routes. It
+listens on port 4420 to remain isolated from the normal Towbar API development
+port.

--- a/apps/towbar-web-app/README.md
+++ b/apps/towbar-web-app/README.md
@@ -39,11 +39,10 @@ list only Source-scoped orphan candidates from the latest check; owner-confirmed
 cleanup is destructive and persistent volumes are never removed automatically.
 Trusted SSH host keys can be explicitly untrusted from the Server's Host Keys
 tab after confirmation.
-Source pages also expose immutable deployment plans. Operators can generate a
-manual, read-only comparison against the configured branch, or open a
-pull-request plan from its GitHub Check. The plan detail shows current and
-target identities, validation, create/update/archive/restore/no-op rows,
-changed field names, and matched repository paths without secret values.
+Source pages also expose immutable pull-request deployment plans from their
+GitHub Checks. The plan detail shows current and target identities, validation,
+create/update/archive/restore/no-op rows, changed field names, and matched
+repository paths without secret values.
 
 ## Local UI fixture
 

--- a/apps/towbar-web-app/scripts/fixture-api.test.mjs
+++ b/apps/towbar-web-app/scripts/fixture-api.test.mjs
@@ -24,6 +24,8 @@ const readRoutes = [
   `/v1/core/sources/${fixtureIds.source}/secrets`,
   `/v1/core/sources/${fixtureIds.source}/apps`,
   `/v1/core/sources/${fixtureIds.source}/capacity`,
+  `/v1/core/sources/${fixtureIds.source}/plans`,
+  `/v1/core/sources/${fixtureIds.source}/plans/${fixtureIds.deploymentPlan}`,
   `/v1/core/sources/${fixtureIds.source}/resources`,
   `/v1/core/sources/${fixtureIds.source}/servers`,
   `/v1/core/sources/${fixtureIds.source}/deployments`,
@@ -346,6 +348,47 @@ test("the local fixture covers source creation and the initial sync", async () =
     assert.equal(syncResponse.status, 202);
     const syncPayload = await syncResponse.json();
     assert.equal(syncPayload.sync.id, fixtureIds.sync);
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+});
+
+test("the local fixture covers immutable deployment planning", async () => {
+  const server = createFixtureApiServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  assert(address && typeof address === "object");
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  try {
+    const listResponse = await fetch(
+      `${baseUrl}/v1/core/sources/${fixtureIds.source}/plans`,
+    );
+    assert.equal(listResponse.status, 200);
+    const initial = await listResponse.json();
+    assert.equal(initial.plans[0].id, fixtureIds.deploymentPlan);
+    assert.equal(initial.plans[0].plan.summary.update, 1);
+    assert.equal(initial.plans[0].plan.summary.no_op, 1);
+
+    const createResponse = await fetch(
+      `${baseUrl}/v1/core/sources/${fixtureIds.source}/actions/plan`,
+      { method: "POST" },
+    );
+    assert.equal(createResponse.status, 201);
+    const created = await createResponse.json();
+    assert.equal(created.plan.trigger, "manual");
+    assert.equal(created.plan.plan.status, "ready");
+    assert.equal(created.plan.plan.summary.no_op > 0, true);
+
+    const detailResponse = await fetch(
+      `${baseUrl}/v1/core/sources/${fixtureIds.source}/plans/${created.plan.id}`,
+    );
+    assert.equal(detailResponse.status, 200);
+    const detail = await detailResponse.json();
+    assert.equal(detail.plan.id, created.plan.id);
+    assert.equal("candidateManifest" in detail.plan, false);
   } finally {
     server.close();
     await once(server, "close");

--- a/apps/towbar-web-app/scripts/fixture-api.test.mjs
+++ b/apps/towbar-web-app/scripts/fixture-api.test.mjs
@@ -354,7 +354,7 @@ test("the local fixture covers source creation and the initial sync", async () =
   }
 });
 
-test("the local fixture covers immutable deployment planning", async () => {
+test("the local fixture covers pull request deployment planning", async () => {
   const server = createFixtureApiServer();
   server.listen(0, "127.0.0.1");
   await once(server, "listening");
@@ -372,22 +372,20 @@ test("the local fixture covers immutable deployment planning", async () => {
     assert.equal(initial.plans[0].plan.summary.update, 1);
     assert.equal(initial.plans[0].plan.summary.no_op, 1);
 
-    const createResponse = await fetch(
+    const manualResponse = await fetch(
       `${baseUrl}/v1/core/sources/${fixtureIds.source}/actions/plan`,
       { method: "POST" },
     );
-    assert.equal(createResponse.status, 201);
-    const created = await createResponse.json();
-    assert.equal(created.plan.trigger, "manual");
-    assert.equal(created.plan.plan.status, "ready");
-    assert.equal(created.plan.plan.summary.no_op > 0, true);
+    assert.equal(manualResponse.status, 404);
 
     const detailResponse = await fetch(
-      `${baseUrl}/v1/core/sources/${fixtureIds.source}/plans/${created.plan.id}`,
+      `${baseUrl}/v1/core/sources/${fixtureIds.source}/plans/${fixtureIds.deploymentPlan}`,
     );
     assert.equal(detailResponse.status, 200);
     const detail = await detailResponse.json();
-    assert.equal(detail.plan.id, created.plan.id);
+    assert.equal(detail.plan.id, fixtureIds.deploymentPlan);
+    assert.equal(detail.plan.pullRequestNumber, 42);
+    assert.equal(detail.plan.trigger, "pull_request");
     assert.equal("candidateManifest" in detail.plan, false);
   } finally {
     server.close();

--- a/apps/towbar-web-app/scripts/fixture-api.ts
+++ b/apps/towbar-web-app/scripts/fixture-api.ts
@@ -774,60 +774,6 @@ export function createFixtureApiServer() {
       return writeJson(response, 202, { sync: { id: sourceSync.id } });
     }
     if (
-      request.method === "POST" &&
-      path === `/v1/core/sources/${source.id}/actions/plan`
-    ) {
-      const plan: DeploymentPlan = {
-        ...deploymentPlans[0]!,
-        branch: source.branch,
-        createdAt: new Date().toISOString(),
-        githubCheckRunId: null,
-        githubCheckStatus: null,
-        id: randomUUID(),
-        plan: {
-          checks: [
-            {
-              code: "manifest_schema",
-              message: "The candidate deployment manifest is valid.",
-              status: "passed",
-            },
-          ],
-          items: [...apps, ...resources, ...servers].map((item) => ({
-            action: "no_op" as const,
-            automaticDeployment:
-              "config" in item && "autoDeploy" in item.config
-                ? Boolean(item.config.autoDeploy)
-                : false,
-            changedFields: [],
-            entityId: "manifestId" in item ? item.manifestId : item.canonicalIp,
-            entityKind:
-              "manifestId" in item
-                ? item.kind === "app"
-                  ? ("app" as const)
-                  : ("resource" as const)
-                : ("server" as const),
-            matchedPaths: [],
-            name: "name" in item ? item.name : item.canonicalIp,
-            reasons: ["No material configuration change"],
-          })),
-          status: "ready",
-          summary: {
-            archive: 0,
-            create: 0,
-            no_op: apps.length + resources.length + servers.length,
-            restore: 0,
-            update: 0,
-          },
-        },
-        pullRequestNumber: null,
-        targetCommitSha: source.latestCommitSha!,
-        targetManifestDigest: source.latestManifestDigest,
-        trigger: "manual",
-      };
-      deploymentPlans.unshift(plan);
-      return writeJson(response, 201, { plan });
-    }
-    if (
       request.method === "PATCH" &&
       path === `/v1/core/sources/${source.id}/secrets`
     ) {

--- a/apps/towbar-web-app/scripts/fixture-api.ts
+++ b/apps/towbar-web-app/scripts/fixture-api.ts
@@ -15,6 +15,7 @@ import type {
   Deployment,
   DeploymentEvent,
   DeploymentLog,
+  DeploymentPlan,
   DeploymentState,
   DeploymentStep,
   GitHubConnection,
@@ -41,6 +42,7 @@ import type {
 export const fixtureIds = {
   app: "31111111-1111-4111-8111-222222222222",
   deployment: "61111111-1111-4111-8111-111111111111",
+  deploymentPlan: "71111111-1111-4111-8111-111111111112",
   preview: "b1111111-1111-4111-8111-111111111111",
   previewDeployment: "61111111-1111-4111-8111-444444444444",
   imageResource: "41111111-1111-4111-8111-444444444444",
@@ -348,6 +350,67 @@ const sourceSync: SourceSync = {
   status: "succeeded",
 };
 
+const deploymentPlans: DeploymentPlan[] = [
+  {
+    branch: "feature/deployment-plan-fixture",
+    createdAt: fixtureNow,
+    currentCommitSha: commitSha,
+    currentManifestDigest: manifestDigest,
+    githubCheckError: null,
+    githubCheckRunId: "1234567890",
+    githubCheckStatus: "published",
+    id: fixtureIds.deploymentPlan,
+    plan: {
+      checks: [
+        {
+          code: "manifest_schema",
+          message: "The candidate deployment manifest is valid.",
+          status: "passed",
+        },
+        {
+          code: "server_capacity",
+          entityId: fixtureIds.server,
+          entityKind: "server",
+          message:
+            "192.0.2.10 has limited Docker disk capacity. Review the server before deployment.",
+          references: ["192.0.2.10"],
+          status: "warning",
+        },
+      ],
+      items: [
+        {
+          action: "update",
+          automaticDeployment: true,
+          changedFields: ["dockerfile", "health.path"],
+          entityId: apps[1]!.manifestId,
+          entityKind: "app",
+          matchedPaths: ["apps/example-website/src/page.tsx"],
+          name: apps[1]!.name,
+          reasons: ["Deployment inputs changed in this pull request"],
+        },
+        {
+          action: "no_op",
+          automaticDeployment: false,
+          changedFields: [],
+          entityId: resources[0]!.manifestId,
+          entityKind: "resource",
+          matchedPaths: [],
+          name: resources[0]!.name,
+          reasons: ["No material configuration change"],
+        },
+      ],
+      status: "ready",
+      summary: { archive: 0, create: 0, no_op: 1, restore: 0, update: 1 },
+    },
+    pullRequestNumber: 42,
+    sourceId: source.id,
+    status: "ready",
+    targetCommitSha: "e".repeat(40),
+    targetManifestDigest: "f".repeat(64),
+    trigger: "pull_request",
+  },
+];
+
 const awsCredential: AwsCredentialMetadata = {
   accessKeyIdSuffix: "ABCD",
   createdAt: fixtureNow,
@@ -364,8 +427,10 @@ const githubConnection: GitHubConnection = {
   id: "b1111111-1111-4111-8111-111111111111",
   installationId: "12345678",
   permissionReadiness: {
+    checks: "write",
     contents: "read",
     deployments: "write",
+    planning: "ready",
     preview: "ready",
     pullRequests: "write",
     status: "available",
@@ -707,6 +772,60 @@ export function createFixtureApiServer() {
       path === `/v1/core/sources/${source.id}/actions/sync`
     ) {
       return writeJson(response, 202, { sync: { id: sourceSync.id } });
+    }
+    if (
+      request.method === "POST" &&
+      path === `/v1/core/sources/${source.id}/actions/plan`
+    ) {
+      const plan: DeploymentPlan = {
+        ...deploymentPlans[0]!,
+        branch: source.branch,
+        createdAt: new Date().toISOString(),
+        githubCheckRunId: null,
+        githubCheckStatus: null,
+        id: randomUUID(),
+        plan: {
+          checks: [
+            {
+              code: "manifest_schema",
+              message: "The candidate deployment manifest is valid.",
+              status: "passed",
+            },
+          ],
+          items: [...apps, ...resources, ...servers].map((item) => ({
+            action: "no_op" as const,
+            automaticDeployment:
+              "config" in item && "autoDeploy" in item.config
+                ? Boolean(item.config.autoDeploy)
+                : false,
+            changedFields: [],
+            entityId: "manifestId" in item ? item.manifestId : item.canonicalIp,
+            entityKind:
+              "manifestId" in item
+                ? item.kind === "app"
+                  ? ("app" as const)
+                  : ("resource" as const)
+                : ("server" as const),
+            matchedPaths: [],
+            name: "name" in item ? item.name : item.canonicalIp,
+            reasons: ["No material configuration change"],
+          })),
+          status: "ready",
+          summary: {
+            archive: 0,
+            create: 0,
+            no_op: apps.length + resources.length + servers.length,
+            restore: 0,
+            update: 0,
+          },
+        },
+        pullRequestNumber: null,
+        targetCommitSha: source.latestCommitSha!,
+        targetManifestDigest: source.latestManifestDigest,
+        trigger: "manual",
+      };
+      deploymentPlans.unshift(plan);
+      return writeJson(response, 201, { plan });
     }
     if (
       request.method === "PATCH" &&
@@ -1051,6 +1170,7 @@ function getFixturePayload(
     [`/v1/core/sources/${source.id}/apps`, { apps }],
     [`/v1/core/sources/${source.id}/capacity`, { capacities: runtimeCapacity }],
     [`/v1/core/sources/${source.id}/previews`, { previews }],
+    [`/v1/core/sources/${source.id}/plans`, { plans: deploymentPlans }],
     [`/v1/core/sources/${source.id}/resources`, { resources }],
     [
       `/v1/core/sources/${source.id}/servers`,
@@ -1084,6 +1204,16 @@ function getFixturePayload(
   ]);
   const fixed = fixedPayloads.get(path);
   if (fixed !== undefined) return fixed;
+
+  const deploymentPlanMatch = path.match(
+    new RegExp(`^/v1/core/sources/${source.id}/plans/([^/]+)$`),
+  );
+  if (deploymentPlanMatch) {
+    const plan = deploymentPlans.find(
+      (item) => item.id === deploymentPlanMatch[1],
+    );
+    return plan ? { plan } : undefined;
+  }
 
   const deploymentMatch = path.match(
     /^\/v1\/core\/deployments\/([^/]+)(?:\/(steps|logs))?$/,

--- a/apps/towbar-web-app/src/app/sources/[sourceId]/plans/[planId]/page.tsx
+++ b/apps/towbar-web-app/src/app/sources/[sourceId]/plans/[planId]/page.tsx
@@ -1,0 +1,5 @@
+import { DeploymentPlanDetail } from "@/components/deployment-plan-detail";
+
+export default function Page() {
+  return <DeploymentPlanDetail />;
+}

--- a/apps/towbar-web-app/src/components/deployment-plan-detail.tsx
+++ b/apps/towbar-web-app/src/components/deployment-plan-detail.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { ValidationIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useParams } from "next/navigation";
+
+import type { DeploymentPlan } from "@workspace/towbar-web-client";
+import { Attributes } from "@workspace/web-design-system/data-display/attributes";
+import { TypographyCode } from "@workspace/web-design-system/typography/typography";
+import { QueryError, QueryLoading } from "@workspace/towbar-web-ui/query-state";
+import {
+  ResourceTable,
+  ResourceName,
+  type ResourceTableColumn,
+} from "@workspace/towbar-web-ui/resource-table";
+import {
+  formatStatus,
+  StatusBadge,
+} from "@workspace/towbar-web-ui/status-badge";
+
+import { DashboardPage } from "@/components/page-parts";
+import { useApiQuery } from "@/hooks/use-api-query";
+import { formatDate } from "./dashboard-overview";
+import { useSourceBreadcrumbs } from "./source-breadcrumbs";
+
+type PlanItem = DeploymentPlan["plan"]["items"][number];
+type PlanCheck = DeploymentPlan["plan"]["checks"][number];
+
+export function DeploymentPlanDetail() {
+  const { planId, sourceId } = useParams<{
+    planId: string;
+    sourceId: string;
+  }>();
+  const breadcrumbs = useSourceBreadcrumbs(sourceId, {
+    href: `/sources/${sourceId}?section=plans`,
+    label: "Plans",
+  });
+  const query = useApiQuery<{ plan: DeploymentPlan }>(
+    `/v1/core/sources/${sourceId}/plans/${planId}`,
+  );
+  if (query.error) {
+    return (
+      <DashboardPage breadcrumbAncestors={breadcrumbs} title="Deployment plan">
+        <QueryError message={query.error} />
+      </DashboardPage>
+    );
+  }
+  if (!query.data) {
+    return (
+      <DashboardPage breadcrumbAncestors={breadcrumbs} title="Deployment plan">
+        <QueryLoading />
+      </DashboardPage>
+    );
+  }
+
+  const plan = query.data.plan;
+  const itemColumns: ResourceTableColumn<PlanItem>[] = [
+    {
+      key: "entity",
+      header: "Planned change",
+      cell: (item) => (
+        <ResourceName
+          description={`${formatStatus(item.entityKind)} · ${item.entityId}`}
+          name={item.name}
+        />
+      ),
+      className: "min-w-56",
+    },
+    {
+      key: "action",
+      header: "Action",
+      cell: (item) => <StatusBadge status={item.action} />,
+    },
+    {
+      key: "reason",
+      header: "Reason",
+      cell: (item) => item.reasons.join(" · ") || "No material change",
+      className: "min-w-72",
+    },
+    {
+      key: "fields",
+      header: "Changed fields",
+      cell: (item) =>
+        item.changedFields.length > 0 ? (
+          <span className="flex max-w-xl flex-wrap gap-1">
+            {item.changedFields.map((field) => (
+              <TypographyCode key={field}>{field}</TypographyCode>
+            ))}
+          </span>
+        ) : (
+          "—"
+        ),
+      className: "min-w-56",
+    },
+    {
+      key: "paths",
+      header: "Matched paths",
+      cell: (item) => item.matchedPaths.join(", ") || "—",
+      className: "min-w-56",
+    },
+  ];
+  const checkColumns: ResourceTableColumn<PlanCheck>[] = [
+    {
+      key: "check",
+      header: "Validation",
+      cell: (check) => (
+        <ResourceName description={check.code} name={check.message} />
+      ),
+      className: "min-w-72",
+    },
+    {
+      key: "status",
+      header: "Result",
+      cell: (check) => <StatusBadge status={check.status} />,
+    },
+    {
+      key: "scope",
+      header: "Scope",
+      cell: (check) =>
+        [check.entityKind, check.entityId].filter(Boolean).join(" · ") ||
+        "Source",
+      className: "min-w-44",
+    },
+    {
+      key: "references",
+      header: "References",
+      cell: (check) => check.references?.join(", ") || "—",
+      className: "min-w-56",
+    },
+  ];
+
+  return (
+    <DashboardPage
+      badge={<StatusBadge status={plan.status} />}
+      breadcrumbAncestors={breadcrumbs}
+      breadcrumbLabel={`Plan ${plan.id.slice(0, 8)}`}
+      title={`Deployment plan ${plan.id.slice(0, 8)}`}
+      titleContent={
+        <span className="inline-flex min-w-0 items-center gap-2">
+          <HugeiconsIcon
+            aria-hidden="true"
+            className="size-6 shrink-0"
+            icon={ValidationIcon}
+          />
+          <span>Deployment plan</span>
+          <TypographyCode title={plan.id}>{plan.id.slice(0, 8)}</TypographyCode>
+        </span>
+      }
+    >
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Attributes columns={2} title="Comparison" variant="card">
+          <Attributes.Item label="Trigger">
+            {plan.trigger === "pull_request" ? "Pull request" : "Manual"}
+          </Attributes.Item>
+          <Attributes.Item label="Pull request">
+            {plan.pullRequestNumber ? `#${plan.pullRequestNumber}` : "—"}
+          </Attributes.Item>
+          <Attributes.Item label="Current commit">
+            {plan.currentCommitSha ? (
+              <TypographyCode title={plan.currentCommitSha}>
+                {plan.currentCommitSha.slice(0, 12)}
+              </TypographyCode>
+            ) : (
+              "None"
+            )}
+          </Attributes.Item>
+          <Attributes.Item label="Target commit">
+            <TypographyCode title={plan.targetCommitSha}>
+              {plan.targetCommitSha.slice(0, 12)}
+            </TypographyCode>
+          </Attributes.Item>
+          <Attributes.Item label="Branch">{plan.branch}</Attributes.Item>
+          <Attributes.Item label="Created">
+            {formatDate(plan.createdAt)}
+          </Attributes.Item>
+        </Attributes>
+        <Attributes columns={2} title="Manifest identity" variant="card">
+          <Attributes.Item label="Current digest">
+            {plan.currentManifestDigest ? (
+              <TypographyCode title={plan.currentManifestDigest}>
+                {plan.currentManifestDigest.slice(0, 12)}
+              </TypographyCode>
+            ) : (
+              "None"
+            )}
+          </Attributes.Item>
+          <Attributes.Item label="Target digest">
+            {plan.targetManifestDigest ? (
+              <TypographyCode title={plan.targetManifestDigest}>
+                {plan.targetManifestDigest.slice(0, 12)}
+              </TypographyCode>
+            ) : (
+              "Unavailable"
+            )}
+          </Attributes.Item>
+          <Attributes.Item label="GitHub Check">
+            {plan.trigger === "pull_request" ? (
+              <span className="grid gap-1">
+                <StatusBadge status={plan.githubCheckStatus ?? "pending"} />
+                {plan.githubCheckError ? (
+                  <span className="text-muted typography--body-xs">
+                    {plan.githubCheckError}
+                  </span>
+                ) : null}
+              </span>
+            ) : (
+              "Not applicable"
+            )}
+          </Attributes.Item>
+          <Attributes.Item label="Plan ID">
+            <TypographyCode>{plan.id}</TypographyCode>
+          </Attributes.Item>
+        </Attributes>
+      </div>
+      <ResourceTable
+        ariaLabel="Deployment plan validation"
+        columns={checkColumns}
+        emptyDescription="This comparison did not require additional validation checks."
+        emptyTitle="No validation checks"
+        getRowKey={(check) =>
+          [check.code, check.entityKind, check.entityId]
+            .filter(Boolean)
+            .join(":")
+        }
+        items={plan.plan.checks}
+      />
+      <ResourceTable
+        ariaLabel="Planned deployment changes"
+        columns={itemColumns}
+        emptyDescription="No app, resource, or server matched the pull request change patterns."
+        emptyTitle="No deployment-relevant changes"
+        getRowKey={(item) => `${item.entityKind}:${item.entityId}`}
+        items={plan.plan.items}
+      />
+    </DashboardPage>
+  );
+}

--- a/apps/towbar-web-app/src/components/github-settings.tsx
+++ b/apps/towbar-web-app/src/components/github-settings.tsx
@@ -56,6 +56,12 @@ export function GitHubSettings() {
     connection !== null &&
     previewPermissionState === "available" &&
     connection.permissionReadiness.preview === "ready";
+  const planningPermissionsReady =
+    connection !== null &&
+    previewPermissionState === "available" &&
+    connection.permissionReadiness.planning === "ready";
+  const reportingPermissionsReady =
+    previewPermissionsReady && planningPermissionsReady;
   const action = connection ? (
     connection.suspendedAt ? (
       <ActionButton
@@ -127,19 +133,19 @@ export function GitHubSettings() {
           </Alert.Content>
         </Alert>
       ) : null}
-      {!connection.suspendedAt && !previewPermissionsReady ? (
+      {!connection.suspendedAt && !reportingPermissionsReady ? (
         <Alert status="warning">
           <Alert.Indicator />
           <Alert.Content>
             <Alert.Title>
               {previewPermissionState === "unavailable"
                 ? "GitHub permissions could not be verified"
-                : "Preview reporting needs additional permissions"}
+                : "GitHub reporting needs additional permissions"}
             </Alert.Title>
             <Alert.Description>
               {previewPermissionState === "unavailable"
                 ? "Towbar could not confirm the installation permissions. Try again before relying on Preview status reporting."
-                : "Grant Pull requests and Deployments read and write access so Towbar can publish Preview statuses and keep one status comment updated on each pull request."}
+                : "Grant Checks, Pull requests, and Deployments read and write access, plus Contents read access. Towbar uses them for deployment-plan Checks and Preview reporting."}
             </Alert.Description>
           </Alert.Content>
         </Alert>
@@ -164,9 +170,14 @@ export function GitHubSettings() {
             status={previewPermissionsReady ? "ready" : "attention"}
           />
         </Attributes.Item>
+        <Attributes.Item label="Deployment plans">
+          <StatusBadge
+            status={planningPermissionsReady ? "ready" : "attention"}
+          />
+        </Attributes.Item>
       </Attributes>
       <div className="flex flex-wrap gap-3">
-        {!connection.suspendedAt && !previewPermissionsReady ? (
+        {!connection.suspendedAt && !reportingPermissionsReady ? (
           <ActionButton
             action={openGitHubInstallation}
             success="Opening GitHub"
@@ -183,8 +194,9 @@ export function GitHubSettings() {
         <EmptyState.Title>GitHub not connected</EmptyState.Title>
         <EmptyState.Description className="max-w-md text-pretty">
           Install the GitHub App and choose only the repositories Towbar should
-          manage. Towbar writes only Preview deployment statuses and the single
-          status comment it maintains for each pull request.
+          manage. Towbar writes deployment-plan Checks, Preview deployment
+          statuses, and the single status comment it maintains for each pull
+          request.
         </EmptyState.Description>
       </EmptyState.Header>
       <EmptyState.Content>{action}</EmptyState.Content>

--- a/apps/towbar-web-app/src/components/source-detail.tsx
+++ b/apps/towbar-web-app/src/components/source-detail.tsx
@@ -7,6 +7,7 @@ import {
   InformationSquareIcon,
   ServerStack01Icon,
   Settings01Icon,
+  ValidationIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
@@ -51,6 +52,7 @@ import { formatDate } from "./dashboard-overview";
 import { SourceAwsCredentials } from "./source-aws-credentials";
 import { SourceSecretStageEditor } from "./app-secrets";
 import { SourceApps, SourceResources, SourceServers } from "./source-inventory";
+import { SourcePlans } from "./source-plans";
 
 type ManifestResponse = {
   manifest: {
@@ -269,6 +271,12 @@ export function SourceDetail() {
                 sourceId={sourceId}
               />
             ),
+          },
+          {
+            value: "plans",
+            label: "Plans",
+            icon: <HugeiconsIcon icon={ValidationIcon} />,
+            content: <SourcePlans sourceId={sourceId} />,
           },
           {
             value: "info",

--- a/apps/towbar-web-app/src/components/source-plans.tsx
+++ b/apps/towbar-web-app/src/components/source-plans.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import type { DeploymentPlan } from "@workspace/towbar-web-client";
+import { TypographyCode } from "@workspace/web-design-system/typography/typography";
+import { QueryError, QueryLoading } from "@workspace/towbar-web-ui/query-state";
+import {
+  ResourceTable,
+  type ResourceTableColumn,
+} from "@workspace/towbar-web-ui/resource-table";
+import { StatusBadge } from "@workspace/towbar-web-ui/status-badge";
+
+import { useApiQuery } from "@/hooks/use-api-query";
+import { api } from "@/lib/api";
+import { ActionButton } from "./page-parts";
+import { formatDate } from "./dashboard-overview";
+
+export function SourcePlans({ sourceId }: { sourceId: string }) {
+  const router = useRouter();
+  const query = useApiQuery<{ plans: DeploymentPlan[] }>(
+    `/v1/core/sources/${sourceId}/plans`,
+    5_000,
+  );
+  if (query.error) return <QueryError message={query.error} />;
+  if (!query.data) return <QueryLoading />;
+  const columns: ResourceTableColumn<DeploymentPlan>[] = [
+    {
+      key: "revision",
+      header: "Target",
+      cell: (plan) => (
+        <span className="grid gap-0.5">
+          <TypographyCode>{plan.targetCommitSha.slice(0, 12)}</TypographyCode>
+          <span className="text-muted typography--body-xs font-normal">
+            {plan.pullRequestNumber
+              ? `PR #${plan.pullRequestNumber}`
+              : plan.branch}
+          </span>
+        </span>
+      ),
+      className: "min-w-40",
+    },
+    {
+      key: "trigger",
+      header: "Trigger",
+      cell: (plan) =>
+        plan.trigger === "pull_request" ? "Pull request" : "Manual",
+    },
+    {
+      key: "changes",
+      header: "Changes",
+      cell: (plan) => summarizeChanges(plan),
+      className: "min-w-52",
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (plan) => <StatusBadge status={plan.status} />,
+    },
+    {
+      key: "created",
+      header: "Created",
+      cell: (plan) => formatDate(plan.createdAt),
+      className: "whitespace-nowrap",
+    },
+  ];
+  return (
+    <div className="grid gap-4">
+      <div className="flex justify-end">
+        <ActionButton
+          action={() =>
+            api.post<{ plan: DeploymentPlan }>(
+              `/v1/core/sources/${sourceId}/actions/plan`,
+            )
+          }
+          onSuccess={({ plan }) =>
+            router.push(`/sources/${sourceId}/plans/${plan.id}`)
+          }
+          pendingLabel="Generating…"
+          success="Deployment plan generated"
+          variant="primary"
+        >
+          Generate plan
+        </ActionButton>
+      </div>
+      <ResourceTable
+        ariaLabel="Deployment plans"
+        columns={columns}
+        emptyAction={
+          <ActionButton
+            action={() =>
+              api.post<{ plan: DeploymentPlan }>(
+                `/v1/core/sources/${sourceId}/actions/plan`,
+              )
+            }
+            onSuccess={({ plan }) =>
+              router.push(`/sources/${sourceId}/plans/${plan.id}`)
+            }
+            pendingLabel="Generating…"
+            success="Deployment plan generated"
+          >
+            Generate first plan
+          </ActionButton>
+        }
+        emptyDescription="Generate a read-only comparison before changing this Source. Pull requests also publish their plan as one GitHub Check."
+        emptyTitle="No deployment plans"
+        getRowHref={(plan) => `/sources/${sourceId}/plans/${plan.id}`}
+        getRowKey={(plan) => plan.id}
+        items={query.data.plans}
+      />
+    </div>
+  );
+}
+
+function summarizeChanges(plan: DeploymentPlan) {
+  const summary = plan.plan.summary;
+  const changes = [
+    summary.create ? `${summary.create} create` : null,
+    summary.update ? `${summary.update} update` : null,
+    summary.restore ? `${summary.restore} restore` : null,
+    summary.archive ? `${summary.archive} archive` : null,
+    summary.no_op ? `${summary.no_op} no-op` : null,
+  ].filter(Boolean);
+  return changes.length > 0 ? changes.join(" · ") : "No relevant changes";
+}

--- a/apps/towbar-web-app/src/components/source-plans.tsx
+++ b/apps/towbar-web-app/src/components/source-plans.tsx
@@ -1,9 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-
 import type { DeploymentPlan } from "@workspace/towbar-web-client";
-import { TypographyCode } from "@workspace/web-design-system/typography/typography";
 import { QueryError, QueryLoading } from "@workspace/towbar-web-ui/query-state";
 import {
   ResourceTable,
@@ -12,12 +9,9 @@ import {
 import { StatusBadge } from "@workspace/towbar-web-ui/status-badge";
 
 import { useApiQuery } from "@/hooks/use-api-query";
-import { api } from "@/lib/api";
-import { ActionButton } from "./page-parts";
 import { formatDate } from "./dashboard-overview";
 
 export function SourcePlans({ sourceId }: { sourceId: string }) {
-  const router = useRouter();
   const query = useApiQuery<{ plans: DeploymentPlan[] }>(
     `/v1/core/sources/${sourceId}/plans`,
     5_000,
@@ -26,25 +20,11 @@ export function SourcePlans({ sourceId }: { sourceId: string }) {
   if (!query.data) return <QueryLoading />;
   const columns: ResourceTableColumn<DeploymentPlan>[] = [
     {
-      key: "revision",
-      header: "Target",
-      cell: (plan) => (
-        <span className="grid gap-0.5">
-          <TypographyCode>{plan.targetCommitSha.slice(0, 12)}</TypographyCode>
-          <span className="text-muted typography--body-xs font-normal">
-            {plan.pullRequestNumber
-              ? `PR #${plan.pullRequestNumber}`
-              : plan.branch}
-          </span>
-        </span>
-      ),
-      className: "min-w-40",
-    },
-    {
-      key: "trigger",
-      header: "Trigger",
+      key: "pull-request",
+      header: "Pull request",
       cell: (plan) =>
-        plan.trigger === "pull_request" ? "Pull request" : "Manual",
+        plan.pullRequestNumber ? `PR #${plan.pullRequestNumber}` : "—",
+      className: "min-w-36",
     },
     {
       key: "changes",
@@ -65,44 +45,11 @@ export function SourcePlans({ sourceId }: { sourceId: string }) {
     },
   ];
   return (
-    <div className="grid gap-4">
-      <div className="flex justify-end">
-        <ActionButton
-          action={() =>
-            api.post<{ plan: DeploymentPlan }>(
-              `/v1/core/sources/${sourceId}/actions/plan`,
-            )
-          }
-          onSuccess={({ plan }) =>
-            router.push(`/sources/${sourceId}/plans/${plan.id}`)
-          }
-          pendingLabel="Generating…"
-          success="Deployment plan generated"
-          variant="primary"
-        >
-          Generate plan
-        </ActionButton>
-      </div>
+    <div>
       <ResourceTable
         ariaLabel="Deployment plans"
         columns={columns}
-        emptyAction={
-          <ActionButton
-            action={() =>
-              api.post<{ plan: DeploymentPlan }>(
-                `/v1/core/sources/${sourceId}/actions/plan`,
-              )
-            }
-            onSuccess={({ plan }) =>
-              router.push(`/sources/${sourceId}/plans/${plan.id}`)
-            }
-            pendingLabel="Generating…"
-            success="Deployment plan generated"
-          >
-            Generate first plan
-          </ActionButton>
-        }
-        emptyDescription="Generate a read-only comparison before changing this Source. Pull requests also publish their plan as one GitHub Check."
+        emptyDescription="Deployment-relevant pull requests publish a GitHub Check linked to their plan in Towbar."
         emptyTitle="No deployment plans"
         getRowHref={(plan) => `/sources/${sourceId}/plans/${plan.id}`}
         getRowKey={(plan) => plan.id}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,6 +31,15 @@ connects to the target Ubuntu host over SSH, builds or pulls the requested
 image, starts a replacement container, verifies health, updates the proxy, and
 retains only the configured release set.
 
+Deployment planning is an API-owned, read-only path before admission. It
+normalizes a candidate manifest, compares it with the active Source inventory,
+calculates effective deployment-input digests, and persists the deterministic
+result with both manifest identities. Plan validation reads server observations
+and credential metadata but never secret values. It cannot enqueue Temporal
+work or mutate Source inventory. Pull request reconciliation reports this same
+plan through one idempotent GitHub Check Run; the Check links back to the
+immutable plan while Preview reconciliation continues independently.
+
 For an App with Preview enabled, a relevant same-repository pull request event
 signals one durable workflow per Source and pull request. The API reads current
 GitHub state and changed files before reconciling. Apps with path-aware

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,7 @@ a Source. Configure a GitHub App with:
 
 - Repository contents: read-only
 - Repository metadata: read-only
+- Checks: read and write (required for deployment-plan reporting)
 - Pull requests: read and write (required for Preview deployments and their PR status comment)
 - Deployments: read and write (required for Preview deployment statuses)
 - Webhook events: push, pull request, and installation
@@ -55,8 +56,9 @@ a Source. Configure a GitHub App with:
 - Setup URL with redirect enabled:
   `${TOWBAR_APP_BASE_URL}/settings?section=github`
 
-Existing installations must approve the Pull requests permission upgrade before
-Towbar can create or update the Preview status comment.
+Existing installations must approve the Checks and Pull requests permission
+upgrades before Towbar can publish deployment-plan Checks or update the Preview
+status comment.
 
 Encode the downloaded PEM without line wrapping:
 
@@ -115,12 +117,37 @@ through a no-store response while editing them. Towbar performs the merge in
 the API, checks the expected AWS version before writing, and does not persist
 secret values in PostgreSQL or logs. Shared references show every affected App
 or Resource before an operator edits them. This flow requires narrowly scoped
-`secretsmanager:GetSecretValue` and `secretsmanager:PutSecretValue` permissions;
-changing the reference itself still requires a manifest commit and Source sync.
+`secretsmanager:DescribeSecret`, `secretsmanager:GetSecretValue`, and
+`secretsmanager:PutSecretValue` permissions; changing the reference itself
+still requires a manifest commit and Source sync.
 
 The current deployment schema is served by the configured website at
 `${TOWBAR_WEBSITE_BASE_URL}/schemas/deployment.v1.json` and documented under
 `${TOWBAR_WEBSITE_BASE_URL}/docs/deployment-file`.
+
+## Deployment plans
+
+Source **Plans** are side-effect-free comparisons between an immutable
+candidate commit and the Source's currently materialized inventory. Generating
+a manual plan fetches the configured branch but does not sync, archive, deploy,
+resolve secret values, or change a server. The plan stores the current and
+target manifest digests, then classifies every App, Resource, and Server as
+create, update, archive, restore, or no-op.
+
+Validation covers manifest schema, domain ownership, Source branch alignment,
+server preparation and observed capacity, declared secret references by name,
+and conflicting active operations. Secret bindings are checked with
+`secretsmanager:DescribeSecret`; secret values are never fetched for a plan.
+A failed validation marks the plan **Blocked** and includes an actionable
+message; warnings remain visible without blocking the comparison.
+
+For a same-repository pull request targeting the Source branch, Towbar creates
+the same comparison against the PR head commit and publishes one completed
+`Towbar deployment plan` Check Run for that commit. App rows respect
+`autoDeploy.inputs`; unrelated paths do not create irrelevant plan rows. The
+Check links to the immutable plan detail page. Repeated webhook deliveries
+update the existing Check instead of creating another one. Plan generation is
+observational and never gates or orders Preview or production deployments.
 
 ## Preview deployments
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,6 +88,7 @@ Create one GitHub App for this Towbar installation:
 
 - Repository contents: read-only
 - Repository metadata: read-only
+- Checks: read and write (required for deployment-plan reporting)
 - Pull requests: read and write (required for Preview deployments and their PR status comment)
 - Deployments: read and write (required when using Preview deployments)
 - Webhook events: `push`, `pull_request`, and `installation`
@@ -148,11 +149,12 @@ Store the SSH private key in AWS Secrets Manager as a JSON object:
 ```
 
 The Source's AWS identity needs `sts:GetCallerIdentity` and
-`secretsmanager:GetSecretValue` only for the secret paths declared by that
-Source. To edit App environment bundles from the App's **Secrets** tab, also
-grant `secretsmanager:PutSecretValue` only on those specific build, deployment,
-and hook secret ARNs. Server login and Cloudflare credentials do not need write
-permission. Add narrowly scoped S3 permissions only when using managed backups.
+`secretsmanager:DescribeSecret` and `secretsmanager:GetSecretValue` only for the
+secret paths declared by that Source. To edit App environment bundles from the
+App's **Secrets** tab, also grant `secretsmanager:PutSecretValue` only on those
+specific build, deployment, and hook secret ARNs. Server login and Cloudflare
+credentials do not need write permission. Add narrowly scoped S3 permissions
+only when using managed backups.
 
 ## 5. Add the deployment manifest
 
@@ -200,7 +202,13 @@ unclear.
 
 ## 7. Make the first deployment
 
-Open **Source → Apps**, select the imported app, and choose **Deploy**. Towbar
+Before changing the server, open **Source → Plans** and choose **Generate
+plan**. Confirm the candidate commit and manifest digest, review every planned
+change and explicit no-op, and resolve any blocking validation. Generating the
+plan is read-only: it does not sync, deploy, archive, restore, or resolve secret
+values.
+
+Then open **Source → Apps**, select the imported app, and choose **Deploy**. Towbar
 queues the operation, fetches the immutable Git commit, transfers the selected
 build context, builds on the target, checks health, configures Caddy, and
 promotes the candidate.
@@ -216,7 +224,8 @@ A working installation has all of the following:
 After the manual deployment succeeds, push a change matching
 `autoDeploy.inputs`. The GitHub delivery, Source sync, and deployment should
 appear independently in Towbar; a successful sync alone does not imply a
-successful deployment.
+successful deployment. A deployment-relevant pull request also receives one
+`Towbar deployment plan` GitHub Check linked to the immutable comparison.
 
 ## Useful diagnostics
 

--- a/packages/towbar-core/README.md
+++ b/packages/towbar-core/README.md
@@ -43,6 +43,13 @@ such as `autoDeploy`, `deploymentInputs`, and `sourceBranch` do not change the
 runtime digest. A truncated Git tree falls back to commit-sensitive deployment
 rather than risking a false skip.
 
+Deployment planning is deterministic domain logic in this package. Given the
+same normalized candidate, materialized inventory, repository changes, target
+deployment digests, and validation checks, it emits the same ordered plan.
+Full plans include explicit no-op rows; pull-request plans omit deployables
+whose input patterns and configuration are unchanged. The plan reports field
+paths and reasons, never field values or mutable inventory objects.
+
 Root `secrets.build` and `secrets.deployment` arrays declare Source-wide JSON
 environment bundles. Apps merge those with their own bundles; app keys override
 shared keys, while duplicate keys between shared bundles fail closed.

--- a/packages/towbar-core/src/deployment-inputs.ts
+++ b/packages/towbar-core/src/deployment-inputs.ts
@@ -33,6 +33,18 @@ export function shouldDeployForChangedPaths(input: {
   );
 }
 
+export function getMatchingChangedPaths(input: {
+  changedPaths: RepositoryChangedPaths;
+  deploymentInputs: string[];
+}) {
+  if (!input.changedPaths.complete || input.deploymentInputs.length === 0) {
+    return [];
+  }
+  return [...new Set(input.changedPaths.paths)]
+    .filter((path) => matchesDeploymentInput(path, input.deploymentInputs))
+    .sort((left, right) => left.localeCompare(right));
+}
+
 export function selectDeploymentInputEntries(
   inputs: string[],
   tree: RepositoryTree,

--- a/packages/towbar-core/src/deployment-plan.test.ts
+++ b/packages/towbar-core/src/deployment-plan.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { digestValue, normalizeDeploymentManifest } from "./manifest.js";
+import {
+  buildBlockedDeploymentPlan,
+  buildDeploymentPlan,
+  changedFieldPaths,
+} from "./deployment-plan.js";
+
+const manifest = normalizeDeploymentManifest({
+  version: 1,
+  servers: [
+    {
+      ip: "192.0.2.10",
+      secrets: { login: "aws:server/login" },
+      ssh: { username: "deploy" },
+    },
+  ],
+  apps: [
+    {
+      id: "website",
+      name: "Website",
+      server: "192.0.2.10",
+      autoDeploy: { inputs: ["apps/website/**"] },
+      container: { port: 3000 },
+      context: ".",
+      dockerfile: "apps/website/Dockerfile",
+      domains: { primary: "example.test" },
+      health: { path: "/health" },
+    },
+  ],
+});
+
+const currentServer = {
+  archivedAt: null,
+  config: manifest.servers[0]!,
+  configDigest: digestValue(manifest.servers[0]),
+  id: "server-id",
+  identity: "192.0.2.10",
+};
+const currentApp = {
+  archivedAt: null,
+  config: manifest.apps[0]!,
+  configDigest: digestValue(manifest.apps[0]),
+  deploymentDigest: "old-digest",
+  id: "app-id",
+  identity: "website",
+};
+
+void test("builds a deterministic full plan with explicit no-op rows", () => {
+  const input = {
+    currentApps: [currentApp],
+    currentResources: [],
+    currentServers: [currentServer],
+    desired: manifest,
+    mode: "full" as const,
+    targetDeploymentDigests: new Map([["website", "old-digest"]]),
+  };
+  const first = buildDeploymentPlan(input);
+  const second = buildDeploymentPlan(input);
+
+  assert.deepEqual(first, second);
+  assert.deepEqual(first.summary, {
+    archive: 0,
+    create: 0,
+    no_op: 2,
+    restore: 0,
+    update: 0,
+  });
+  assert.deepEqual(
+    first.items.map(({ action, entityId, entityKind }) => ({
+      action,
+      entityId,
+      entityKind,
+    })),
+    [
+      { action: "no_op", entityId: "website", entityKind: "app" },
+      { action: "no_op", entityId: "192.0.2.10", entityKind: "server" },
+    ],
+  );
+});
+
+void test("promotes a matching pull request path to an update", () => {
+  const plan = buildDeploymentPlan({
+    currentApps: [currentApp],
+    currentResources: [],
+    currentServers: [currentServer],
+    desired: manifest,
+    mode: "pull_request",
+    repositoryChanges: {
+      complete: true,
+      paths: ["README.md", "apps/website/src/page.tsx"],
+    },
+    targetDeploymentDigests: new Map([["website", "new-digest"]]),
+  });
+
+  assert.deepEqual(plan.items, [
+    {
+      action: "update",
+      automaticDeployment: true,
+      changedFields: [],
+      entityId: "website",
+      entityKind: "app",
+      matchedPaths: ["apps/website/src/page.tsx"],
+      name: "Website",
+      reasons: ["Changed paths match this deployable's deployment inputs"],
+    },
+  ]);
+});
+
+void test("omits irrelevant pull request no-op rows", () => {
+  const plan = buildDeploymentPlan({
+    currentApps: [currentApp],
+    currentResources: [],
+    currentServers: [currentServer],
+    desired: manifest,
+    mode: "pull_request",
+    repositoryChanges: { complete: true, paths: ["README.md"] },
+    targetDeploymentDigests: new Map([["website", "old-digest"]]),
+  });
+
+  assert.deepEqual(plan.items, []);
+  assert.deepEqual(plan.summary, {
+    archive: 0,
+    create: 0,
+    no_op: 0,
+    restore: 0,
+    update: 0,
+  });
+});
+
+void test("reports changed fields without returning field values", () => {
+  assert.deepEqual(
+    changedFieldPaths(
+      { domains: { primary: "old.example" }, secrets: { build: "old" } },
+      { domains: { primary: "new.example" }, secrets: { build: "new" } },
+    ),
+    ["domains.primary", "secrets.build"],
+  );
+});
+
+void test("sorts blocking checks and exposes no mutable inventory", () => {
+  const plan = buildBlockedDeploymentPlan([
+    { code: "warning", message: "Warning", status: "warning" },
+    { code: "schema", message: "Invalid", status: "failed" },
+  ]);
+  assert.equal(plan.status, "blocked");
+  assert.equal(plan.checks[0]?.code, "schema");
+  assert.deepEqual(plan.items, []);
+});

--- a/packages/towbar-core/src/deployment-plan.ts
+++ b/packages/towbar-core/src/deployment-plan.ts
@@ -1,0 +1,310 @@
+import { getMatchingChangedPaths } from "./deployment-inputs.js";
+import { reconcileManifest } from "./reconciliation.js";
+
+import type {
+  DeploymentPlan,
+  DeploymentPlanAction,
+  DeploymentPlanCheck,
+  DeploymentPlanEntityKind,
+  DeploymentPlanItem,
+  DeploymentPlanSummary,
+  MaterializedDeploymentPlanEntity,
+} from "./deployment-plan.types.js";
+import type { RepositoryChangedPaths } from "./deployment-inputs.js";
+import type {
+  NormalizedApp,
+  NormalizedDeployable,
+  NormalizedDeploymentManifest,
+  NormalizedResource,
+  NormalizedServer,
+} from "./manifest.js";
+import type { ReconciliationAction } from "./reconciliation.js";
+
+export type {
+  DeploymentPlan,
+  DeploymentPlanAction,
+  DeploymentPlanCheck,
+  DeploymentPlanCheckStatus,
+  DeploymentPlanEntityKind,
+  DeploymentPlanItem,
+  DeploymentPlanStatus,
+  DeploymentPlanSummary,
+  MaterializedDeploymentPlanEntity,
+} from "./deployment-plan.types.js";
+
+export function buildDeploymentPlan(input: {
+  checks?: DeploymentPlanCheck[];
+  currentApps: Array<MaterializedDeploymentPlanEntity<NormalizedApp>>;
+  currentResources: Array<MaterializedDeploymentPlanEntity<NormalizedResource>>;
+  currentServers: Array<MaterializedDeploymentPlanEntity<NormalizedServer>>;
+  desired: NormalizedDeploymentManifest;
+  mode: "full" | "pull_request";
+  repositoryChanges?: RepositoryChangedPaths;
+  targetDeploymentDigests: Map<string, string>;
+}): DeploymentPlan {
+  const reconciliation = reconcileManifest({
+    currentApps: input.currentApps,
+    currentResources: input.currentResources,
+    currentServers: input.currentServers,
+    desired: input.desired,
+  });
+  const items = [
+    ...reconciliation.apps.map((action) =>
+      planDeployableAction({
+        action,
+        current: input.currentApps,
+        entityKind: "app",
+        repositoryChanges: input.repositoryChanges,
+        targetDeploymentDigests: input.targetDeploymentDigests,
+      }),
+    ),
+    ...reconciliation.resources.map((action) =>
+      planDeployableAction({
+        action,
+        current: input.currentResources,
+        entityKind: "resource",
+        repositoryChanges: input.repositoryChanges,
+        targetDeploymentDigests: input.targetDeploymentDigests,
+      }),
+    ),
+    ...reconciliation.servers.map((action) =>
+      planServerAction(action, input.currentServers),
+    ),
+  ]
+    .filter(
+      (item) =>
+        input.mode === "full" ||
+        item.action !== "no_op" ||
+        item.matchedPaths.length > 0,
+    )
+    .sort(comparePlanItems);
+  const checks = [...(input.checks ?? [])].sort(comparePlanChecks);
+  return {
+    checks,
+    items,
+    status: checks.some((check) => check.status === "failed")
+      ? "blocked"
+      : "ready",
+    summary: summarizePlanItems(items),
+  };
+}
+
+export function buildBlockedDeploymentPlan(
+  checks: DeploymentPlanCheck[],
+): DeploymentPlan {
+  const ordered = [...checks].sort(comparePlanChecks);
+  return {
+    checks: ordered,
+    items: [],
+    status: "blocked",
+    summary: emptyPlanSummary(),
+  };
+}
+
+export function changedFieldPaths(left: unknown, right: unknown) {
+  const paths: string[] = [];
+  visitChangedFields(left, right, "", paths);
+  return paths.sort((first, second) => first.localeCompare(second));
+}
+
+function planDeployableAction<T extends NormalizedDeployable>(input: {
+  action: ReconciliationAction<T>;
+  current: Array<MaterializedDeploymentPlanEntity<T>>;
+  entityKind: "app" | "resource";
+  repositoryChanges?: RepositoryChangedPaths;
+  targetDeploymentDigests: Map<string, string>;
+}): DeploymentPlanItem {
+  const current = input.current.find(
+    (candidate) => candidate.identity === input.action.id,
+  );
+  const desired = input.action.desired;
+  const name = desired?.name ?? current?.config.name ?? input.action.id;
+  const deploymentInputs =
+    input.entityKind === "app" && desired && "deploymentInputs" in desired
+      ? desired.deploymentInputs
+      : [];
+  const matchedPaths =
+    input.entityKind === "app" && desired && input.repositoryChanges
+      ? getMatchingChangedPaths({
+          changedPaths: input.repositoryChanges,
+          deploymentInputs,
+        })
+      : [];
+  const changedFields =
+    input.action.current && desired
+      ? changedFieldPaths(input.action.current.config, desired)
+      : [];
+  const automaticDeployment = desired?.autoDeploy ?? false;
+
+  if (input.action.action !== "unchanged") {
+    return {
+      action: input.action.action,
+      automaticDeployment,
+      changedFields,
+      entityId: input.action.id,
+      entityKind: input.entityKind,
+      matchedPaths,
+      name,
+      reasons: reconciliationReasons(input.action.action, changedFields),
+    };
+  }
+
+  const targetDigest = input.targetDeploymentDigests.get(input.action.id);
+  const deploymentInputChanged =
+    targetDigest !== undefined && targetDigest !== current?.deploymentDigest;
+  if (deploymentInputChanged && automaticDeployment) {
+    return {
+      action: "update",
+      automaticDeployment,
+      changedFields: [],
+      entityId: input.action.id,
+      entityKind: input.entityKind,
+      matchedPaths,
+      name,
+      reasons: [
+        matchedPaths.length > 0
+          ? "Changed paths match this deployable's deployment inputs"
+          : "The effective deployment input digest changed",
+      ],
+    };
+  }
+
+  return {
+    action: "no_op",
+    automaticDeployment,
+    changedFields: [],
+    entityId: input.action.id,
+    entityKind: input.entityKind,
+    matchedPaths,
+    name,
+    reasons: [
+      deploymentInputChanged
+        ? "Deployment inputs changed, but automatic deployment is disabled"
+        : "Configuration and deployment inputs are unchanged",
+    ],
+  };
+}
+
+function planServerAction(
+  action: ReconciliationAction<NormalizedServer>,
+  currentServers: Array<MaterializedDeploymentPlanEntity<NormalizedServer>>,
+): DeploymentPlanItem {
+  const current = currentServers.find(
+    (candidate) => candidate.identity === action.id,
+  );
+  const changedFields =
+    action.current && action.desired
+      ? changedFieldPaths(action.current.config, action.desired)
+      : [];
+  const planAction = normalizeAction(action.action);
+  return {
+    action: planAction,
+    automaticDeployment: false,
+    changedFields,
+    entityId: action.id,
+    entityKind: "server",
+    matchedPaths: [],
+    name: action.desired?.ip ?? current?.config.ip ?? action.id,
+    reasons:
+      planAction === "no_op"
+        ? ["Server configuration is unchanged"]
+        : reconciliationReasons(planAction, changedFields),
+  };
+}
+
+function reconciliationReasons(
+  action: Exclude<DeploymentPlanAction, "no_op">,
+  changedFields: string[],
+) {
+  switch (action) {
+    case "archive":
+      return ["The entity is absent from the candidate manifest"];
+    case "create":
+      return ["The entity is not present in the active Source inventory"];
+    case "restore":
+      return ["The entity reappears after being archived"];
+    case "update":
+      return [
+        changedFields.length > 0
+          ? `Configuration changed in ${changedFields.join(", ")}`
+          : "The effective deployment input digest changed",
+      ];
+  }
+}
+
+function normalizeAction(
+  action: ReconciliationAction<unknown>["action"],
+): DeploymentPlanAction {
+  return action === "unchanged" ? "no_op" : action;
+}
+
+function summarizePlanItems(items: DeploymentPlanItem[]) {
+  const summary = emptyPlanSummary();
+  for (const item of items) summary[item.action] += 1;
+  return summary;
+}
+
+function emptyPlanSummary(): DeploymentPlanSummary {
+  return { archive: 0, create: 0, no_op: 0, restore: 0, update: 0 };
+}
+
+function comparePlanItems(left: DeploymentPlanItem, right: DeploymentPlanItem) {
+  return (
+    entityKindOrder(left.entityKind) - entityKindOrder(right.entityKind) ||
+    left.entityId.localeCompare(right.entityId)
+  );
+}
+
+function entityKindOrder(kind: DeploymentPlanEntityKind) {
+  return kind === "app" ? 0 : kind === "resource" ? 1 : 2;
+}
+
+function comparePlanChecks(
+  left: DeploymentPlanCheck,
+  right: DeploymentPlanCheck,
+) {
+  return (
+    checkStatusOrder(left.status) - checkStatusOrder(right.status) ||
+    left.code.localeCompare(right.code) ||
+    (left.entityId ?? "").localeCompare(right.entityId ?? "") ||
+    left.message.localeCompare(right.message)
+  );
+}
+
+function checkStatusOrder(status: DeploymentPlanCheck["status"]) {
+  return status === "failed" ? 0 : status === "warning" ? 1 : 2;
+}
+
+function visitChangedFields(
+  left: unknown,
+  right: unknown,
+  path: string,
+  paths: string[],
+) {
+  if (Object.is(left, right)) return;
+  if (Array.isArray(left) && Array.isArray(right)) {
+    if (JSON.stringify(left) !== JSON.stringify(right)) {
+      paths.push(path || "value");
+    }
+    return;
+  }
+  if (isRecord(left) && isRecord(right)) {
+    const keys = [
+      ...new Set([...Object.keys(left), ...Object.keys(right)]),
+    ].sort((first, second) => first.localeCompare(second));
+    for (const key of keys) {
+      visitChangedFields(
+        left[key],
+        right[key],
+        path ? `${path}.${key}` : key,
+        paths,
+      );
+    }
+    return;
+  }
+  paths.push(path || "value");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/towbar-core/src/deployment-plan.types.ts
+++ b/packages/towbar-core/src/deployment-plan.types.ts
@@ -1,0 +1,47 @@
+import type {
+  NormalizedApp,
+  NormalizedResource,
+  NormalizedServer,
+} from "./manifest.js";
+import type { MaterializedManifestEntity } from "./reconciliation.js";
+
+export type DeploymentPlanAction =
+  "archive" | "create" | "no_op" | "restore" | "update";
+export type DeploymentPlanEntityKind = "app" | "resource" | "server";
+export type DeploymentPlanCheckStatus = "failed" | "passed" | "warning";
+export type DeploymentPlanStatus = "blocked" | "ready";
+
+export type DeploymentPlanItem = {
+  action: DeploymentPlanAction;
+  automaticDeployment: boolean;
+  changedFields: string[];
+  entityId: string;
+  entityKind: DeploymentPlanEntityKind;
+  matchedPaths: string[];
+  name: string;
+  reasons: string[];
+};
+
+export type DeploymentPlanCheck = {
+  code: string;
+  entityId?: string;
+  entityKind?: DeploymentPlanEntityKind | "source";
+  message: string;
+  references?: string[];
+  status: DeploymentPlanCheckStatus;
+};
+
+export type DeploymentPlanSummary = Record<DeploymentPlanAction, number>;
+
+export type DeploymentPlan = {
+  checks: DeploymentPlanCheck[];
+  items: DeploymentPlanItem[];
+  status: DeploymentPlanStatus;
+  summary: DeploymentPlanSummary;
+};
+
+export type MaterializedDeploymentPlanEntity<
+  T extends NormalizedApp | NormalizedResource | NormalizedServer,
+> = MaterializedManifestEntity<T> & {
+  deploymentDigest?: string | null;
+};

--- a/packages/towbar-core/src/index.ts
+++ b/packages/towbar-core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./deployment-inputs.js";
+export * from "./deployment-plan.js";
 export * from "./manifest.js";
 export * from "./preview.js";
 export * from "./reconciliation.js";

--- a/packages/towbar-database/README.md
+++ b/packages/towbar-database/README.md
@@ -24,4 +24,9 @@ releases carry an explicit environment and never update the production runtime
 observation row. Deleted Preview records remain as operational history while
 their runtime artifacts are removed durably.
 
+Deployment plans are immutable Source-scoped records keyed by a deterministic
+identity digest. They retain current and target commit and manifest identities
+plus the serialized comparison. Mutable GitHub Check delivery state lives in a
+separate one-to-one table so retries never rewrite the plan itself.
+
 [Packages](../README.md) · [Repository](../../README.md)

--- a/packages/towbar-database/drizzle/0028_sticky_infant_terrible.sql
+++ b/packages/towbar-database/drizzle/0028_sticky_infant_terrible.sql
@@ -1,0 +1,40 @@
+CREATE TYPE "public"."towbar_deployment_plan_delivery_status" AS ENUM('pending', 'published', 'failed');--> statement-breakpoint
+CREATE TYPE "public"."towbar_deployment_plan_status" AS ENUM('ready', 'blocked');--> statement-breakpoint
+CREATE TYPE "public"."towbar_deployment_plan_trigger" AS ENUM('manual', 'pull_request');--> statement-breakpoint
+CREATE TABLE "towbar_deployment_plan_github_checks" (
+	"plan_id" uuid PRIMARY KEY NOT NULL,
+	"check_run_id" varchar(40),
+	"status" "towbar_deployment_plan_delivery_status" DEFAULT 'pending' NOT NULL,
+	"error_message" varchar(1000),
+	"last_attempted_at" timestamp with time zone,
+	"published_at" timestamp with time zone,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "towbar_deployment_plans" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"workspace_id" uuid NOT NULL,
+	"source_id" uuid NOT NULL,
+	"requested_by" uuid,
+	"identity_digest" varchar(64) NOT NULL,
+	"trigger" "towbar_deployment_plan_trigger" NOT NULL,
+	"status" "towbar_deployment_plan_status" NOT NULL,
+	"pull_request_number" integer,
+	"branch" varchar(255) NOT NULL,
+	"current_commit_sha" varchar(64),
+	"target_commit_sha" varchar(64) NOT NULL,
+	"current_manifest_digest" varchar(64),
+	"target_manifest_digest" varchar(64),
+	"candidate_digest" varchar(64) NOT NULL,
+	"plan" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "chk_towbar_deployment_plans_trigger" CHECK (("towbar_deployment_plans"."trigger" = 'manual' AND "towbar_deployment_plans"."pull_request_number" IS NULL) OR ("towbar_deployment_plans"."trigger" = 'pull_request' AND "towbar_deployment_plans"."pull_request_number" IS NOT NULL))
+);
+--> statement-breakpoint
+ALTER TABLE "towbar_deployment_plan_github_checks" ADD CONSTRAINT "towbar_deployment_plan_github_checks_plan_id_towbar_deployment_plans_id_fk" FOREIGN KEY ("plan_id") REFERENCES "public"."towbar_deployment_plans"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "towbar_deployment_plans" ADD CONSTRAINT "towbar_deployment_plans_workspace_id_towbar_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."towbar_workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "towbar_deployment_plans" ADD CONSTRAINT "towbar_deployment_plans_source_id_towbar_sources_id_fk" FOREIGN KEY ("source_id") REFERENCES "public"."towbar_sources"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "towbar_deployment_plans" ADD CONSTRAINT "towbar_deployment_plans_requested_by_towbar_users_id_fk" FOREIGN KEY ("requested_by") REFERENCES "public"."towbar_users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_towbar_deployment_plan_checks_status" ON "towbar_deployment_plan_github_checks" USING btree ("status");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_towbar_deployment_plans_identity" ON "towbar_deployment_plans" USING btree ("source_id","identity_digest");--> statement-breakpoint
+CREATE INDEX "idx_towbar_deployment_plans_source_created" ON "towbar_deployment_plans" USING btree ("source_id","created_at");

--- a/packages/towbar-database/drizzle/meta/0028_snapshot.json
+++ b/packages/towbar-database/drizzle/meta/0028_snapshot.json
@@ -1,0 +1,4138 @@
+{
+  "id": "6784229d-f9b3-468e-80d0-606767aa032c",
+  "prevId": "e3009601-9d40-4307-9c7f-199dbe37995c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.towbar_apps": {
+      "name": "towbar_apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_id": {
+          "name": "manifest_id",
+          "type": "varchar(63)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "towbar_deployable_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'app'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_digest": {
+          "name": "config_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_digest": {
+          "name": "deployment_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_input_digest": {
+          "name": "source_input_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_apps_source_manifest_id": {
+          "name": "uq_towbar_apps_source_manifest_id",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "manifest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_apps_workspace": {
+          "name": "idx_towbar_apps_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_apps_server": {
+          "name": "idx_towbar_apps_server",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_apps_archived_at": {
+          "name": "idx_towbar_apps_archived_at",
+          "columns": [
+            {
+              "expression": "archived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_apps_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_apps_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_apps",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_apps_source_id_towbar_sources_id_fk": {
+          "name": "towbar_apps_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_apps",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_apps_server_id_towbar_servers_id_fk": {
+          "name": "towbar_apps_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_apps",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_audit_events": {
+      "name": "towbar_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_audit_workspace_created": {
+          "name": "idx_towbar_audit_workspace_created",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_audit_events_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_audit_events_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_audit_events",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_audit_events_actor_user_id_towbar_users_id_fk": {
+          "name": "towbar_audit_events_actor_user_id_towbar_users_id_fk",
+          "tableFrom": "towbar_audit_events",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_auth_rate_limit_buckets": {
+      "name": "towbar_auth_rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_auth_rate_limit_expires": {
+          "name": "idx_towbar_auth_rate_limit_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_deployable_runtime_states": {
+      "name": "towbar_deployable_runtime_states",
+      "schema": "",
+      "columns": {
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "desired_state": {
+          "name": "desired_state",
+          "type": "towbar_runtime_desired_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "observed_state": {
+          "name": "observed_state",
+          "type": "towbar_runtime_observed_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "health_status": {
+          "name": "health_status",
+          "type": "towbar_runtime_health_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "drift_status": {
+          "name": "drift_status",
+          "type": "towbar_runtime_drift_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "drift_reasons": {
+          "name": "drift_reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "observed_container_name": {
+          "name": "observed_container_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_image": {
+          "name": "observed_image",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_check_id": {
+          "name": "last_check_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_runtime_drift": {
+          "name": "idx_towbar_runtime_drift",
+          "columns": [
+            {
+              "expression": "drift_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_deployable_runtime_states_app_id_towbar_apps_id_fk": {
+          "name": "towbar_deployable_runtime_states_app_id_towbar_apps_id_fk",
+          "tableFrom": "towbar_deployable_runtime_states",
+          "tableTo": "towbar_apps",
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_deployable_runtime_states_last_check_id_towbar_server_checks_id_fk": {
+          "name": "towbar_deployable_runtime_states_last_check_id_towbar_server_checks_id_fk",
+          "tableFrom": "towbar_deployable_runtime_states",
+          "tableTo": "towbar_server_checks",
+          "columnsFrom": ["last_check_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_deployment_log_chunks": {
+      "name": "towbar_deployment_log_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stream": {
+          "name": "stream",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_deployment_logs_sequence": {
+          "name": "uq_towbar_deployment_logs_sequence",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_deployment_logs_created": {
+          "name": "idx_towbar_deployment_logs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_deployment_log_chunks_deployment_id_towbar_deployments_id_fk": {
+          "name": "towbar_deployment_log_chunks_deployment_id_towbar_deployments_id_fk",
+          "tableFrom": "towbar_deployment_log_chunks",
+          "tableTo": "towbar_deployments",
+          "columnsFrom": ["deployment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_deployment_plan_github_checks": {
+      "name": "towbar_deployment_plan_github_checks",
+      "schema": "",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "check_run_id": {
+          "name": "check_run_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_deployment_plan_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_at": {
+          "name": "last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_deployment_plan_checks_status": {
+          "name": "idx_towbar_deployment_plan_checks_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_deployment_plan_github_checks_plan_id_towbar_deployment_plans_id_fk": {
+          "name": "towbar_deployment_plan_github_checks_plan_id_towbar_deployment_plans_id_fk",
+          "tableFrom": "towbar_deployment_plan_github_checks",
+          "tableTo": "towbar_deployment_plans",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_deployment_plans": {
+      "name": "towbar_deployment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_digest": {
+          "name": "identity_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "towbar_deployment_plan_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_deployment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_commit_sha": {
+          "name": "current_commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_commit_sha": {
+          "name": "target_commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_manifest_digest": {
+          "name": "current_manifest_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_manifest_digest": {
+          "name": "target_manifest_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_digest": {
+          "name": "candidate_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_deployment_plans_identity": {
+          "name": "uq_towbar_deployment_plans_identity",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identity_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_deployment_plans_source_created": {
+          "name": "idx_towbar_deployment_plans_source_created",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_deployment_plans_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_deployment_plans_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_deployment_plans",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_deployment_plans_source_id_towbar_sources_id_fk": {
+          "name": "towbar_deployment_plans_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_deployment_plans",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_deployment_plans_requested_by_towbar_users_id_fk": {
+          "name": "towbar_deployment_plans_requested_by_towbar_users_id_fk",
+          "tableFrom": "towbar_deployment_plans",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["requested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_towbar_deployment_plans_trigger": {
+          "name": "chk_towbar_deployment_plans_trigger",
+          "value": "(\"towbar_deployment_plans\".\"trigger\" = 'manual' AND \"towbar_deployment_plans\".\"pull_request_number\" IS NULL) OR (\"towbar_deployment_plans\".\"trigger\" = 'pull_request' AND \"towbar_deployment_plans\".\"pull_request_number\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.towbar_deployment_steps": {
+      "name": "towbar_deployment_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "towbar_deployment_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_deployment_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_deployment_steps_sequence": {
+          "name": "uq_towbar_deployment_steps_sequence",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_deployment_steps_deployment_id_towbar_deployments_id_fk": {
+          "name": "towbar_deployment_steps_deployment_id_towbar_deployments_id_fk",
+          "tableFrom": "towbar_deployment_steps",
+          "tableTo": "towbar_deployments",
+          "columnsFrom": ["deployment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_deployments": {
+      "name": "towbar_deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "temporal_workflow_id": {
+          "name": "temporal_workflow_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "towbar_deployment_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deploy'"
+        },
+        "environment": {
+          "name": "environment",
+          "type": "towbar_deployment_environment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "git_ref": {
+          "name": "git_ref",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_deployment_id": {
+          "name": "github_deployment_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_environment_id": {
+          "name": "preview_environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployable_kind": {
+          "name": "deployable_kind",
+          "type": "towbar_deployable_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'app'"
+        },
+        "state": {
+          "name": "state",
+          "type": "towbar_deployment_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_digest": {
+          "name": "config_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_digest": {
+          "name": "deployment_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_input_digest": {
+          "name": "source_input_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_digest": {
+          "name": "manifest_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_snapshot": {
+          "name": "app_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_snapshot": {
+          "name": "server_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollback_release_snapshot": {
+          "name": "rollback_release_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_deployments_idempotency": {
+          "name": "uq_towbar_deployments_idempotency",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_towbar_deployments_workflow_id": {
+          "name": "uq_towbar_deployments_workflow_id",
+          "columns": [
+            {
+              "expression": "temporal_workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_deployments_app_created": {
+          "name": "idx_towbar_deployments_app_created",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_deployments_server_state": {
+          "name": "idx_towbar_deployments_server_state",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_deployments_preview_created": {
+          "name": "idx_towbar_deployments_preview_created",
+          "columns": [
+            {
+              "expression": "preview_environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_deployments_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_deployments_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_deployments",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_deployments_source_id_towbar_sources_id_fk": {
+          "name": "towbar_deployments_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_deployments",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "towbar_deployments_app_id_towbar_apps_id_fk": {
+          "name": "towbar_deployments_app_id_towbar_apps_id_fk",
+          "tableFrom": "towbar_deployments",
+          "tableTo": "towbar_apps",
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "towbar_deployments_server_id_towbar_servers_id_fk": {
+          "name": "towbar_deployments_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_deployments",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "towbar_deployments_requested_by_towbar_users_id_fk": {
+          "name": "towbar_deployments_requested_by_towbar_users_id_fk",
+          "tableFrom": "towbar_deployments",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["requested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "towbar_deployments_preview_environment_id_towbar_preview_environments_id_fk": {
+          "name": "towbar_deployments_preview_environment_id_towbar_preview_environments_id_fk",
+          "tableFrom": "towbar_deployments",
+          "tableTo": "towbar_preview_environments",
+          "columnsFrom": ["preview_environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_towbar_deployments_rollback_snapshot": {
+          "name": "chk_towbar_deployments_rollback_snapshot",
+          "value": "(\"towbar_deployments\".\"kind\" = 'deploy' AND \"towbar_deployments\".\"rollback_release_snapshot\" IS NULL) OR (\"towbar_deployments\".\"kind\" = 'rollback' AND \"towbar_deployments\".\"rollback_release_snapshot\" IS NOT NULL)"
+        },
+        "chk_towbar_deployments_environment": {
+          "name": "chk_towbar_deployments_environment",
+          "value": "(\"towbar_deployments\".\"environment\" = 'production' AND \"towbar_deployments\".\"preview_environment_id\" IS NULL AND \"towbar_deployments\".\"git_ref\" IS NULL AND \"towbar_deployments\".\"hostname\" IS NULL) OR (\"towbar_deployments\".\"environment\" = 'preview' AND \"towbar_deployments\".\"preview_environment_id\" IS NOT NULL AND \"towbar_deployments\".\"git_ref\" IS NOT NULL AND \"towbar_deployments\".\"hostname\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.towbar_github_installations": {
+      "name": "towbar_github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_github_installation_id": {
+          "name": "uq_towbar_github_installation_id",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_towbar_github_installations_workspace": {
+          "name": "uq_towbar_github_installations_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_github_installations_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_github_installations_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_github_installations",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_github_webhook_deliveries": {
+      "name": "towbar_github_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_digest": {
+          "name": "payload_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_towbar_webhooks_accepted_at": {
+          "name": "idx_towbar_webhooks_accepted_at",
+          "columns": [
+            {
+              "expression": "accepted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_github_webhook_deliveries_source_id_towbar_sources_id_fk": {
+          "name": "towbar_github_webhook_deliveries_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_github_webhook_deliveries",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_password_credentials": {
+      "name": "towbar_password_credentials",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_reset_fingerprint": {
+          "name": "operator_reset_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "towbar_password_credentials_user_id_towbar_users_id_fk": {
+          "name": "towbar_password_credentials_user_id_towbar_users_id_fk",
+          "tableFrom": "towbar_password_credentials",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_preview_environments": {
+      "name": "towbar_preview_environments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "git_ref": {
+          "name": "git_ref",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_id": {
+          "name": "runtime_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_commit_sha": {
+          "name": "latest_commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_deployment_id": {
+          "name": "latest_deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_preview_environment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'building'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_attempts": {
+          "name": "cleanup_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_cleanup_attempt_at": {
+          "name": "last_cleanup_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_cleanup_attempt_at": {
+          "name": "next_cleanup_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_preview_environment_ref": {
+          "name": "uq_towbar_preview_environment_ref",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "git_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_towbar_preview_environment_hostname": {
+          "name": "uq_towbar_preview_environment_hostname",
+          "columns": [
+            {
+              "expression": "hostname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_preview_environment_source_status": {
+          "name": "idx_towbar_preview_environment_source_status",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_preview_environment_expires": {
+          "name": "idx_towbar_preview_environment_expires",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_preview_environments_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_preview_environments_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_preview_environments",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_preview_environments_source_id_towbar_sources_id_fk": {
+          "name": "towbar_preview_environments_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_preview_environments",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_preview_environments_app_id_towbar_apps_id_fk": {
+          "name": "towbar_preview_environments_app_id_towbar_apps_id_fk",
+          "tableFrom": "towbar_preview_environments",
+          "tableTo": "towbar_apps",
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_preview_environments_server_id_towbar_servers_id_fk": {
+          "name": "towbar_preview_environments_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_preview_environments",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_preview_pull_request_reports": {
+      "name": "towbar_preview_pull_request_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_commit_sha": {
+          "name": "latest_commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skipped_apps": {
+          "name": "skipped_apps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "comment_delivery_status": {
+          "name": "comment_delivery_status",
+          "type": "towbar_preview_report_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "comment_delivery_error": {
+          "name": "comment_delivery_error",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_last_attempted_at": {
+          "name": "comment_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_published_at": {
+          "name": "comment_published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_delivery_status": {
+          "name": "deployment_delivery_status",
+          "type": "towbar_preview_report_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "deployment_delivery_error": {
+          "name": "deployment_delivery_error",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_last_attempted_at": {
+          "name": "deployment_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_published_at": {
+          "name": "deployment_published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_preview_report_source_pr": {
+          "name": "uq_towbar_preview_report_source_pr",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pull_request_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_preview_report_workspace_comment": {
+          "name": "idx_towbar_preview_report_workspace_comment",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "comment_delivery_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_preview_report_workspace_deployment": {
+          "name": "idx_towbar_preview_report_workspace_deployment",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deployment_delivery_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_preview_pull_request_reports_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_preview_pull_request_reports_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_preview_pull_request_reports",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_preview_pull_request_reports_source_id_towbar_sources_id_fk": {
+          "name": "towbar_preview_pull_request_reports_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_preview_pull_request_reports",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_releases": {
+      "name": "towbar_releases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "towbar_deployment_environment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "git_ref": {
+          "name": "git_ref",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_environment_id": {
+          "name": "preview_environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_release_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_digest": {
+          "name": "config_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_digest": {
+          "name": "deployment_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_input_digest": {
+          "name": "source_input_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_tag": {
+          "name": "image_tag",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_towbar_releases_deployment": {
+          "name": "uq_towbar_releases_deployment",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_releases_app_status": {
+          "name": "idx_towbar_releases_app_status",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_releases_preview_status": {
+          "name": "idx_towbar_releases_preview_status",
+          "columns": [
+            {
+              "expression": "preview_environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_releases_app_id_towbar_apps_id_fk": {
+          "name": "towbar_releases_app_id_towbar_apps_id_fk",
+          "tableFrom": "towbar_releases",
+          "tableTo": "towbar_apps",
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_releases_deployment_id_towbar_deployments_id_fk": {
+          "name": "towbar_releases_deployment_id_towbar_deployments_id_fk",
+          "tableFrom": "towbar_releases",
+          "tableTo": "towbar_deployments",
+          "columnsFrom": ["deployment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "towbar_releases_preview_environment_id_towbar_preview_environments_id_fk": {
+          "name": "towbar_releases_preview_environment_id_towbar_preview_environments_id_fk",
+          "tableFrom": "towbar_releases",
+          "tableTo": "towbar_preview_environments",
+          "columnsFrom": ["preview_environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_towbar_releases_environment": {
+          "name": "chk_towbar_releases_environment",
+          "value": "(\"towbar_releases\".\"environment\" = 'production' AND \"towbar_releases\".\"preview_environment_id\" IS NULL AND \"towbar_releases\".\"git_ref\" IS NULL) OR (\"towbar_releases\".\"environment\" = 'preview' AND \"towbar_releases\".\"preview_environment_id\" IS NOT NULL AND \"towbar_releases\".\"git_ref\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.towbar_request_nonces": {
+      "name": "towbar_request_nonces",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_request_nonces_expires": {
+          "name": "idx_towbar_request_nonces_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pk_towbar_request_nonces": {
+          "name": "pk_towbar_request_nonces",
+          "columns": ["scope", "nonce"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_resource_operations": {
+      "name": "towbar_resource_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "temporal_workflow_id": {
+          "name": "temporal_workflow_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "towbar_resource_operation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "towbar_resource_operation_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_snapshot": {
+          "name": "app_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_snapshot": {
+          "name": "server_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_resource_operations_idempotency": {
+          "name": "uq_towbar_resource_operations_idempotency",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_towbar_resource_operations_workflow": {
+          "name": "uq_towbar_resource_operations_workflow",
+          "columns": [
+            {
+              "expression": "temporal_workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_resource_operations_resource_created": {
+          "name": "idx_towbar_resource_operations_resource_created",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_resource_operations_server_state": {
+          "name": "idx_towbar_resource_operations_server_state",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_resource_operations_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_resource_operations_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_resource_operations",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_resource_operations_source_id_towbar_sources_id_fk": {
+          "name": "towbar_resource_operations_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_resource_operations",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_resource_operations_resource_id_towbar_apps_id_fk": {
+          "name": "towbar_resource_operations_resource_id_towbar_apps_id_fk",
+          "tableFrom": "towbar_resource_operations",
+          "tableTo": "towbar_apps",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_resource_operations_server_id_towbar_servers_id_fk": {
+          "name": "towbar_resource_operations_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_resource_operations",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_resource_operations_requested_by_towbar_users_id_fk": {
+          "name": "towbar_resource_operations_requested_by_towbar_users_id_fk",
+          "tableFrom": "towbar_resource_operations",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["requested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_server_checks": {
+      "name": "towbar_server_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_check_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_server_checks_server": {
+          "name": "idx_towbar_server_checks_server",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_server_checks_server_id_towbar_servers_id_fk": {
+          "name": "towbar_server_checks_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_server_checks",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_server_checks_requested_by_towbar_users_id_fk": {
+          "name": "towbar_server_checks_requested_by_towbar_users_id_fk",
+          "tableFrom": "towbar_server_checks",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["requested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_server_preparations": {
+      "name": "towbar_server_preparations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_digest": {
+          "name": "config_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_check_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_server_preparations_server_created": {
+          "name": "idx_towbar_server_preparations_server_created",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_towbar_server_preparations_active": {
+          "name": "uq_towbar_server_preparations_active",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"towbar_server_preparations\".\"status\" in ('queued', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_server_preparations_server_id_towbar_servers_id_fk": {
+          "name": "towbar_server_preparations_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_server_preparations",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_server_preparations_requested_by_towbar_users_id_fk": {
+          "name": "towbar_server_preparations_requested_by_towbar_users_id_fk",
+          "tableFrom": "towbar_server_preparations",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["requested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_servers": {
+      "name": "towbar_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_ip": {
+          "name": "canonical_ip",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_digest": {
+          "name": "config_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prepared_at": {
+          "name": "prepared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prepared_config_digest": {
+          "name": "prepared_config_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_servers_source_ip": {
+          "name": "uq_towbar_servers_source_ip",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "canonical_ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_servers_workspace": {
+          "name": "idx_towbar_servers_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_servers_archived_at": {
+          "name": "idx_towbar_servers_archived_at",
+          "columns": [
+            {
+              "expression": "archived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_servers_source_id_towbar_sources_id_fk": {
+          "name": "towbar_servers_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_servers",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_servers_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_servers_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_servers",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_sessions": {
+      "name": "towbar_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_sessions_token_hash": {
+          "name": "uq_towbar_sessions_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_sessions_user_id": {
+          "name": "idx_towbar_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_sessions_expires_at": {
+          "name": "idx_towbar_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_sessions_user_id_towbar_users_id_fk": {
+          "name": "towbar_sessions_user_id_towbar_users_id_fk",
+          "tableFrom": "towbar_sessions",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_source_aws_credentials": {
+      "name": "towbar_source_aws_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_payload": {
+          "name": "encrypted_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_key_suffix": {
+          "name": "access_key_suffix",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "towbar_credential_verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unverified'"
+        },
+        "verification_message": {
+          "name": "verification_message",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_aws_credentials_source": {
+          "name": "uq_towbar_aws_credentials_source",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_aws_credentials_workspace": {
+          "name": "idx_towbar_aws_credentials_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_source_aws_credentials_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_source_aws_credentials_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_source_aws_credentials",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_source_aws_credentials_source_id_towbar_sources_id_fk": {
+          "name": "towbar_source_aws_credentials_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_source_aws_credentials",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_source_syncs": {
+      "name": "towbar_source_syncs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_source_sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_digest": {
+          "name": "manifest_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_manifest": {
+          "name": "raw_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_manifest": {
+          "name": "normalized_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciliation": {
+          "name": "reconciliation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issues": {
+          "name": "issues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_source_syncs_source_created": {
+          "name": "idx_towbar_source_syncs_source_created",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_source_syncs_source_id_towbar_sources_id_fk": {
+          "name": "towbar_source_syncs_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_source_syncs",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_source_syncs_requested_by_towbar_users_id_fk": {
+          "name": "towbar_source_syncs_requested_by_towbar_users_id_fk",
+          "tableFrom": "towbar_source_syncs",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["requested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_sources": {
+      "name": "towbar_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_owner": {
+          "name": "repository_owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_name": {
+          "name": "repository_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_source_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "latest_commit_sha": {
+          "name": "latest_commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_manifest_digest": {
+          "name": "latest_manifest_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_successful_sync_id": {
+          "name": "latest_successful_sync_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_sources_repository_branch": {
+          "name": "uq_towbar_sources_repository_branch",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_sources_workspace": {
+          "name": "idx_towbar_sources_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_sources_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_sources_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_sources",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_sources_github_installation_id_towbar_github_installations_id_fk": {
+          "name": "towbar_sources_github_installation_id_towbar_github_installations_id_fk",
+          "tableFrom": "towbar_sources",
+          "tableTo": "towbar_github_installations",
+          "columnsFrom": ["github_installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_ssh_host_keys": {
+      "name": "towbar_ssh_host_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trusted_by": {
+          "name": "trusted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_ssh_host_keys_active": {
+          "name": "uq_towbar_ssh_host_keys_active",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_ssh_host_keys_server_id_towbar_servers_id_fk": {
+          "name": "towbar_ssh_host_keys_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_ssh_host_keys",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_ssh_host_keys_trusted_by_towbar_users_id_fk": {
+          "name": "towbar_ssh_host_keys_trusted_by_towbar_users_id_fk",
+          "tableFrom": "towbar_ssh_host_keys",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["trusted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_system_health_signals": {
+      "name": "towbar_system_health_signals",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "component": {
+          "name": "component",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_system_health_workspace": {
+          "name": "idx_towbar_system_health_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "component",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_system_health_signals_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_system_health_signals_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_system_health_signals",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_users": {
+      "name": "towbar_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_users_email": {
+          "name": "uq_towbar_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_workspace_members": {
+      "name": "towbar_workspace_members",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "towbar_workspace_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_workspace_members_user_id": {
+          "name": "idx_towbar_workspace_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_workspace_members_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_workspace_members_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_workspace_members",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_workspace_members_user_id_towbar_users_id_fk": {
+          "name": "towbar_workspace_members_user_id_towbar_users_id_fk",
+          "tableFrom": "towbar_workspace_members",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pk_towbar_workspace_members": {
+          "name": "pk_towbar_workspace_members",
+          "columns": ["workspace_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_workspaces": {
+      "name": "towbar_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_workspaces_slug": {
+          "name": "uq_towbar_workspaces_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.towbar_check_status": {
+      "name": "towbar_check_status",
+      "schema": "public",
+      "values": ["queued", "running", "succeeded", "failed"]
+    },
+    "public.towbar_credential_verification_status": {
+      "name": "towbar_credential_verification_status",
+      "schema": "public",
+      "values": ["unverified", "verified", "failed"]
+    },
+    "public.towbar_deployable_kind": {
+      "name": "towbar_deployable_kind",
+      "schema": "public",
+      "values": ["app", "image", "postgres", "redis"]
+    },
+    "public.towbar_deployment_environment": {
+      "name": "towbar_deployment_environment",
+      "schema": "public",
+      "values": ["production", "preview"]
+    },
+    "public.towbar_deployment_kind": {
+      "name": "towbar_deployment_kind",
+      "schema": "public",
+      "values": ["deploy", "rollback"]
+    },
+    "public.towbar_deployment_plan_delivery_status": {
+      "name": "towbar_deployment_plan_delivery_status",
+      "schema": "public",
+      "values": ["pending", "published", "failed"]
+    },
+    "public.towbar_deployment_plan_status": {
+      "name": "towbar_deployment_plan_status",
+      "schema": "public",
+      "values": ["ready", "blocked"]
+    },
+    "public.towbar_deployment_plan_trigger": {
+      "name": "towbar_deployment_plan_trigger",
+      "schema": "public",
+      "values": ["manual", "pull_request"]
+    },
+    "public.towbar_deployment_state": {
+      "name": "towbar_deployment_state",
+      "schema": "public",
+      "values": [
+        "queued",
+        "waiting_for_server",
+        "preparing",
+        "validating_credentials",
+        "checking_server",
+        "fetching_source",
+        "resolving_secrets",
+        "transferring",
+        "building",
+        "running_pre_deploy",
+        "starting_candidate",
+        "checking_health",
+        "configuring_routing",
+        "provisioning_tls",
+        "checking_public_endpoint",
+        "switching_traffic",
+        "running_post_deploy",
+        "cleaning_up",
+        "succeeded",
+        "succeeded_with_warnings",
+        "skipped",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.towbar_deployment_step_status": {
+      "name": "towbar_deployment_step_status",
+      "schema": "public",
+      "values": ["waiting", "running", "succeeded", "failed", "skipped"]
+    },
+    "public.towbar_preview_environment_status": {
+      "name": "towbar_preview_environment_status",
+      "schema": "public",
+      "values": [
+        "building",
+        "healthy",
+        "failed",
+        "deleting",
+        "cleanup_failed",
+        "deleted"
+      ]
+    },
+    "public.towbar_preview_report_delivery_status": {
+      "name": "towbar_preview_report_delivery_status",
+      "schema": "public",
+      "values": ["pending", "published", "failed"]
+    },
+    "public.towbar_release_status": {
+      "name": "towbar_release_status",
+      "schema": "public",
+      "values": ["current", "previous", "superseded"]
+    },
+    "public.towbar_resource_operation_state": {
+      "name": "towbar_resource_operation_state",
+      "schema": "public",
+      "values": ["queued", "running", "succeeded", "failed"]
+    },
+    "public.towbar_resource_operation_type": {
+      "name": "towbar_resource_operation_type",
+      "schema": "public",
+      "values": [
+        "backup",
+        "capture_logs",
+        "cleanup_orphans",
+        "restart",
+        "restore",
+        "start",
+        "stop"
+      ]
+    },
+    "public.towbar_runtime_desired_state": {
+      "name": "towbar_runtime_desired_state",
+      "schema": "public",
+      "values": ["running", "stopped"]
+    },
+    "public.towbar_runtime_drift_state": {
+      "name": "towbar_runtime_drift_state",
+      "schema": "public",
+      "values": ["drifted", "in_sync", "unknown"]
+    },
+    "public.towbar_runtime_health_state": {
+      "name": "towbar_runtime_health_state",
+      "schema": "public",
+      "values": ["healthy", "none", "starting", "unhealthy", "unknown"]
+    },
+    "public.towbar_runtime_observed_state": {
+      "name": "towbar_runtime_observed_state",
+      "schema": "public",
+      "values": ["missing", "running", "stopped", "unknown"]
+    },
+    "public.towbar_source_status": {
+      "name": "towbar_source_status",
+      "schema": "public",
+      "values": ["active", "archived"]
+    },
+    "public.towbar_source_sync_status": {
+      "name": "towbar_source_sync_status",
+      "schema": "public",
+      "values": ["queued", "running", "succeeded", "failed"]
+    },
+    "public.towbar_workspace_role": {
+      "name": "towbar_workspace_role",
+      "schema": "public",
+      "values": ["owner", "member"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/towbar-database/drizzle/meta/_journal.json
+++ b/packages/towbar-database/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1787895424959,
       "tag": "0027_robust_nextwave",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1788040577569,
+      "tag": "0028_sticky_infant_terrible",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/towbar-database/src/schema/index.ts
+++ b/packages/towbar-database/src/schema/index.ts
@@ -18,6 +18,7 @@ import { deploymentStates } from "@workspace/towbar-core/temporal";
 import { deploymentEnvironments } from "@workspace/towbar-core/preview";
 
 import type {
+  DeploymentPlan,
   PersistedResourceOperationRequest,
   ResourceOperationResult,
   EncryptedCredential,
@@ -87,6 +88,18 @@ export const previewEnvironmentStatusEnum = pgEnum(
 );
 export const previewReportDeliveryStatusEnum = pgEnum(
   "towbar_preview_report_delivery_status",
+  ["pending", "published", "failed"],
+);
+export const deploymentPlanTriggerEnum = pgEnum(
+  "towbar_deployment_plan_trigger",
+  ["manual", "pull_request"],
+);
+export const deploymentPlanStatusEnum = pgEnum(
+  "towbar_deployment_plan_status",
+  ["ready", "blocked"],
+);
+export const deploymentPlanDeliveryStatusEnum = pgEnum(
+  "towbar_deployment_plan_delivery_status",
   ["pending", "published", "failed"],
 );
 export const resourceOperationTypeEnum = pgEnum(
@@ -356,6 +369,72 @@ export const sourceSyncs = pgTable(
       table.sourceId,
       table.createdAt,
     ),
+  ],
+);
+
+export const deploymentPlans = pgTable(
+  "towbar_deployment_plans",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    workspaceId: uuid("workspace_id")
+      .notNull()
+      .references(() => workspaces.id, { onDelete: "cascade" }),
+    sourceId: uuid("source_id")
+      .notNull()
+      .references(() => sources.id, { onDelete: "cascade" }),
+    requestedBy: uuid("requested_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    identityDigest: varchar("identity_digest", { length: 64 }).notNull(),
+    trigger: deploymentPlanTriggerEnum("trigger").notNull(),
+    status: deploymentPlanStatusEnum("status").notNull(),
+    pullRequestNumber: integer("pull_request_number"),
+    branch: varchar("branch", { length: 255 }).notNull(),
+    currentCommitSha: varchar("current_commit_sha", { length: 64 }),
+    targetCommitSha: varchar("target_commit_sha", { length: 64 }).notNull(),
+    currentManifestDigest: varchar("current_manifest_digest", { length: 64 }),
+    targetManifestDigest: varchar("target_manifest_digest", { length: 64 }),
+    candidateDigest: varchar("candidate_digest", { length: 64 }).notNull(),
+    plan: jsonb("plan").$type<DeploymentPlan>().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    check(
+      "chk_towbar_deployment_plans_trigger",
+      sql`(${table.trigger} = 'manual' AND ${table.pullRequestNumber} IS NULL) OR (${table.trigger} = 'pull_request' AND ${table.pullRequestNumber} IS NOT NULL)`,
+    ),
+    uniqueIndex("uq_towbar_deployment_plans_identity").on(
+      table.sourceId,
+      table.identityDigest,
+    ),
+    index("idx_towbar_deployment_plans_source_created").on(
+      table.sourceId,
+      table.createdAt,
+    ),
+  ],
+);
+
+export const deploymentPlanGithubChecks = pgTable(
+  "towbar_deployment_plan_github_checks",
+  {
+    planId: uuid("plan_id")
+      .primaryKey()
+      .references(() => deploymentPlans.id, { onDelete: "cascade" }),
+    checkRunId: varchar("check_run_id", { length: 40 }),
+    status: deploymentPlanDeliveryStatusEnum("status")
+      .default("pending")
+      .notNull(),
+    errorMessage: varchar("error_message", { length: 1_000 }),
+    lastAttemptedAt: timestamp("last_attempted_at", { withTimezone: true }),
+    publishedAt: timestamp("published_at", { withTimezone: true }),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("idx_towbar_deployment_plan_checks_status").on(table.status),
   ],
 );
 

--- a/packages/towbar-web-client/src/types.ts
+++ b/packages/towbar-web-client/src/types.ts
@@ -18,6 +18,48 @@ export type Source = {
   updatedAt: string;
 };
 
+export type DeploymentPlanAction =
+  "archive" | "create" | "no_op" | "restore" | "update";
+
+export type DeploymentPlan = {
+  branch: string;
+  createdAt: string;
+  currentCommitSha: string | null;
+  currentManifestDigest: string | null;
+  githubCheckError?: string | null;
+  githubCheckRunId?: string | null;
+  githubCheckStatus: "failed" | "pending" | "published" | null;
+  id: string;
+  plan: {
+    checks: Array<{
+      code: string;
+      entityId?: string;
+      entityKind?: "app" | "resource" | "server" | "source";
+      message: string;
+      references?: string[];
+      status: "failed" | "passed" | "warning";
+    }>;
+    items: Array<{
+      action: DeploymentPlanAction;
+      automaticDeployment: boolean;
+      changedFields: string[];
+      entityId: string;
+      entityKind: "app" | "resource" | "server";
+      matchedPaths: string[];
+      name: string;
+      reasons: string[];
+    }>;
+    status: "blocked" | "ready";
+    summary: Record<DeploymentPlanAction, number>;
+  };
+  pullRequestNumber: number | null;
+  sourceId: string;
+  status: "blocked" | "ready";
+  targetCommitSha: string;
+  targetManifestDigest: string | null;
+  trigger: "manual" | "pull_request";
+};
+
 export type App = {
   archivedAt: string | null;
   config: {
@@ -379,8 +421,10 @@ export type GitHubConnection = {
   installationId: string;
   permissionReadiness:
     | {
+        checks: "none" | "read" | "write";
         contents: "none" | "read" | "write";
         deployments: "none" | "read" | "write";
+        planning: "missing" | "ready";
         preview: "missing" | "ready";
         pullRequests: "none" | "read" | "write";
         status: "available";

--- a/packages/towbar-web-ui/src/status-badge.tsx
+++ b/packages/towbar-web-ui/src/status-badge.tsx
@@ -7,6 +7,8 @@ const success = new Set([
   "current",
   "healthy",
   "live",
+  "passed",
+  "published",
   "ready",
   "succeeded",
   "trusted",
@@ -49,6 +51,7 @@ const warning = new Set([
   "pending",
 ]);
 const destructive = new Set([
+  "blocked",
   "decommissioned",
   "failed",
   "cleanup_failed",


### PR DESCRIPTION
## Summary

- add immutable, deterministic deployment plans for manual and pull-request comparisons
- validate manifest, domains, server readiness/capacity, secret bindings by metadata only, and active-operation conflicts
- publish one idempotent GitHub Check with a direct link to the complete Towbar plan
- add Source plan list/detail UI, fixture coverage, migration, and operator documentation

## Verification

- `pnpm verify`
- local fixture QA for Source Plans list and plan detail routes

## Ground Tasks

- TW-13
- TW-18
- TW-19
- TW-20
- TW-22