### PR TITLE
Fix TW-43 and TW-44 CodeQL findings

### DIFF
--- a/apps/towbar-api/README.md
+++ b/apps/towbar-api/README.md
@@ -34,9 +34,11 @@ no authorization-code exchange or separate authentication origin.
 Forgotten-owner recovery is an operator-only startup operation. Configure
 `TOWBAR_OWNER_RESET_EMAIL` and a high-entropy temporary
 `TOWBAR_OWNER_RESET_PASSWORD`, restart the API, sign in normally, and change the
-password in Settings. The API stores only a keyed fingerprint of the recovery
-value, revokes existing sessions, and refuses to reapply the same value on a
-later restart. Towbar exposes no unauthenticated password-reset route.
+password in Settings. The API stores the login credential only as an Argon2id
+password hash. A separate keyed marker records only whether that operator reset
+value has already run; it is never accepted by login. Existing sessions are
+revoked, and the same reset value is not reapplied on a later restart. Towbar
+exposes no unauthenticated password-reset route.
 
 Signed GitHub push webhooks synchronize only the manifest's configured branch.
 After any successful Source sync, including an operator-requested sync, the API

--- a/apps/towbar-api/src/areas/auth/operator-reset-idempotency.test.ts
+++ b/apps/towbar-api/src/areas/auth/operator-reset-idempotency.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { verifyPassword } from "@workspace/towbar-core/security";
+
+import {
+  createOperatorResetIdempotencyMarker,
+  matchesOperatorResetIdempotencyMarker,
+} from "./operator-reset-idempotency.js";
+
+void describe("operator reset idempotency", () => {
+  const input = {
+    email: "owner@example.com",
+    internalHmacSecret: "an-internal-secret-with-sufficient-length",
+    temporaryPassword: "a-high-entropy-temporary-password",
+  };
+
+  void it("creates a deterministic marker bound to the internal key and reset value", () => {
+    const marker = createOperatorResetIdempotencyMarker(input);
+
+    assert.match(marker, /^[a-f\d]{64}$/u);
+    assert.equal(createOperatorResetIdempotencyMarker(input), marker);
+    assert.notEqual(
+      createOperatorResetIdempotencyMarker({
+        ...input,
+        internalHmacSecret: "a-different-internal-secret-of-safe-length",
+      }),
+      marker,
+    );
+    assert.notEqual(
+      createOperatorResetIdempotencyMarker({
+        ...input,
+        temporaryPassword: "a-different-high-entropy-password",
+      }),
+      marker,
+    );
+    assert.equal(marker.includes(input.email), false);
+    assert.equal(marker.includes(input.temporaryPassword), false);
+  });
+
+  void it("matches only a valid stored marker and cannot serve as a login verifier", async () => {
+    const marker = createOperatorResetIdempotencyMarker(input);
+
+    assert.equal(matchesOperatorResetIdempotencyMarker(marker, marker), true);
+    assert.equal(matchesOperatorResetIdempotencyMarker(marker, null), false);
+    assert.equal(
+      matchesOperatorResetIdempotencyMarker(marker, "malformed"),
+      false,
+    );
+    assert.equal(await verifyPassword(input.temporaryPassword, marker), false);
+  });
+});

--- a/apps/towbar-api/src/areas/auth/operator-reset-idempotency.ts
+++ b/apps/towbar-api/src/areas/auth/operator-reset-idempotency.ts
@@ -1,0 +1,42 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const markerPrefix = "towbar:operator-reset-idempotency:v1";
+const markerPattern = /^[a-f\d]{64}$/u;
+
+/**
+ * Creates an internal idempotency marker for one operator reset value.
+ *
+ * This marker is not a password verifier and is never used by login. The
+ * accepted password continues to be stored and verified exclusively through
+ * the Argon2id password hash in `passwordCredentials.passwordHash`.
+ */
+export function createOperatorResetIdempotencyMarker(input: {
+  email: string;
+  internalHmacSecret: string;
+  temporaryPassword: string;
+}) {
+  return createHmac("sha256", input.internalHmacSecret)
+    .update(markerPrefix, "utf8")
+    .update("\0", "utf8")
+    .update(input.email, "utf8")
+    .update("\0", "utf8")
+    .update(input.temporaryPassword, "utf8")
+    .digest("hex");
+}
+
+export function matchesOperatorResetIdempotencyMarker(
+  candidate: string,
+  stored: string | null,
+) {
+  if (
+    !stored ||
+    !markerPattern.test(candidate) ||
+    !markerPattern.test(stored)
+  ) {
+    return false;
+  }
+  return timingSafeEqual(
+    Buffer.from(candidate, "hex"),
+    Buffer.from(stored, "hex"),
+  );
+}

