### PR TITLE
Gate vulnerability scanning per app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,9 +28,10 @@ TOWBAR_APP_ID=towbar-worker
 # worker and destination-host capacity.
 TOWBAR_WORKER_MAX_CONCURRENT_ACTIVITIES=4
 
-# Optional post-deployment image vulnerability scanning. Results are cached by
-# immutable digest and reused until explicitly rescanned. Keep the scanner image
-# pinned by tag and multi-architecture digest.
+# Optional post-deployment image vulnerability scanning capability. Each App
+# must also set vulnerabilityScanning: true in its deployment manifest. Results
+# are cached by immutable digest and reused until explicitly rescanned. Keep the
+# scanner image pinned by tag and multi-architecture digest.
 TOWBAR_VULNERABILITY_SCANNING_ENABLED=false
 TOWBAR_VULNERABILITY_SCAN_MAX_AGE_HOURS=168
 TOWBAR_TRIVY_IMAGE=aquasec/trivy:0.74.0@sha256:62b1e65e8869bc4b4c6aa4fa2b21595256c7c2f6018a9d9ad61caf87187c1969

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Towbar are documented in this file. This project follows
 
 ## [Unreleased]
 
+### Changed
+
+- Image vulnerability scanning now requires an explicit
+  `vulnerabilityScanning: true` opt-in on each App in addition to the
+  installation-wide capability flag. The policy can change without forcing an
+  App redeployment, Resources remain unscanned, and prior results are retained.
+
 ## [1.3.0] - 2026-08-30
 
 ### Added

