### PR TITLE
Polish database restore settings layout

### DIFF
--- a/apps/towbar-web-app/src/components/resource-backup-configuration.tsx
+++ b/apps/towbar-web-app/src/components/resource-backup-configuration.tsx
@@ -27,7 +27,6 @@ import { toast } from "@workspace/web-design-system/overlays/toast";
 import { TypographyCode } from "@workspace/web-design-system/typography/typography";
 import { QueryError, QueryLoading } from "@workspace/towbar-web-ui/query-state";
 import {
-  ResourceName,
   ResourceTable,
   type ResourceTableColumn,
 } from "@workspace/towbar-web-ui/resource-table";
@@ -36,6 +35,7 @@ import { StatusBadge } from "@workspace/towbar-web-ui/status-badge";
 import { ActionButton } from "@/components/page-parts";
 import { refreshApiQueries, useApiQuery } from "@/hooks/use-api-query";
 import { api } from "@/lib/api";
+import { summarizeAssuranceChecks } from "@/lib/backup-assurance-summary";
 import { formatDate } from "./dashboard-overview";
 import { formatBytes } from "./runtime-operations";
 
@@ -104,18 +104,23 @@ export function ResourceBackupConfiguration({
   const latestAssurance = latestBackup
     ? assuranceByBackup.get(latestBackup.id)
     : undefined;
+  const assuranceSummary = latestAssurance
+    ? summarizeAssuranceChecks(latestAssurance.checks)
+    : [];
 
   const backupColumns: ResourceTableColumn<SourceBackup>[] = [
     {
       key: "created",
       header: "Created",
-      cell: (item) => (
-        <ResourceName
-          description={formatBytes(item.result.sizeBytes)}
-          name={formatDate(item.finishedAt ?? item.createdAt)}
-        />
-      ),
-      className: "min-w-52",
+      cell: (item) => formatDate(item.finishedAt ?? item.createdAt),
+      className: "min-w-48 whitespace-nowrap tabular-nums",
+    },
+    {
+      key: "size",
+      header: "Size",
+      cell: (item) => formatBytes(item.result.sizeBytes),
+      className: "whitespace-nowrap tabular-nums",
+      headerClassName: "whitespace-nowrap",
     },
     {
       key: "engine",
@@ -168,13 +173,7 @@ export function ResourceBackupConfiguration({
 
   return (
     <div className="grid gap-8">
-      <div
-        className={
-          active
-            ? "grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(20rem,0.65fr)]"
-            : "grid gap-4"
-        }
-      >
+      <div className={active ? "grid gap-6 2xl:grid-cols-2" : "grid gap-6"}>
         <Attributes title="Backup policy" variant="card">
           <Attributes.Item label="Schedule">
             {backup.schedule ? (
@@ -220,22 +219,22 @@ export function ResourceBackupConfiguration({
                   ? `Checked ${formatDate(latestAssurance.checkedAt)}`
                   : "Run a backup before Towbar can verify restore readiness."}
               </p>
-              {latestAssurance ? (
-                <ul className="grid gap-2">
-                  {latestAssurance.checks.map((check) => (
+              {assuranceSummary.length ? (
+                <ul className="grid gap-3 md:grid-cols-3">
+                  {assuranceSummary.map((summary) => (
                     <li
                       className="flex items-start gap-2 typography--body-sm"
-                      key={check.name}
+                      key={summary.name}
                     >
                       <span
                         aria-hidden="true"
                         className={
-                          check.passed ? "text-success" : "text-danger"
+                          summary.passed ? "text-success" : "text-danger"
                         }
                       >
-                        {check.passed ? "●" : "○"}
+                        {summary.passed ? "●" : "○"}
                       </span>
-                      <span>{check.message}</span>
+                      <span>{summary.message}</span>
                     </li>
                   ))}
                 </ul>
@@ -475,14 +474,21 @@ function RestoreHistory({
   );
   const restoreColumns: ResourceTableColumn<ResourceOperation>[] = [
     {
-      key: "operation",
-      header: "Restore",
+      key: "created",
+      header: "Created",
+      cell: (operation) => formatDate(operation.createdAt),
+      className: "min-w-48 whitespace-nowrap tabular-nums",
+    },
+    {
+      key: "restore-id",
+      header: "Restore ID",
       cell: (operation) => (
-        <ResourceName
-          description={formatDate(operation.createdAt)}
-          name={operation.id.slice(0, 8)}
-        />
+        <TypographyCode title={operation.id}>
+          {operation.id.slice(0, 8)}
+        </TypographyCode>
       ),
+      className: "whitespace-nowrap",
+      headerClassName: "whitespace-nowrap",
     },
     {
       key: "reason",

--- a/apps/towbar-web-app/src/lib/backup-assurance-summary.test.ts
+++ b/apps/towbar-web-app/src/lib/backup-assurance-summary.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { BackupAssurance } from "@workspace/towbar-web-client";
+
+import { summarizeAssuranceChecks } from "./backup-assurance-summary";
+
+const passingChecks: BackupAssurance["checks"] = [
+  { message: "Fresh", name: "freshness", passed: true },
+  { message: "Exists", name: "object_exists", passed: true },
+  { message: "Sized", name: "size", passed: true },
+  { message: "Checksum", name: "checksum", passed: true },
+  { message: "Encrypted", name: "encryption", passed: true },
+  { message: "Engine", name: "engine", passed: true },
+  { message: "Format", name: "format", passed: true },
+];
+
+test("summarizes seven passing assurance checks into three groups", () => {
+  assert.deepEqual(summarizeAssuranceChecks(passingChecks), [
+    {
+      message: "Backup is current and available",
+      name: "availability",
+      passed: true,
+    },
+    {
+      message: "Integrity and encryption are verified",
+      name: "integrity",
+      passed: true,
+    },
+    {
+      message: "Engine and format are compatible",
+      name: "compatibility",
+      passed: true,
+    },
+  ]);
+});
+
+test("preserves the first failure detail within its summary group", () => {
+  const checks = passingChecks.map((check) =>
+    check.name === "checksum"
+      ? { ...check, message: "Checksum does not match", passed: false }
+      : check,
+  );
+
+  assert.deepEqual(summarizeAssuranceChecks(checks)[1], {
+    message: "Checksum does not match",
+    name: "integrity",
+    passed: false,
+  });
+});
+
+test("does not report an incomplete group as verified", () => {
+  const checks = passingChecks.filter((check) => check.name !== "format");
+
+  assert.deepEqual(summarizeAssuranceChecks(checks)[2], {
+    message: "Verification details are incomplete",
+    name: "compatibility",
+    passed: false,
+  });
+});

--- a/apps/towbar-web-app/src/lib/backup-assurance-summary.ts
+++ b/apps/towbar-web-app/src/lib/backup-assurance-summary.ts
@@ -1,0 +1,36 @@
+import type { BackupAssurance } from "@workspace/towbar-web-client";
+
+const assuranceGroups = [
+  {
+    message: "Backup is current and available",
+    name: "availability",
+    checks: ["freshness", "object_exists", "size"],
+  },
+  {
+    message: "Integrity and encryption are verified",
+    name: "integrity",
+    checks: ["checksum", "encryption"],
+  },
+  {
+    message: "Engine and format are compatible",
+    name: "compatibility",
+    checks: ["engine", "format"],
+  },
+] as const;
+
+export function summarizeAssuranceChecks(checks: BackupAssurance["checks"]) {
+  return assuranceGroups.map((group) => {
+    const groupedChecks = checks.filter((check) =>
+      group.checks.some((name) => name === check.name),
+    );
+    const failure = groupedChecks.find((check) => !check.passed);
+    const complete = groupedChecks.length === group.checks.length;
+    return {
+      message:
+        failure?.message ??
+        (complete ? group.message : "Verification details are incomplete"),
+      name: group.name,
+      passed: complete && failure === undefined,
+    };
+  });
+}


### PR DESCRIPTION
## Summary

- stack backup policy and assurance cards until there is enough width
- condense seven assurance checks into three meaningful groups while preserving failure detail
- split retained backup size into its own column
- split restore creation date and restore ID into separate columns
- add assurance summary coverage for passing, failing, and incomplete data

## Validation

- `pnpm verify`
- fixture QA at the reported 1444px width with no page overflow
- responsive fixture inspection of the backup settings surface