--- a/apps/towbar-api/src/areas/auth/service.ts
+++ b/apps/towbar-api/src/areas/auth/service.ts
@@ -1,5 +1,3 @@
-import { createHmac } from "node:crypto";
-
 import { and, count, desc, eq, gt, isNull, ne, sql } from "drizzle-orm";
 
 import {
@@ -22,6 +20,10 @@ import {
   runPasswordOperationWithCapacityLimit,
   verifyPasswordWithCapacityLimit,
 } from "./password-verification.js";
+import {
+  createOperatorResetIdempotencyMarker,
+  matchesOperatorResetIdempotencyMarker,
+} from "./operator-reset-idempotency.js";
 
 export const sessionLifetimeSeconds = 7 * 24 * 60 * 60;
 const unknownAccountPasswordHash =
@@ -290,10 +292,11 @@ export async function applyOwnerPasswordResetFromEnvironment() {
   }
   const email = normalizeEmail(env.TOWBAR_OWNER_RESET_EMAIL);
   const temporaryPassword = env.TOWBAR_OWNER_RESET_PASSWORD;
-  const fingerprint = createHmac("sha256", env.TOWBAR_INTERNAL_HMAC_SECRET)
-    .update(`owner-password-reset:${email}:`, "utf8")
-    .update(temporaryPassword, "utf8")
-    .digest("hex");
+  const resetMarker = createOperatorResetIdempotencyMarker({
+    email,
+    internalHmacSecret: env.TOWBAR_INTERNAL_HMAC_SECRET,
+    temporaryPassword,
+  });
   const passwordHash = await runPasswordOperationWithCapacityLimit(() =>
     hashPassword(temporaryPassword),
   );
@@ -322,13 +325,15 @@ export async function applyOwnerPasswordResetFromEnvironment() {
     if (!credential) {
       throw new Error(`Towbar owner ${email} was not found`);
     }
-    if (credential.fingerprint === fingerprint) {
+    if (
+      matchesOperatorResetIdempotencyMarker(resetMarker, credential.fingerprint)
+    ) {
       return { email, status: "already-applied" } as const;
     }
     await transaction
       .update(passwordCredentials)
       .set({
-        operatorResetFingerprint: fingerprint,
+        operatorResetFingerprint: resetMarker,
         passwordHash,
         updatedAt: new Date(),
       })

--- a/apps/towbar-web-app/scripts/fixture-api.test.mjs
+++ b/apps/towbar-web-app/scripts/fixture-api.test.mjs
@@ -65,6 +65,110 @@ test("terminal preparation state replaces a stale preparing server state", () =>
   assert.equal(reconcileServerSetupStatus("pending", "succeeded"), "pending");
 });
 
+test("the local fixture permits credentialed CORS only from exact web fixture origins", async () => {
+  const server = createFixtureApiServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  assert(address && typeof address === "object");
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  try {
+    for (const origin of [
+      "http://127.0.0.1:4021",
+      "http://[::1]:4021",
+      "http://localhost:4021",
+    ]) {
+      const response = await fetch(`${baseUrl}/v1/core/session`, {
+        headers: { origin },
+      });
+      assert.equal(response.status, 200, origin);
+      assert.equal(response.headers.get("access-control-allow-origin"), origin);
+      assert.equal(
+        response.headers.get("access-control-allow-credentials"),
+        "true",
+      );
+      assert.match(response.headers.get("vary") ?? "", /\bOrigin\b/u);
+    }
+
+    const toolingResponse = await fetch(`${baseUrl}/v1/core/session`);
+    assert.equal(toolingResponse.status, 200);
+    assert.equal(
+      toolingResponse.headers.get("access-control-allow-origin"),
+      null,
+    );
+    assert.equal(
+      toolingResponse.headers.get("access-control-allow-credentials"),
+      null,
+    );
+    assert.match(toolingResponse.headers.get("vary") ?? "", /\bOrigin\b/u);
+
+    const preflight = await fetch(`${baseUrl}/v1/core/session`, {
+      headers: { origin: "http://localhost:4021" },
+      method: "OPTIONS",
+    });
+    assert.equal(preflight.status, 204);
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+});
+
+test("the local fixture rejects disallowed origins before state changes", async () => {
+  const server = createFixtureApiServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  assert(address && typeof address === "object");
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  const route = `/v1/core/apps/${fixtureIds.app}/auto-deploy-control`;
+
+  try {
+    const beforeResponse = await fetch(`${baseUrl}${route}`);
+    assert.equal(beforeResponse.status, 200);
+    const before = await beforeResponse.json();
+
+    for (const origin of [
+      "null",
+      "http://localhost:4022",
+      "http://localhost.evil.example:4021",
+      "http://localhost:4021@evil.example",
+      "not-an-origin",
+    ]) {
+      const response = await fetch(`${baseUrl}${route}`, {
+        body: JSON.stringify({ paused: !before.autoDeploy.paused }),
+        headers: { "content-type": "application/json", origin },
+        method: "PATCH",
+      });
+      assert.equal(response.status, 403, origin);
+      assert.equal(
+        response.headers.get("access-control-allow-origin"),
+        null,
+        origin,
+      );
+      assert.equal(
+        response.headers.get("access-control-allow-credentials"),
+        null,
+        origin,
+      );
+    }
+
+    const preflight = await fetch(`${baseUrl}${route}`, {
+      headers: { origin: "https://attacker.example" },
+      method: "OPTIONS",
+    });
+    assert.equal(preflight.status, 403);
+
+    const afterResponse = await fetch(`${baseUrl}${route}`);
+    assert.equal(afterResponse.status, 200);
+    const after = await afterResponse.json();
+    assert.equal(after.autoDeploy.paused, before.autoDeploy.paused);
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+});
+
 test("the local fixture separates control-plane checks from server capacity", async () => {
   const server = createFixtureApiServer();
   server.listen(0, "127.0.0.1");

--- a/apps/towbar-web-app/scripts/fixture-api.ts
+++ b/apps/towbar-web-app/scripts/fixture-api.ts
@@ -815,7 +815,7 @@ const workflowStates: DeploymentState[] = [
 
 export function createFixtureApiServer() {
   return createServer((request, response) => {
-    setCorsHeaders(response, request.headers.origin);
+    if (!authorizeFixtureCorsRequest(response, request.headers.origin)) return;
     if (request.method === "OPTIONS") {
       response.writeHead(204);
       response.end();
@@ -2325,8 +2325,26 @@ function writeDeploymentEvents(
   response.on("close", () => clearInterval(keepAlive));
 }
 
-function setCorsHeaders(response: ServerResponse, origin?: string) {
-  if (origin) response.setHeader("access-control-allow-origin", origin);
+const allowedFixtureOrigins = new Set([
+  "http://127.0.0.1:4021",
+  "http://[::1]:4021",
+  "http://localhost:4021",
+]);
+
+function authorizeFixtureCorsRequest(
+  response: ServerResponse,
+  origin?: string,
+) {
+  response.setHeader("vary", "Origin");
+  if (!origin) return true;
+  if (!allowedFixtureOrigins.has(origin)) {
+    writeJson(response, 403, {
+      error: { message: "Origin is not allowed by the local fixture API" },
+    });
+    return false;
+  }
+
+  response.setHeader("access-control-allow-origin", origin);
   response.setHeader("access-control-allow-credentials", "true");
   response.setHeader(
     "access-control-allow-headers",
@@ -2336,6 +2354,7 @@ function setCorsHeaders(response: ServerResponse, origin?: string) {
     "access-control-allow-methods",
     "DELETE,GET,OPTIONS,PATCH,POST,PUT",
   );
+  return true;
 }
 
 function writeJson(response: ServerResponse, status: number, payload: unknown) {


### PR DESCRIPTION
## Summary

- restrict the local fixture API to exact credentialed loopback origins and reject disallowed requests before route execution
- isolate the operator-reset idempotency marker from the Argon2id login verifier
- add focused security regression tests and document the password-reset boundary

## Security disposition

- TW-43 / CodeQL #2 was a real CORS boundary issue and is fixed in code
- TW-44 / CodeQL #1 was a false positive caused by an ambiguous data-flow boundary: the keyed HMAC is an internal restart marker, while login exclusively verifies `password_hash` with Argon2id. The new module and tests make that separation explicit.
- Hosted JavaScript/TypeScript CodeQL reports **0 results** for commit `7377fce`, so neither alert requires manual dismissal

## Verification

- `pnpm verify`
- hosted CI `verify` and `compose`
- hosted CodeQL for Actions and JavaScript/TypeScript
- fixture CORS tests cover exact localhost, 127.0.0.1 and IPv6 loopback origins; missing Origin tooling; attacker, null, suffix, userinfo, malformed and arbitrary-port origins; rejected preflight and mutation
- operator-reset tests cover deterministic key binding, plaintext non-disclosure, malformed markers and rejection by the Argon2id login verifier