--- a/apps/towbar-api/src/areas/apps/secrets.test.ts
+++ b/apps/towbar-api/src/areas/apps/secrets.test.ts
@@ -20,6 +20,7 @@ const previewDeployment = "aws:example/apps/api/preview-deployment";
 
 const app: NormalizedApp = {
   autoDeploy: true,
+  vulnerabilityScanning: false,
   container: { port: 4_020 },
   context: ".",
   deploymentInputs: [],

--- a/apps/towbar-api/src/areas/deployments/service.ts
+++ b/apps/towbar-api/src/areas/deployments/service.ts
@@ -14,6 +14,7 @@ import {
 } from "@workspace/towbar-core/temporal";
 import { digestValue } from "@workspace/towbar-core";
 import {
+  apps,
   deployableRuntimeStates,
   deploymentLogChunks,
   deploymentSteps,
@@ -32,6 +33,7 @@ import { cancelDeploymentWorkflow } from "../../infrastructure/temporal.js";
 import { createInstallationToken } from "../github/client.js";
 import { emitDeploymentNotification } from "../notifications/events.js";
 import { publicDeploymentSelection } from "../deployment-selection.js";
+import { isVulnerabilityScanningEnabled } from "../vulnerability-scans/admission.js";
 import { getDeploymentVulnerabilityScan } from "../vulnerability-scans/service.js";
 import { collectRetainedImageTags } from "./image-retention.js";
 import { propagatePreviewDeploymentState } from "./preview-status.js";
@@ -83,8 +85,9 @@ export async function listDeployments(workspaceId: string, sourceId?: string) {
 
 export async function getDeployment(deploymentId: string, workspaceId: string) {
   const [deployment] = await getTowbarDatabase()
-    .select(publicDeploymentSelection)
+    .select({ ...publicDeploymentSelection, appConfig: apps.config })
     .from(deployments)
+    .innerJoin(apps, eq(apps.id, deployments.appId))
     .where(
       and(
         eq(deployments.id, deploymentId),
@@ -93,15 +96,18 @@ export async function getDeployment(deploymentId: string, workspaceId: string) {
     )
     .limit(1);
   if (!deployment) throw notFound("Deployment");
-  const [item] = await attachDeploymentQueueBlockers([deployment]);
+  const { appConfig, ...publicDeployment } = deployment;
+  const [item] = await attachDeploymentQueueBlockers([publicDeployment]);
   return {
     ...item!,
     vulnerabilityScan: await getDeploymentVulnerabilityScan(
       deployment,
       workspaceId,
     ),
-    vulnerabilityScanningEnabled:
-      getEnv().TOWBAR_VULNERABILITY_SCANNING_ENABLED,
+    vulnerabilityScanningEnabled: isVulnerabilityScanningEnabled({
+      deployable: appConfig,
+      instanceEnabled: getEnv().TOWBAR_VULNERABILITY_SCANNING_ENABLED,
+    }),
   };
 }
 

--- a/apps/towbar-api/src/areas/sources/deployment-digests.test.ts
+++ b/apps/towbar-api/src/areas/sources/deployment-digests.test.ts
@@ -23,6 +23,7 @@ const server = {
 
 const app = {
   autoDeploy: true,
+  vulnerabilityScanning: false,
   container: { port: 3_000 },
   context: ".",
   deploymentInputs: ["apps/web/**"],

--- a/apps/towbar-api/src/areas/vulnerability-scans/admission.test.ts
+++ b/apps/towbar-api/src/areas/vulnerability-scans/admission.test.ts
@@ -1,7 +1,69 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { vulnerabilityScanAdmissionAction } from "./admission.js";
+import {
+  isVulnerabilityScanningEnabled,
+  vulnerabilityScanAdmissionAction,
+} from "./admission.js";
+
+import type { NormalizedApp, NormalizedResource } from "@workspace/towbar-core";
+
+const app = {
+  autoDeploy: true,
+  container: { port: 3_000 },
+  context: ".",
+  deploymentInputs: [],
+  dockerfile: "Dockerfile",
+  health: { path: "/health", timeoutSeconds: 60 },
+  hooks: {},
+  id: "web",
+  kind: "app",
+  name: "Web",
+  secrets: {},
+  server: "203.0.113.10",
+  sharedSecrets: { build: [], deployment: [] },
+  sourceBranch: "main",
+  vulnerabilityScanning: true,
+} satisfies NormalizedApp;
+
+const resource = {
+  autoDeploy: true,
+  container: { command: [], resources: { cpus: 1, memory: "1g" }, volumes: [] },
+  health: { timeoutSeconds: 60, type: "container" },
+  id: "postgres",
+  image: "postgres:18-alpine",
+  kind: "postgres",
+  name: "PostgreSQL",
+  secrets: {},
+  server: "203.0.113.10",
+  sharedSecrets: { build: [], deployment: [] },
+  sourceBranch: "main",
+} satisfies NormalizedResource;
+
+void test("requires both the installation capability and App opt-in", () => {
+  assert.equal(
+    isVulnerabilityScanningEnabled({ deployable: app, instanceEnabled: true }),
+    true,
+  );
+  assert.equal(
+    isVulnerabilityScanningEnabled({
+      deployable: { ...app, vulnerabilityScanning: false },
+      instanceEnabled: true,
+    }),
+    false,
+  );
+  assert.equal(
+    isVulnerabilityScanningEnabled({ deployable: app, instanceEnabled: false }),
+    false,
+  );
+  assert.equal(
+    isVulnerabilityScanningEnabled({
+      deployable: resource,
+      instanceEnabled: true,
+    }),
+    false,
+  );
+});
 
 void test("reuses one automatic scan per immutable image digest", () => {
   assert.equal(

--- a/apps/towbar-api/src/areas/vulnerability-scans/admission.ts
+++ b/apps/towbar-api/src/areas/vulnerability-scans/admission.ts
@@ -1,4 +1,20 @@
-import type { VulnerabilityScanState } from "@workspace/towbar-core";
+import { isNormalizedResource } from "@workspace/towbar-core";
+
+import type {
+  NormalizedDeployable,
+  VulnerabilityScanState,
+} from "@workspace/towbar-core";
+
+export function isVulnerabilityScanningEnabled(input: {
+  deployable: NormalizedDeployable;
+  instanceEnabled: boolean;
+}) {
+  return (
+    input.instanceEnabled &&
+    !isNormalizedResource(input.deployable) &&
+    input.deployable.vulnerabilityScanning === true
+  );
+}
 
 export function vulnerabilityScanAdmissionAction(input: {
   existingState?: VulnerabilityScanState;

--- a/apps/towbar-api/src/areas/vulnerability-scans/service.ts
+++ b/apps/towbar-api/src/areas/vulnerability-scans/service.ts
@@ -5,6 +5,7 @@ import {
   vulnerabilityScanResultSchema,
 } from "@workspace/towbar-core";
 import {
+  apps,
   deployments,
   imageVulnerabilityFindings,
   imageVulnerabilityScans,
@@ -16,7 +17,10 @@ import { conflict, notFound } from "../../http/errors.js";
 import { getTowbarDatabase } from "../../infrastructure/database.js";
 import { enqueueVulnerabilityScan } from "../../infrastructure/temporal.js";
 import { resolveDeploymentLogin } from "../deployments/deployment-secrets.js";
-import { vulnerabilityScanAdmissionAction } from "./admission.js";
+import {
+  isVulnerabilityScanningEnabled,
+  vulnerabilityScanAdmissionAction,
+} from "./admission.js";
 
 import type { VulnerabilityScanResult } from "@workspace/towbar-core";
 
@@ -42,6 +46,20 @@ export async function requestDeploymentVulnerabilityScan(input: {
     input.deploymentId,
     input.workspaceId,
   );
+  if (
+    !isVulnerabilityScanningEnabled({
+      deployable: deployment.appConfig,
+      instanceEnabled: env.TOWBAR_VULNERABILITY_SCANNING_ENABLED,
+    })
+  ) {
+    if (input.force) {
+      throw conflict(
+        "Image vulnerability scanning is not enabled for this App",
+        "APP_VULNERABILITY_SCANNING_DISABLED",
+      );
+    }
+    return null;
+  }
   const database = getTowbarDatabase();
   const admission = await database.transaction(async (transaction) => {
     let [existing] = await transaction
@@ -430,6 +448,7 @@ async function getScannableDeployment(
 ) {
   const [deployment] = await getTowbarDatabase()
     .select({
+      appConfig: apps.config,
       appId: deployments.appId,
       id: deployments.id,
       imageDigest: deployments.imageDigest,
@@ -440,6 +459,7 @@ async function getScannableDeployment(
       workspaceId: deployments.workspaceId,
     })
     .from(deployments)
+    .innerJoin(apps, eq(apps.id, deployments.appId))
     .where(
       workspaceId
         ? and(

--- a/apps/towbar-web-app/src/components/deployment-vulnerability-scan.tsx
+++ b/apps/towbar-web-app/src/components/deployment-vulnerability-scan.tsx
@@ -31,11 +31,11 @@ export function DeploymentVulnerabilityScanPanel({
 }: {
   deployment: Deployment;
 }) {
+  const initialScan = initialDeployment.vulnerabilityScan;
   const shouldRender =
-    initialDeployment.vulnerabilityScanningEnabled &&
+    (initialDeployment.vulnerabilityScanningEnabled || initialScan) &&
     initialDeployment.imageDigest &&
     ["succeeded", "succeeded_with_warnings"].includes(initialDeployment.state);
-  const initialScan = initialDeployment.vulnerabilityScan;
   const [pollRequestedAt, setPollRequestedAt] = useState<string | null>(() =>
     initialScan && activeScanStates.has(initialScan.state)
       ? initialScan.requestedAt
@@ -101,6 +101,18 @@ export function DeploymentVulnerabilityScanPanel({
               </Alert.Content>
             </Alert>
           ) : null}
+          {!deployment.vulnerabilityScanningEnabled && scan ? (
+            <Alert status="warning">
+              <Alert.Indicator />
+              <Alert.Content>
+                <Alert.Title>Scanning is disabled for this App</Alert.Title>
+                <Alert.Description>
+                  Towbar retained this existing result, but it will not queue a
+                  new scan until the App opts in again.
+                </Alert.Description>
+              </Alert.Content>
+            </Alert>
+          ) : null}
           {scan && !activeScanStates.has(scan.state) ? (
             <ScanSummary scan={scan} />
           ) : scan ? (
@@ -158,7 +170,9 @@ export function DeploymentVulnerabilityScanPanel({
               digest.
             </p>
           ) : null}
-          {!isActive && sessionQuery.data?.user.workspaceRole === "owner" ? (
+          {!isActive &&
+          deployment.vulnerabilityScanningEnabled &&
+          sessionQuery.data?.user.workspaceRole === "owner" ? (
             <div>
               <ActionButton
                 action={async () => {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,12 +100,24 @@ docker compose up --detach --force-recreate api
 
 ## Image vulnerability scanning
 
-Set `TOWBAR_VULNERABILITY_SCANNING_ENABLED=true` to queue an optional scan of
-the immutable image digest after each successful deployment. Towbar reuses one
-result per workspace and image digest, stores only bounded normalized findings,
-and keeps scan failures separate from deployment health. The deployment detail
-page shows severity totals, actionable findings, scanner metadata, and stale or
-failed states.
+Set `TOWBAR_VULNERABILITY_SCANNING_ENABLED=true` to make image scanning
+available to Sources. Each App must then opt in explicitly in its deployment
+manifest:
+
+```yaml
+apps:
+  - id: hello-towbar
+    vulnerabilityScanning: true
+```
+
+Towbar queues a scan of that App's immutable image digest after each successful
+production or Preview deployment. Changing only this App policy does not force
+a redeployment, and Resources are not scanned. Towbar reuses one result per
+workspace and image digest, stores only bounded normalized findings, and keeps
+scan failures separate from deployment health. The deployment detail page
+shows severity totals, actionable findings, scanner metadata, and stale or
+failed states. Disabling the App policy stops new scans without deleting prior
+results.
 
 `TOWBAR_VULNERABILITY_SCAN_MAX_AGE_HOURS` controls when completed results are
 labelled stale and defaults to `168` hours. `TOWBAR_TRIVY_IMAGE` configures the

--- a/examples/deployment.yml
+++ b/examples/deployment.yml
@@ -20,6 +20,7 @@ apps:
     server: 203.0.113.10
     dockerfile: Dockerfile
     context: .
+    vulnerabilityScanning: true
     autoDeploy:
       inputs:
         - Dockerfile

--- a/packages/towbar-core/README.md
+++ b/packages/towbar-core/README.md
@@ -26,8 +26,10 @@ Apps may opt into `autoDeploy`, declare named root
 backward compatibility. Towbar does not impose deployment ordering between
 deployables. Operators who require ordering can disable automatic deployment
 for the downstream deployable and admit it manually after its prerequisite.
-Normalized snapshots expand input groups and include their security-sensitive
-and automatic-deployment configuration.
+Apps may also set `vulnerabilityScanning: true` when the Towbar installation
+enables the scanner capability. This control-plane policy does not change the
+runtime deployment digest. Normalized snapshots expand input groups and
+include their security-sensitive and automatic-deployment configuration.
 
 Apps may also opt into Preview deployments for same-repository pull requests
 targeting the Source branch. The normalized contract supplies an isolated

--- a/packages/towbar-core/schemas/deployment.v1.json
+++ b/packages/towbar-core/schemas/deployment.v1.json
@@ -149,6 +149,7 @@
               }
             ]
           },
+          "vulnerabilityScanning": { "type": "boolean", "default": false },
           "id": {
             "type": "string",
             "pattern": "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$"

--- a/packages/towbar-core/src/deployment-inputs.test.ts
+++ b/packages/towbar-core/src/deployment-inputs.test.ts
@@ -122,6 +122,7 @@ void test("keeps commit-sensitive and incomplete pull requests eligible", () => 
 void test("deployment metadata and scheduling controls do not change the runtime digest", () => {
   const app = {
     autoDeploy: true,
+    vulnerabilityScanning: false,
     container: { port: 3_000 },
     context: ".",
     deploymentInputs: ["apps/web/**"],
@@ -157,6 +158,7 @@ void test("deployment metadata and scheduling controls do not change the runtime
         deploymentInputs: ["packages/shared/**"],
         name: "Renamed Web",
         sourceBranch: "release",
+        vulnerabilityScanning: true,
       },
       server: { ...server, buildConcurrency: 8 },
       sourceInputDigest: "source",

--- a/packages/towbar-core/src/deployment-inputs.ts
+++ b/packages/towbar-core/src/deployment-inputs.ts
@@ -123,5 +123,6 @@ function getDeploymentRuntimeConfig(deployable: NormalizedDeployable) {
   delete value.name;
   delete value.preview;
   delete value.sourceBranch;
+  delete value.vulnerabilityScanning;
   return value;
 }

--- a/packages/towbar-core/src/manifest.test.ts
+++ b/packages/towbar-core/src/manifest.test.ts
@@ -41,6 +41,7 @@ apps:
       inputs:
         - $shared-web
         - apps/towbar-web-app/**
+    vulnerabilityScanning: true
     name: Towbar Web App
     server: 203.0.113.10
     dockerfile: apps/towbar-web-app/Dockerfile
@@ -98,6 +99,7 @@ void test("parses and canonicalizes a version 1 manifest", () => {
     deployment: ["aws:example/production/shared/runtime"],
   });
   assert.equal(result.manifest.apps[0]?.autoDeploy, true);
+  assert.equal(result.manifest.apps[0]?.vulnerabilityScanning, true);
   assert.deepEqual(result.manifest.apps[0]?.deploymentInputs, [
     "apps/towbar-web-app/**",
     "packages/web-design-system/**",
@@ -245,6 +247,10 @@ void test("publishes server concurrency and hooks in the JSON schema", () => {
     type: "string",
   });
   assert.equal(schemaObject(appProperties.autoDeploy).default, false);
+  assert.deepEqual(appProperties.vulnerabilityScanning, {
+    default: false,
+    type: "boolean",
+  });
   const autoDeployVariants = schemaObject(appProperties.autoDeploy).oneOf;
   assert.ok(Array.isArray(autoDeployVariants));
   assert.equal(autoDeployVariants.length, 2);

--- a/packages/towbar-core/src/manifest.ts
+++ b/packages/towbar-core/src/manifest.ts
@@ -359,6 +359,7 @@ const resourceBackupSchema = z
 const appSchema = z
   .object({
     autoDeploy: appAutoDeploySchema.optional(),
+    vulnerabilityScanning: z.boolean().optional(),
     id: z.string().trim().regex(appIdPattern),
     name: z.string().trim().min(1).max(120),
     description: z.string().trim().max(500).optional(),
@@ -835,6 +836,7 @@ export type NormalizedDeploymentHook = {
 export type NormalizedApp = {
   kind?: "app";
   autoDeploy: boolean;
+  vulnerabilityScanning: boolean;
   container: {
     network?: string;
     port: number;
@@ -1059,6 +1061,7 @@ export function normalizeDeploymentManifest(
         return {
           kind: "app" as const,
           autoDeploy: automaticDeployment.enabled,
+          vulnerabilityScanning: app.vulnerabilityScanning ?? false,
           id: app.id,
           name: app.name,
           ...(app.description ? { description: app.description } : {}),

--- a/packages/towbar-core/src/preview.test.ts
+++ b/packages/towbar-core/src/preview.test.ts
@@ -12,6 +12,7 @@ import type { NormalizedApp } from "./manifest.js";
 
 const app: NormalizedApp = {
   autoDeploy: true,
+  vulnerabilityScanning: true,
   container: { port: 3000 },
   context: ".",
   deploymentInputs: ["apps/example/**"],
@@ -87,6 +88,7 @@ void test("builds Preview snapshots without production or shared secrets", () =>
     hostname: "example-feature-tw-4.preview.example.com",
   });
   assert.equal(snapshot.preview, undefined);
+  assert.equal(snapshot.vulnerabilityScanning, true);
   assert.equal(snapshot.sourceBranch, "feature/tw-4");
   assert.deepEqual(snapshot.domains, {
     primary: "example-feature-tw-4.preview.example.com",

--- a/packages/towbar-core/src/reconciliation.test.ts
+++ b/packages/towbar-core/src/reconciliation.test.ts
@@ -18,6 +18,7 @@ const desired: NormalizedDeploymentManifest = {
   apps: [
     {
       autoDeploy: false,
+      vulnerabilityScanning: false,
       id: "app",
       name: "Renamed app",
       server: "203.0.113.10",

--- a/packages/towbar-deployer/src/routing.test.ts
+++ b/packages/towbar-deployer/src/routing.test.ts
@@ -27,6 +27,7 @@ function context(
       server: "192.0.2.1",
       sourceBranch: "main",
       tls: { mode: tlsMode },
+      vulnerabilityScanning: false,
     },
     commitSha: "0123456789abcdef0123456789abcdef01234567",
     currentRelease: null,


### PR DESCRIPTION
## Summary
- add an optional `vulnerabilityScanning` App manifest setting, defaulting to `false`
- require both the installation-wide capability flag and App opt-in before automatic or manual scans
- keep Resources excluded and preserve prior scan results when an App opts out
- exclude the policy from runtime deployment digests so changing it does not redeploy the App
- document the two-level configuration and update the example manifest

## Validation
- `pnpm verify`

## Rollout
Deploy a release containing this change before syncing manifests that use `vulnerabilityScanning`. After that, enable `TOWBAR_VULNERABILITY_SCANNING_ENABLED=true` on the Towbar installation.