### PR TITLE
Release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to Towbar are documented in this file. This project follows
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-08-31
+
 ### Changed
 
 - Image vulnerability scanning now requires an explicit
@@ -157,7 +159,8 @@ All notable changes to Towbar are documented in this file. This project follows
 - Source-scoped AWS Secrets Manager integration and environment editors.
 - A same-domain owner setup, authentication, and operations dashboard.
 
-[Unreleased]: https://github.com/avgeek-inc/towbar/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/avgeek-inc/towbar/compare/v1.3.1...HEAD
+[1.3.1]: https://github.com/avgeek-inc/towbar/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/avgeek-inc/towbar/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/avgeek-inc/towbar/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/avgeek-inc/towbar/compare/v1.1.0...v1.1.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "towbar",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Opinionated, source-driven deployments to Ubuntu servers you own.",
   "keywords": [
     "deployment",


### PR DESCRIPTION
## Summary
- bump Towbar to `1.3.1`
- publish the per-App vulnerability-scanning gate in the changelog

## Validation
- `pnpm exec prettier --check package.json CHANGELOG.md`
- package version assertion
- `git diff --check`

After merge, publish the `v1.3.1` GitHub release so the release workflow deploys the exact tagged commit.