### PR TITLE
Fix idempotent PR plan evaluation (TW-45)

### DIFF
--- a/apps/towbar-api/README.md
+++ b/apps/towbar-api/README.md
@@ -69,7 +69,13 @@ Source inventory, repository input digests, server observations, credential
 metadata, and active operation state without resolving secret values or
 enqueueing work. The API publishes one completed GitHub Check per Source and
 head commit and links it to the full plan. Repeated deliveries update the
-existing Check; planning failures do not block Preview reconciliation.
+existing Check and reuse the same plan record and Preview deployment work for
+that Source, pull request, and head commit.
+Pull requests with no matching deployable changes produce a neutral `skipped`
+plan without evaluating unrelated server capacity, readiness, or secret
+bindings. Transient GitHub transport, rate-limit, and availability failures are
+retried instead of being persisted as blocked plans. GitHub Check reporting is
+tracked independently and cannot change or invalidate a persisted plan.
 
 AWS credentials and Servers are Source-scoped. Server identity is
 `(source_id, canonical_ip)`, allowing independent Sources to target the same IP

--- a/apps/towbar-api/src/areas/github/client.ts
+++ b/apps/towbar-api/src/areas/github/client.ts
@@ -4,10 +4,8 @@ import { SignJWT } from "jose";
 import { z } from "zod";
 
 import { requireGitHubEnv } from "../../env.js";
-import { HttpError, serviceUnavailable } from "../../http/errors.js";
-
-const githubApiBaseUrl = "https://api.github.com";
-const githubAccept = "application/vnd.github+json";
+import { HttpError } from "../../http/errors.js";
+import { githubRequest } from "./request.js";
 
 const installationSchema = z.object({
   account: z.object({
@@ -379,6 +377,7 @@ export async function createInstallationToken(installationId: string) {
   const value = installationTokenSchema.parse(
     await githubRequest(`/app/installations/${installationId}/access_tokens`, {
       method: "POST",
+      retry: true,
       token: jwt,
     }),
   );
@@ -576,50 +575,4 @@ async function createGitHubAppJwt() {
     .setIssuer(github.appId)
     .setExpirationTime(now + 9 * 60)
     .sign(createPrivateKey(github.privateKey));
-}
-
-async function githubRequest(
-  path: string,
-  options: {
-    body?: unknown;
-    method?: "DELETE" | "GET" | "PATCH" | "POST";
-    token: string;
-  },
-) {
-  let response: Response;
-  try {
-    response = await fetch(`${githubApiBaseUrl}${path}`, {
-      headers: {
-        accept: githubAccept,
-        authorization: `Bearer ${options.token}`,
-        "user-agent": "towbar.dev",
-        "x-github-api-version": "2022-11-28",
-        ...(options.body === undefined
-          ? {}
-          : { "content-type": "application/json" }),
-      },
-      body:
-        options.body === undefined ? undefined : JSON.stringify(options.body),
-      method: options.method ?? "GET",
-      signal: AbortSignal.timeout(15_000),
-    });
-  } catch (error) {
-    throw serviceUnavailable("GitHub could not be reached", { cause: error });
-  }
-  if (!response.ok) {
-    const requestId = response.headers.get("x-github-request-id");
-    throw new HttpError(
-      githubErrorStatus(response.status),
-      "GITHUB_REQUEST_FAILED",
-      requestId
-        ? `GitHub rejected the request (${requestId})`
-        : "GitHub rejected the request",
-    );
-  }
-  return response.status === 204 ? null : ((await response.json()) as unknown);
-}
-
-function githubErrorStatus(status: number): 403 | 404 | 409 | 502 {
-  if (status === 403 || status === 404 || status === 409) return status;
-  return 502;
 }

--- a/apps/towbar-api/src/areas/github/request.test.ts
+++ b/apps/towbar-api/src/areas/github/request.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { HttpError } from "../../http/errors.js";
+import { classifyGitHubResponseFailure, githubRequest } from "./request.js";
+
+void test("retries transport timeouts before returning GitHub data", async () => {
+  let attempts = 0;
+  const delays: number[] = [];
+  const value = await githubRequest(
+    "/meta",
+    { token: "test-token" },
+    {
+      fetch: () => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw new DOMException("timed out", "TimeoutError");
+        }
+        return Promise.resolve(Response.json({ ok: true }));
+      },
+      sleep: (delay) => {
+        delays.push(delay);
+        return Promise.resolve();
+      },
+    },
+  );
+
+  assert.deepEqual(value, { ok: true });
+  assert.equal(attempts, 3);
+  assert.deepEqual(delays, [250, 500]);
+});
+
+void test("reports exhausted timeouts as retryable connectivity failures", async () => {
+  await assert.rejects(
+    githubRequest(
+      "/meta",
+      { token: "test-token" },
+      {
+        fetch: () => {
+          throw new DOMException("timed out", "TimeoutError");
+        },
+        sleep: () => Promise.resolve(),
+      },
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.status, 503);
+      assert.equal(error.code, "SERVICE_UNAVAILABLE");
+      assert.match(error.message, /timed out after 3 attempts/u);
+      assert.doesNotMatch(error.message, /rejected/u);
+      return true;
+    },
+  );
+});
+
+void test("retries temporary GitHub responses", async () => {
+  let attempts = 0;
+  const value = await githubRequest(
+    "/meta",
+    { token: "test-token" },
+    {
+      fetch: () => {
+        attempts += 1;
+        return Promise.resolve(
+          attempts === 1
+            ? new Response(null, { status: 503 })
+            : Response.json({ ok: true }),
+        );
+      },
+      sleep: () => Promise.resolve(),
+    },
+  );
+
+  assert.deepEqual(value, { ok: true });
+  assert.equal(attempts, 2);
+});
+
+void test("does not replay a non-idempotent GitHub request", async () => {
+  let attempts = 0;
+  await assert.rejects(
+    githubRequest(
+      "/repos/example/comments",
+      { body: { body: "hello" }, method: "POST", token: "test-token" },
+      {
+        fetch: () => {
+          attempts += 1;
+          throw new DOMException("timed out", "TimeoutError");
+        },
+        sleep: () => Promise.resolve(),
+      },
+    ),
+    /timed out after 1 attempt/u,
+  );
+  assert.equal(attempts, 1);
+});
+
+void test("distinguishes rate limits from permission failures", () => {
+  const rateLimit = classifyGitHubResponseFailure(
+    new Response(null, {
+      headers: {
+        "x-github-request-id": "request-1",
+        "x-ratelimit-remaining": "0",
+      },
+      status: 403,
+    }),
+  );
+  const permission = classifyGitHubResponseFailure(
+    new Response(null, { status: 403 }),
+  );
+  const authentication = classifyGitHubResponseFailure(
+    new Response(null, { status: 401 }),
+  );
+
+  assert.equal(rateLimit.code, "GITHUB_RATE_LIMITED");
+  assert.equal(rateLimit.retryable, true);
+  assert.match(rateLimit.publicMessage, /rate limit exceeded/u);
+  assert.equal(permission.code, "GITHUB_REQUEST_FAILED");
+  assert.equal(permission.retryable, false);
+  assert.match(permission.publicMessage, /denied this request/u);
+  assert.equal(authentication.status, 403);
+  assert.equal(authentication.retryable, false);
+});

--- a/apps/towbar-api/src/areas/github/request.test.ts
+++ b/apps/towbar-api/src/areas/github/request.test.ts
@@ -53,6 +53,31 @@ void test("reports exhausted timeouts as retryable connectivity failures", async
   );
 });
 
+void test("reports exhausted connection resets as retryable connectivity failures", async () => {
+  await assert.rejects(
+    githubRequest(
+      "/meta",
+      { token: "test-token" },
+      {
+        fetch: () => {
+          const error = new Error("socket reset") as Error & { code: string };
+          error.code = "ECONNRESET";
+          throw error;
+        },
+        sleep: () => Promise.resolve(),
+      },
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.status, 503);
+      assert.equal(error.code, "SERVICE_UNAVAILABLE");
+      assert.match(error.message, /could not be reached after 3 attempts/u);
+      assert.doesNotMatch(error.message, /rejected/u);
+      return true;
+    },
+  );
+});
+
 void test("retries temporary GitHub responses", async () => {
   let attempts = 0;
   const value = await githubRequest(
@@ -107,6 +132,21 @@ void test("distinguishes rate limits from permission failures", () => {
   const permission = classifyGitHubResponseFailure(
     new Response(null, { status: 403 }),
   );
+  const secondaryRateLimit = classifyGitHubResponseFailure(
+    new Response(null, {
+      headers: {
+        "retry-after": "60",
+        "x-ratelimit-remaining": "42",
+      },
+      status: 403,
+    }),
+  );
+  const secondaryRateLimitWithoutHeaders = classifyGitHubResponseFailure(
+    new Response(null, { status: 403 }),
+    JSON.stringify({
+      message: "You have exceeded a secondary rate limit.",
+    }),
+  );
   const authentication = classifyGitHubResponseFailure(
     new Response(null, { status: 401 }),
   );
@@ -117,6 +157,11 @@ void test("distinguishes rate limits from permission failures", () => {
   assert.equal(permission.code, "GITHUB_REQUEST_FAILED");
   assert.equal(permission.retryable, false);
   assert.match(permission.publicMessage, /denied this request/u);
+  assert.equal(secondaryRateLimit.code, "GITHUB_RATE_LIMITED");
+  assert.equal(secondaryRateLimit.retryable, true);
+  assert.equal(secondaryRateLimit.retryAfterMilliseconds, 60_000);
+  assert.equal(secondaryRateLimitWithoutHeaders.code, "GITHUB_RATE_LIMITED");
+  assert.equal(secondaryRateLimitWithoutHeaders.retryable, true);
   assert.equal(authentication.status, 403);
   assert.equal(authentication.retryable, false);
 });

--- a/apps/towbar-api/src/areas/github/request.ts
+++ b/apps/towbar-api/src/areas/github/request.ts
@@ -1,0 +1,193 @@
+import { HttpError, serviceUnavailable } from "../../http/errors.js";
+
+const githubApiBaseUrl = "https://api.github.com";
+const githubAccept = "application/vnd.github+json";
+const maximumAttempts = 3;
+const maximumRetryDelayMs = 2_000;
+
+type GitHubRequestOptions = {
+  body?: unknown;
+  method?: "DELETE" | "GET" | "PATCH" | "POST";
+  retry?: boolean;
+  token: string;
+};
+
+type GitHubRequestDependencies = {
+  fetch: typeof globalThis.fetch;
+  sleep: (delayMs: number) => Promise<void>;
+};
+
+const defaultDependencies: GitHubRequestDependencies = {
+  fetch: globalThis.fetch,
+  sleep: async (delayMs) => {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  },
+};
+
+export async function githubRequest(
+  path: string,
+  options: GitHubRequestOptions,
+  dependencies: GitHubRequestDependencies = defaultDependencies,
+) {
+  let lastTransportError: unknown;
+  const method = options.method ?? "GET";
+  const retry =
+    options.retry ??
+    (method === "GET" || method === "PATCH" || method === "DELETE");
+  const attemptLimit = retry ? maximumAttempts : 1;
+  for (let attempt = 1; attempt <= attemptLimit; attempt += 1) {
+    let response: Response;
+    try {
+      response = await dependencies.fetch(`${githubApiBaseUrl}${path}`, {
+        headers: {
+          accept: githubAccept,
+          authorization: `Bearer ${options.token}`,
+          "user-agent": "towbar.dev",
+          "x-github-api-version": "2022-11-28",
+          ...(options.body === undefined
+            ? {}
+            : { "content-type": "application/json" }),
+        },
+        body:
+          options.body === undefined ? undefined : JSON.stringify(options.body),
+        method,
+        signal: AbortSignal.timeout(15_000),
+      });
+    } catch (error) {
+      lastTransportError = error;
+      if (attempt < attemptLimit) {
+        await dependencies.sleep(retryDelayMs(attempt));
+        continue;
+      }
+      throw serviceUnavailable(transportFailureMessage(error, attemptLimit), {
+        cause: error,
+      });
+    }
+
+    if (response.ok) {
+      return response.status === 204
+        ? null
+        : ((await response.json()) as unknown);
+    }
+
+    const failure = classifyGitHubResponseFailure(response);
+    await response.body?.cancel().catch(() => undefined);
+    if (failure.retryable && attempt < attemptLimit) {
+      await dependencies.sleep(
+        retryDelayMs(attempt, failure.retryAfterMilliseconds),
+      );
+      continue;
+    }
+    throw new HttpError(failure.status, failure.code, failure.publicMessage, {
+      responseHeaders: failure.responseHeaders,
+    });
+  }
+
+  throw serviceUnavailable(
+    transportFailureMessage(lastTransportError, attemptLimit),
+    {
+      cause: lastTransportError,
+    },
+  );
+}
+
+export function classifyGitHubResponseFailure(response: Response) {
+  const requestId = response.headers.get("x-github-request-id");
+  const requestSuffix = requestId ? ` (${requestId})` : "";
+  const rateLimited =
+    response.status === 429 ||
+    (response.status === 403 &&
+      response.headers.get("x-ratelimit-remaining") === "0");
+  if (rateLimited) {
+    const retryAfter = retryAfterMilliseconds(response.headers);
+    return {
+      code: "GITHUB_RATE_LIMITED",
+      publicMessage: `GitHub rate limit exceeded${requestSuffix}; Towbar will retry`,
+      responseHeaders:
+        retryAfter === undefined
+          ? undefined
+          : { "retry-after": String(Math.ceil(retryAfter / 1_000)) },
+      retryable: true,
+      retryAfterMilliseconds: retryAfter,
+      status: 429 as const,
+    };
+  }
+  if (response.status >= 500) {
+    return {
+      code: "GITHUB_UNAVAILABLE",
+      publicMessage: `GitHub is temporarily unavailable${requestSuffix}; Towbar will retry`,
+      responseHeaders: undefined,
+      retryable: true,
+      retryAfterMilliseconds: retryAfterMilliseconds(response.headers),
+      status: 503 as const,
+    };
+  }
+  const status = githubErrorStatus(response.status);
+  return {
+    code: "GITHUB_REQUEST_FAILED",
+    publicMessage: githubFailureMessage(status, requestSuffix),
+    responseHeaders: undefined,
+    retryable: false,
+    retryAfterMilliseconds: undefined,
+    status,
+  };
+}
+
+function transportFailureMessage(error: unknown, attemptCount: number) {
+  const attempts = `${attemptCount} ${attemptCount === 1 ? "attempt" : "attempts"}`;
+  return isTimeoutError(error)
+    ? `GitHub request timed out after ${attempts}; Towbar will retry`
+    : `GitHub could not be reached after ${attempts}; Towbar will retry`;
+}
+
+function isTimeoutError(error: unknown) {
+  return (
+    error instanceof Error &&
+    (error.name === "TimeoutError" || error.name === "AbortError")
+  );
+}
+
+function retryAfterMilliseconds(headers: Headers) {
+  const retryAfter = headers.get("retry-after");
+  if (retryAfter) {
+    const seconds = Number(retryAfter);
+    if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1_000;
+    const date = Date.parse(retryAfter);
+    if (Number.isFinite(date)) return Math.max(0, date - Date.now());
+  }
+  const reset = Number(headers.get("x-ratelimit-reset"));
+  return Number.isFinite(reset) && reset > 0
+    ? Math.max(0, reset * 1_000 - Date.now())
+    : undefined;
+}
+
+function retryDelayMs(attempt: number, requestedDelay?: number) {
+  if (requestedDelay !== undefined) {
+    return Math.min(requestedDelay, maximumRetryDelayMs);
+  }
+  return Math.min(250 * 2 ** (attempt - 1), maximumRetryDelayMs);
+}
+
+function githubErrorStatus(status: number): 403 | 404 | 409 | 422 {
+  if (status === 401 || status === 403) return 403;
+  if (status === 404 || status === 409 || status === 422) {
+    return status;
+  }
+  return 422;
+}
+
+function githubFailureMessage(
+  status: 403 | 404 | 409 | 422,
+  requestSuffix: string,
+) {
+  switch (status) {
+    case 403:
+      return `GitHub denied this request${requestSuffix}; verify the GitHub App permissions`;
+    case 404:
+      return `The requested GitHub resource was not found${requestSuffix}`;
+    case 409:
+      return `GitHub could not complete this request because the repository state changed${requestSuffix}`;
+    case 422:
+      return `GitHub could not process this request${requestSuffix}`;
+  }
+}

--- a/apps/towbar-api/src/areas/github/request.ts
+++ b/apps/towbar-api/src/areas/github/request.ts
@@ -70,7 +70,14 @@ export async function githubRequest(
         : ((await response.json()) as unknown);
     }
 
-    const failure = classifyGitHubResponseFailure(response);
+    const failureBody =
+      response.status === 403
+        ? await response
+            .clone()
+            .text()
+            .catch(() => "")
+        : "";
+    const failure = classifyGitHubResponseFailure(response, failureBody);
     await response.body?.cancel().catch(() => undefined);
     if (failure.retryable && attempt < attemptLimit) {
       await dependencies.sleep(
@@ -91,13 +98,20 @@ export async function githubRequest(
   );
 }
 
-export function classifyGitHubResponseFailure(response: Response) {
+export function classifyGitHubResponseFailure(
+  response: Response,
+  failureBody = "",
+) {
   const requestId = response.headers.get("x-github-request-id");
   const requestSuffix = requestId ? ` (${requestId})` : "";
   const rateLimited =
     response.status === 429 ||
     (response.status === 403 &&
-      response.headers.get("x-ratelimit-remaining") === "0");
+      (response.headers.get("x-ratelimit-remaining") === "0" ||
+        response.headers.has("retry-after") ||
+        /secondary rate limit|rate limit exceeded|exceeded (?:a )?(?:secondary |api )?rate limit|abuse detection/iu.test(
+          failureBody,
+        )));
   if (rateLimited) {
     const retryAfter = retryAfterMilliseconds(response.headers);
     return {

--- a/apps/towbar-api/src/areas/plans/github-check.test.ts
+++ b/apps/towbar-api/src/areas/plans/github-check.test.ts
@@ -8,12 +8,13 @@ void test("renders a no-op pull request as one neutral GitHub Check", () => {
     plan: {
       checks: [],
       items: [],
-      status: "ready",
+      status: "skipped",
       summary: { archive: 0, create: 0, no_op: 0, restore: 0, update: 0 },
     },
   });
   assert.equal(rendered.conclusion, "neutral");
-  assert.match(rendered.output.summary, /No deployment changes/u);
+  assert.equal(rendered.output.title, "No deployment changes");
+  assert.match(rendered.output.summary, /No deployment-relevant changes/u);
   assert.match(rendered.output.text, /No deployment-relevant changes/u);
 });
 

--- a/apps/towbar-api/src/areas/plans/github-check.ts
+++ b/apps/towbar-api/src/areas/plans/github-check.ts
@@ -24,9 +24,11 @@ export function renderDeploymentPlanGitHubCheck(input: {
   const summary =
     input.plan.status === "blocked"
       ? `${input.plan.checks.filter((check) => check.status === "failed").length} blocking validation issue(s) found.`
-      : changed.length === 0
-        ? "No deployment changes are required."
-        : `${changed.length} deployment change(s) are ready for review.`;
+      : input.plan.status === "skipped"
+        ? "No deployment-relevant changes matched this pull request."
+        : changed.length === 0
+          ? "No deployment changes are required."
+          : `${changed.length} deployment change(s) are ready for review.`;
   const itemRows = input.plan.items
     .slice(0, maximumReportedRows)
     .map(
@@ -43,7 +45,7 @@ export function renderDeploymentPlanGitHubCheck(input: {
     conclusion:
       input.plan.status === "blocked"
         ? ("failure" as const)
-        : input.plan.items.length === 0
+        : input.plan.status === "skipped"
           ? ("neutral" as const)
           : ("success" as const),
     output: {
@@ -80,7 +82,9 @@ export function renderDeploymentPlanGitHubCheck(input: {
       title:
         input.plan.status === "blocked"
           ? "Deployment plan blocked"
-          : "Deployment plan ready",
+          : input.plan.status === "skipped"
+            ? "No deployment changes"
+            : "Deployment plan ready",
     },
   };
 }

--- a/apps/towbar-api/src/areas/plans/identity.test.ts
+++ b/apps/towbar-api/src/areas/plans/identity.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { pullRequestDeploymentPlanIdentity } from "./identity.js";
+
+void test("uses one identity for repeated evaluation of the same pull request head", () => {
+  const input = {
+    pullRequestNumber: 42,
+    sourceId: "source-1",
+    targetCommitSha: "abc123",
+  };
+
+  assert.equal(
+    pullRequestDeploymentPlanIdentity(input),
+    pullRequestDeploymentPlanIdentity({ ...input }),
+  );
+  assert.notEqual(
+    pullRequestDeploymentPlanIdentity(input),
+    pullRequestDeploymentPlanIdentity({
+      ...input,
+      targetCommitSha: "def456",
+    }),
+  );
+});

--- a/apps/towbar-api/src/areas/plans/identity.ts
+++ b/apps/towbar-api/src/areas/plans/identity.ts
@@ -1,0 +1,14 @@
+import { digestValue } from "@workspace/towbar-core";
+
+export function pullRequestDeploymentPlanIdentity(input: {
+  pullRequestNumber: number;
+  sourceId: string;
+  targetCommitSha: string;
+}) {
+  return digestValue({
+    pullRequestNumber: input.pullRequestNumber,
+    sourceId: input.sourceId,
+    targetCommitSha: input.targetCommitSha,
+    trigger: "pull_request",
+  });
+}

--- a/apps/towbar-api/src/areas/plans/service.ts
+++ b/apps/towbar-api/src/areas/plans/service.ts
@@ -22,7 +22,7 @@ import {
   sources,
 } from "@workspace/towbar-database/schema";
 
-import { conflict, notFound } from "../../http/errors.js";
+import { HttpError, conflict, notFound } from "../../http/errors.js";
 import { getTowbarDatabase } from "../../infrastructure/database.js";
 import { inspectAwsSecretReferences } from "../aws/service.js";
 import { fetchGitHubManifestSnapshot } from "../github/client.js";
@@ -36,9 +36,12 @@ import {
   loadCurrentInventory,
 } from "../sources/inventory.js";
 import {
+  buildCandidateDeploymentPlanValidationChecks,
   buildDeploymentPlanValidationChecks,
-  collectSecretReferences,
+  buildDeploymentPlanValidationScope,
+  collectPlanSecretReferences,
 } from "./validation.js";
+import { pullRequestDeploymentPlanIdentity } from "./identity.js";
 
 import type {
   DeploymentPlan,
@@ -76,6 +79,7 @@ export async function createPullRequestDeploymentPlan(input: {
       commitSha: input.pullRequest.headSha,
     });
   } catch (error) {
+    if (!isPersistableCandidateError(error)) throw error;
     return await persistDeploymentPlan({
       branch: input.pullRequest.headBranch,
       candidateDigest: digestValue({
@@ -164,42 +168,67 @@ async function createAndPersistPullRequestDeploymentPlan(input: {
   try {
     const parsed = parseDeploymentManifest(input.candidate.manifestSource);
     targetManifestDigest = parsed.digest;
-    const [current, context, repositoryTree] = await Promise.all([
+    const [current, repositoryTree] = await Promise.all([
       loadCurrentInventory(input.source.id),
-      loadValidationContext(input.source, parsed.manifest),
       fetchRepositoryTreeForDeploymentInputs({
         commitSha: input.candidate.commitSha,
         manifestApps: parsed.manifest.apps,
         repository: input.source,
       }),
     ]);
-    const checks = buildDeploymentPlanValidationChecks({
-      context,
+    const staticChecks = buildCandidateDeploymentPlanValidationChecks({
       manifest: parsed.manifest,
+      sourceBranch: input.source.branch,
     });
+    const kindChecks: DeploymentPlanCheck[] = [];
     try {
       assertStableDeployableKinds(current, parsed.manifest);
     } catch (error) {
-      checks.push(planCheckFromError(error, "deployable_kind"));
+      kindChecks.push(planCheckFromError(error, "deployable_kind"));
     }
     const targetDigests = calculateDesiredDeploymentDigests({
       commitSha: input.candidate.commitSha,
       manifest: parsed.manifest,
       repositoryTree,
     });
-    plan = buildDeploymentPlan({
-      checks,
+    const planInput = {
       currentApps: current.apps,
       currentResources: current.resources,
       currentServers: current.servers,
       desired: parsed.manifest,
-      mode: "pull_request",
+      mode: "pull_request" as const,
       repositoryChanges: input.repositoryChanges,
       targetDeploymentDigests: new Map(
         [...targetDigests].map(([id, digest]) => [id, digest.deploymentDigest]),
       ),
+    };
+    const candidatePlan = buildDeploymentPlan({
+      ...planInput,
+      checks: [...staticChecks, ...kindChecks],
     });
+    if (candidatePlan.status === "skipped") {
+      plan = candidatePlan;
+    } else {
+      const scope = buildDeploymentPlanValidationScope({
+        items: candidatePlan.items,
+        manifest: parsed.manifest,
+      });
+      const context = await loadValidationContext(
+        input.source,
+        parsed.manifest,
+        scope,
+      );
+      plan = buildDeploymentPlan({
+        ...planInput,
+        checks: buildDeploymentPlanValidationChecks({
+          context,
+          manifest: parsed.manifest,
+          scope,
+        }).concat(kindChecks),
+      });
+    }
   } catch (error) {
+    if (!isPersistableCandidateError(error)) throw error;
     plan = buildBlockedDeploymentPlan(planChecksFromCandidateError(error));
   }
 
@@ -223,16 +252,10 @@ async function persistDeploymentPlan(input: {
   targetCommitSha: string;
   targetManifestDigest: string | null;
 }) {
-  const identityDigest = digestValue({
-    candidateDigest: input.candidateDigest,
-    currentCommitSha: input.source.latestCommitSha,
-    currentManifestDigest: input.source.latestManifestDigest,
-    plan: input.plan,
+  const identityDigest = pullRequestDeploymentPlanIdentity({
     pullRequestNumber: input.pullRequestNumber,
     sourceId: input.source.id,
     targetCommitSha: input.targetCommitSha,
-    targetManifestDigest: input.targetManifestDigest,
-    trigger: "pull_request",
   });
   const database = getTowbarDatabase();
   const [inserted] = await database
@@ -255,20 +278,30 @@ async function persistDeploymentPlan(input: {
     })
     .onConflictDoNothing()
     .returning(publicPlanSelection);
-  const persisted =
-    inserted ??
-    (
-      await database
-        .select(publicPlanSelection)
-        .from(deploymentPlans)
+  const [updated] = inserted
+    ? []
+    : await database
+        .update(deploymentPlans)
+        .set({
+          branch: input.branch,
+          candidateDigest: input.candidateDigest,
+          currentCommitSha: input.source.latestCommitSha,
+          currentManifestDigest: input.source.latestManifestDigest,
+          identityDigest,
+          plan: input.plan,
+          status: input.plan.status,
+          targetManifestDigest: input.targetManifestDigest,
+        })
         .where(
           and(
             eq(deploymentPlans.sourceId, input.source.id),
-            eq(deploymentPlans.identityDigest, identityDigest),
+            eq(deploymentPlans.pullRequestNumber, input.pullRequestNumber),
+            eq(deploymentPlans.targetCommitSha, input.targetCommitSha),
+            eq(deploymentPlans.trigger, "pull_request"),
           ),
         )
-        .limit(1)
-    )[0];
+        .returning(publicPlanSelection);
+  const persisted = inserted ?? updated;
   if (!persisted) throw new Error("Unable to persist deployment plan");
   await database
     .insert(deploymentPlanGithubChecks)
@@ -317,7 +350,8 @@ async function assertSourceAccess(sourceId: string, workspaceId: string) {
 
 async function loadValidationContext(
   source: PlanningSource,
-  manifest: Parameters<typeof collectSecretReferences>[0],
+  manifest: Parameters<typeof collectPlanSecretReferences>[0],
+  scope: Parameters<typeof collectPlanSecretReferences>[1],
 ) {
   const database = getTowbarDatabase();
   const [domainRows, serverRows, credentialRows, capacities, operations] =
@@ -351,7 +385,7 @@ async function loadValidationContext(
       loadActiveOperationDescriptions(source.id),
     ]);
   const credentialStatus = credentialRows[0]?.status ?? null;
-  const secretReferences = collectSecretReferences(manifest);
+  const secretReferences = collectPlanSecretReferences(manifest, scope);
   const secretBindings =
     credentialStatus === "verified" && secretReferences.length > 0
       ? await inspectAwsSecretReferences({
@@ -486,6 +520,13 @@ function planChecksFromCandidateError(error: unknown): DeploymentPlanCheck[] {
     }));
   }
   return [planCheckFromError(error, "candidate_unavailable")];
+}
+
+function isPersistableCandidateError(error: unknown) {
+  return (
+    error instanceof ManifestValidationError ||
+    (error instanceof HttpError && error.status !== 429 && error.status < 500)
+  );
 }
 
 function planCheckFromError(error: unknown, code: string): DeploymentPlanCheck {

--- a/apps/towbar-api/src/areas/plans/validation.test.ts
+++ b/apps/towbar-api/src/areas/plans/validation.test.ts
@@ -8,6 +8,8 @@ import {
 
 import {
   buildDeploymentPlanValidationChecks,
+  buildDeploymentPlanValidationScope,
+  collectPlanSecretReferences,
   collectSecretReferences,
   parseDockerMemoryBytes,
 } from "./validation.js";
@@ -39,6 +41,40 @@ void test("collects sorted secret names without resolving values", () => {
   assert.deepEqual(
     collectSecretReferences({ second: "aws:z", first: ["aws:a", "plain"] }),
     ["aws:a", "aws:z"],
+  );
+});
+
+void test("does not require shared runtime secrets for an archive-only plan", () => {
+  const candidate = normalizeDeploymentManifest({
+    version: 1,
+    source: { branch: "main" },
+    secrets: { deployment: ["aws:source/shared-runtime"] },
+    servers: [
+      {
+        ip: "192.0.2.10",
+        secrets: { login: "aws:source/server-login" },
+        ssh: { username: "deploy" },
+      },
+    ],
+    apps: [
+      {
+        id: "retained-app",
+        name: "Retained app",
+        server: "192.0.2.10",
+        container: { port: 3000 },
+        context: ".",
+        dockerfile: "Dockerfile",
+        health: { path: "/health" },
+      },
+    ],
+  });
+
+  assert.deepEqual(
+    collectPlanSecretReferences(candidate, {
+      deployableIds: ["archived-app"],
+      serverIps: [],
+    }),
+    [],
   );
 });
 
@@ -74,7 +110,157 @@ void test("returns actionable checks without secret values", () => {
     checks.some((check) => check.code === "operation_conflict"),
     true,
   );
+  assert.equal(
+    checks.find((check) => check.code === "operation_conflict")?.status,
+    "warning",
+  );
   assert.equal(JSON.stringify(checks).includes("server-login"), true);
+});
+
+void test("validates only deployables and servers affected by the plan", () => {
+  const candidate = normalizeDeploymentManifest({
+    version: 1,
+    source: { branch: "main" },
+    servers: [
+      {
+        ip: "192.0.2.10",
+        secrets: { login: "aws:source/server-login" },
+        ssh: { username: "deploy" },
+      },
+      {
+        ip: "192.0.2.11",
+        secrets: { login: "aws:source/unrelated-login" },
+        ssh: { username: "deploy" },
+      },
+    ],
+    apps: [
+      {
+        id: "website",
+        name: "Website",
+        server: "192.0.2.10",
+        container: { port: 3000 },
+        context: ".",
+        dockerfile: "Dockerfile",
+        health: { path: "/health" },
+      },
+      {
+        id: "unrelated",
+        name: "Unrelated",
+        server: "192.0.2.11",
+        container: { port: 3001 },
+        context: ".",
+        dockerfile: "Dockerfile",
+        health: { path: "/health" },
+      },
+    ],
+  });
+  const scope = buildDeploymentPlanValidationScope({
+    items: [
+      {
+        action: "update",
+        automaticDeployment: true,
+        changedFields: [],
+        entityId: "website",
+        entityKind: "app",
+        matchedPaths: ["apps/website/page.tsx"],
+        name: "Website",
+        reasons: ["Deployment inputs changed"],
+      },
+    ],
+    manifest: candidate,
+  });
+  const currentServer = candidate.servers[0]!;
+  const currentDigest = digestValue(currentServer);
+  const checks = buildDeploymentPlanValidationChecks({
+    context: {
+      activeOperationDescriptions: [],
+      capacities: [],
+      credentialStatus: "verified",
+      existingDomainClaims: [],
+      materializedServers: [
+        {
+          config: currentServer,
+          configDigest: currentDigest,
+          ip: currentServer.ip,
+          preparedAt: new Date(),
+          preparedConfigDigest: currentDigest,
+        },
+      ],
+      secretBindings: [
+        { available: true, reference: "aws:source/server-login" },
+      ],
+      sourceBranch: "main",
+    },
+    manifest: candidate,
+    scope,
+  });
+
+  assert.deepEqual(scope, {
+    deployableIds: ["website"],
+    serverIps: ["192.0.2.10"],
+  });
+  assert.equal(
+    checks.some((check) =>
+      check.references?.includes("aws:source/unrelated-login"),
+    ),
+    false,
+  );
+  assert.equal(
+    checks.some((check) => check.entityId === "192.0.2.11"),
+    false,
+  );
+});
+
+void test("warns when declared CPU limits intentionally overcommit the host", () => {
+  const candidate = structuredClone(manifest);
+  candidate.apps[0]!.container.resources = { cpus: 2, memory: "512m" };
+  const currentServer = candidate.servers[0]!;
+  const currentDigest = digestValue(currentServer);
+  const checks = buildDeploymentPlanValidationChecks({
+    context: {
+      activeOperationDescriptions: [],
+      capacities: [
+        {
+          checkedAt: new Date().toISOString(),
+          cpu: { loadAverage1m: 0.2, logicalCount: 1, usagePercent: 20 },
+          disk: null,
+          id: "server-1",
+          ip: currentServer.ip,
+          latestCheckStatus: "succeeded",
+          memory: {
+            availableBytes: 4_000,
+            totalBytes: 8_000,
+            usedPercent: 50,
+          },
+          runtimes: [],
+          sourceId: "source-1",
+          status: "healthy",
+          uptimeSeconds: 3_600,
+        },
+      ],
+      credentialStatus: "verified",
+      existingDomainClaims: [],
+      materializedServers: [
+        {
+          config: currentServer,
+          configDigest: currentDigest,
+          ip: currentServer.ip,
+          preparedAt: new Date(),
+          preparedConfigDigest: currentDigest,
+        },
+      ],
+      secretBindings: [
+        { available: true, reference: "aws:source/server-login" },
+      ],
+      sourceBranch: "main",
+    },
+    manifest: candidate,
+  });
+
+  assert.equal(
+    checks.find((check) => check.code === "cpu_capacity_exceeded")?.status,
+    "warning",
+  );
 });
 
 void test("blocks secret bindings that cannot be described by name", () => {

--- a/apps/towbar-api/src/areas/plans/validation.ts
+++ b/apps/towbar-api/src/areas/plans/validation.ts
@@ -2,10 +2,16 @@ import { requiresServerPreparation } from "@workspace/towbar-core";
 
 import type {
   DeploymentPlanCheck,
+  DeploymentPlanItem,
   NormalizedDeploymentManifest,
   NormalizedServer,
   RuntimeCapacity,
 } from "@workspace/towbar-core";
+
+export type DeploymentPlanValidationScope = {
+  deployableIds: string[];
+  serverIps: string[];
+};
 
 export type DeploymentPlanValidationContext = {
   activeOperationDescriptions: string[];
@@ -26,6 +32,24 @@ export type DeploymentPlanValidationContext = {
 export function buildDeploymentPlanValidationChecks(input: {
   context: DeploymentPlanValidationContext;
   manifest: NormalizedDeploymentManifest;
+  scope?: DeploymentPlanValidationScope;
+}): DeploymentPlanCheck[] {
+  const scope = input.scope ?? fullManifestScope(input.manifest);
+  return [
+    ...buildCandidateDeploymentPlanValidationChecks({
+      manifest: input.manifest,
+      sourceBranch: input.context.sourceBranch,
+    }),
+    ...validateDomains({ ...input, scope }),
+    ...validateServers({ ...input, scope }),
+    ...validateSecretBindings({ ...input, scope }),
+    ...validateOperationConflicts(input.context.activeOperationDescriptions),
+  ];
+}
+
+export function buildCandidateDeploymentPlanValidationChecks(input: {
+  manifest: NormalizedDeploymentManifest;
+  sourceBranch: string;
 }): DeploymentPlanCheck[] {
   return [
     {
@@ -33,12 +57,56 @@ export function buildDeploymentPlanValidationChecks(input: {
       message: "The candidate manifest matches the Towbar v1 schema",
       status: "passed",
     },
-    ...validateSourceBranch(input),
-    ...validateDomains(input),
-    ...validateServers(input),
-    ...validateSecretBindings(input),
-    ...validateOperationConflicts(input.context.activeOperationDescriptions),
+    ...validateSourceBranch({
+      context: { sourceBranch: input.sourceBranch },
+      manifest: input.manifest,
+    }),
   ];
+}
+
+export function buildDeploymentPlanValidationScope(input: {
+  items: DeploymentPlanItem[];
+  manifest: NormalizedDeploymentManifest;
+}): DeploymentPlanValidationScope {
+  const deployableIds = new Set(
+    input.items
+      .filter(
+        (item) =>
+          item.action !== "no_op" &&
+          (item.entityKind === "app" || item.entityKind === "resource"),
+      )
+      .map((item) => item.entityId),
+  );
+  const serverIps = new Set(
+    input.items
+      .filter((item) => item.action !== "no_op" && item.entityKind === "server")
+      .map((item) => item.entityId),
+  );
+  for (const deployable of deployables(input.manifest)) {
+    if (deployableIds.has(deployable.id)) serverIps.add(deployable.server);
+  }
+  return {
+    deployableIds: [...deployableIds].sort((left, right) =>
+      left.localeCompare(right),
+    ),
+    serverIps: [...serverIps].sort((left, right) => left.localeCompare(right)),
+  };
+}
+
+export function collectPlanSecretReferences(
+  manifest: NormalizedDeploymentManifest,
+  scope: DeploymentPlanValidationScope,
+) {
+  const deployableIds = new Set(scope.deployableIds);
+  const serverIps = new Set(scope.serverIps);
+  const scopedDeployables = deployables(manifest).filter((deployable) =>
+    deployableIds.has(deployable.id),
+  );
+  return collectSecretReferences([
+    ...(scopedDeployables.length > 0 ? [manifest.secrets] : []),
+    ...scopedDeployables,
+    ...manifest.servers.filter((server) => serverIps.has(server.ip)),
+  ]);
 }
 
 export function collectSecretReferences(value: unknown) {
@@ -60,7 +128,7 @@ export function parseDockerMemoryBytes(value: string) {
 }
 
 function validateSourceBranch(input: {
-  context: DeploymentPlanValidationContext;
+  context: Pick<DeploymentPlanValidationContext, "sourceBranch">;
   manifest: NormalizedDeploymentManifest;
 }): DeploymentPlanCheck[] {
   if (input.manifest.source.branch === input.context.sourceBranch) return [];
@@ -77,12 +145,15 @@ function validateSourceBranch(input: {
 function validateDomains(input: {
   context: DeploymentPlanValidationContext;
   manifest: NormalizedDeploymentManifest;
+  scope: DeploymentPlanValidationScope;
 }) {
   const claims = new Map(
     input.context.existingDomainClaims.map((claim) => [claim.domain, claim]),
   );
-  return deployables(input.manifest).flatMap<DeploymentPlanCheck>(
-    (deployable) =>
+  const deployableIds = new Set(input.scope.deployableIds);
+  return deployables(input.manifest)
+    .filter((deployable) => deployableIds.has(deployable.id))
+    .flatMap<DeploymentPlanCheck>((deployable) =>
       deployable.domains
         ? [
             deployable.domains.primary,
@@ -106,12 +177,13 @@ function validateDomains(input: {
               : [];
           })
         : [],
-  );
+    );
 }
 
 function validateServers(input: {
   context: DeploymentPlanValidationContext;
   manifest: NormalizedDeploymentManifest;
+  scope: DeploymentPlanValidationScope;
 }) {
   const materialized = new Map(
     input.context.materializedServers.map((server) => [server.ip, server]),
@@ -119,47 +191,50 @@ function validateServers(input: {
   const capacities = new Map(
     input.context.capacities.map((capacity) => [capacity.ip, capacity]),
   );
-  return input.manifest.servers.flatMap<DeploymentPlanCheck>((server) => {
-    const checks: DeploymentPlanCheck[] = [];
-    const current = materialized.get(server.ip);
-    if (!current) {
-      checks.push({
-        code: "server_not_materialized",
-        entityId: server.ip,
-        entityKind: "server",
-        message:
-          "Sync this Source, trust its SSH host key, and prepare the new server before deployment",
-        status: "failed",
-      });
+  const serverIps = new Set(input.scope.serverIps);
+  return input.manifest.servers
+    .filter((server) => serverIps.has(server.ip))
+    .flatMap<DeploymentPlanCheck>((server) => {
+      const checks: DeploymentPlanCheck[] = [];
+      const current = materialized.get(server.ip);
+      if (!current) {
+        checks.push({
+          code: "server_not_materialized",
+          entityId: server.ip,
+          entityKind: "server",
+          message:
+            "Sync this Source, trust its SSH host key, and prepare the new server before deployment",
+          status: "failed",
+        });
+        return checks;
+      }
+      if (
+        !current.preparedAt ||
+        current.preparedConfigDigest !== current.configDigest ||
+        requiresServerPreparation(current.config, server)
+      ) {
+        checks.push({
+          code: "server_not_ready",
+          entityId: server.ip,
+          entityKind: "server",
+          message:
+            "The server must be prepared for the candidate configuration before deployment",
+          status: "failed",
+        });
+      } else {
+        checks.push({
+          code: "server_ready",
+          entityId: server.ip,
+          entityKind: "server",
+          message: "The server is prepared for the candidate configuration",
+          status: "passed",
+        });
+      }
+      checks.push(
+        ...capacityChecks(input.manifest, server.ip, capacities.get(server.ip)),
+      );
       return checks;
-    }
-    if (
-      !current.preparedAt ||
-      current.preparedConfigDigest !== current.configDigest ||
-      requiresServerPreparation(current.config, server)
-    ) {
-      checks.push({
-        code: "server_not_ready",
-        entityId: server.ip,
-        entityKind: "server",
-        message:
-          "The server must be prepared for the candidate configuration before deployment",
-        status: "failed",
-      });
-    } else {
-      checks.push({
-        code: "server_ready",
-        entityId: server.ip,
-        entityKind: "server",
-        message: "The server is prepared for the candidate configuration",
-        status: "passed",
-      });
-    }
-    checks.push(
-      ...capacityChecks(input.manifest, server.ip, capacities.get(server.ip)),
-    );
-    return checks;
-  });
+    });
 }
 
 function capacityChecks(
@@ -221,7 +296,7 @@ function capacityChecks(
       entityId: serverIp,
       entityKind: "server",
       message: `Declared container CPU limits (${declared.cpus}) exceed ${capacity.cpu.logicalCount} logical CPUs`,
-      status: "failed",
+      status: "warning",
     });
   }
   if (capacity.memory && declared.memoryBytes > capacity.memory.totalBytes) {
@@ -248,8 +323,9 @@ function capacityChecks(
 function validateSecretBindings(input: {
   context: DeploymentPlanValidationContext;
   manifest: NormalizedDeploymentManifest;
+  scope: DeploymentPlanValidationScope;
 }): DeploymentPlanCheck[] {
-  const references = collectSecretReferences(input.manifest);
+  const references = collectPlanSecretReferences(input.manifest, input.scope);
   if (references.length === 0) return [];
   if (input.context.credentialStatus !== "verified") {
     return [
@@ -293,12 +369,21 @@ function validateOperationConflicts(descriptions: string[]) {
       code: "operation_conflict",
       entityKind: "source",
       message: description,
-      status: "failed",
+      status: "warning",
     }));
 }
 
 function deployables(manifest: NormalizedDeploymentManifest) {
   return [...manifest.apps, ...(manifest.resources ?? [])];
+}
+
+function fullManifestScope(
+  manifest: NormalizedDeploymentManifest,
+): DeploymentPlanValidationScope {
+  return {
+    deployableIds: deployables(manifest).map((deployable) => deployable.id),
+    serverIps: manifest.servers.map((server) => server.ip),
+  };
 }
 
 function visitStrings(value: unknown, callback: (value: string) => void) {

--- a/apps/towbar-api/src/areas/previews/admission-state.test.ts
+++ b/apps/towbar-api/src/areas/previews/admission-state.test.ts
@@ -3,6 +3,9 @@ import test from "node:test";
 
 import {
   isPreviewReleaseCurrent,
+  previewAdmissionLockKey,
+  previewAdmissionReplayAction,
+  previewDeploymentIdempotencyKey,
   shouldDeferPreviewAdmission,
 } from "./admission-state.js";
 
@@ -16,4 +19,61 @@ void test("keeps an input-equivalent Preview release current", () => {
   assert.equal(isPreviewReleaseCurrent("same-inputs", "same-inputs"), true);
   assert.equal(isPreviewReleaseCurrent("old-inputs", "new-inputs"), false);
   assert.equal(isPreviewReleaseCurrent(undefined, "new-inputs"), false);
+});
+
+void test("replays active Preview work and preserves genuine terminal outcomes", () => {
+  assert.equal(
+    previewAdmissionReplayAction({
+      deploymentErrorCode: null,
+      deploymentState: "queued",
+      environmentStatus: "building",
+    }),
+    "enqueue",
+  );
+  assert.equal(
+    previewAdmissionReplayAction({
+      deploymentErrorCode: "DEPLOYMENT_FAILED",
+      deploymentState: "failed",
+      environmentStatus: "failed",
+    }),
+    "reuse",
+  );
+});
+
+void test("recovers an uncertain enqueue without reusing cleaned Preview work", () => {
+  assert.equal(
+    previewAdmissionReplayAction({
+      deploymentErrorCode: "TEMPORAL_UNAVAILABLE",
+      deploymentState: "failed",
+      environmentStatus: "failed",
+    }),
+    "reset_and_enqueue",
+  );
+  assert.equal(
+    previewAdmissionReplayAction({
+      deploymentErrorCode: null,
+      deploymentState: "succeeded",
+      environmentStatus: "deleted",
+    }),
+    "replace",
+  );
+});
+
+void test("uses stable identities when a Preview admission activity is retried", () => {
+  assert.equal(
+    previewAdmissionLockKey({
+      appId: "app-1",
+      gitRef: "refs/pull/42/head",
+      sourceId: "source-1",
+    }),
+    "preview-admission:source-1:app-1:refs/pull/42/head",
+  );
+  assert.equal(
+    previewDeploymentIdempotencyKey({
+      commitSha: "abc123",
+      deploymentDigest: "deployment-digest",
+      environmentId: "environment-1",
+    }),
+    "preview:environment-1:abc123:deployment-digest",
+  );
 });

--- a/apps/towbar-api/src/areas/previews/admission-state.ts
+++ b/apps/towbar-api/src/areas/previews/admission-state.ts
@@ -1,5 +1,31 @@
+import { terminalDeploymentStates } from "@workspace/towbar-core/temporal";
+
+import type { DeploymentState } from "@workspace/towbar-core/temporal";
+
 export function shouldDeferPreviewAdmission(status: string | undefined) {
   return status === "deleting";
+}
+
+export function previewAdmissionReplayAction(input: {
+  deploymentErrorCode: string | null;
+  deploymentState: DeploymentState;
+  environmentStatus: string;
+}) {
+  if (
+    input.environmentStatus === "deleted" ||
+    input.environmentStatus === "cleanup_failed"
+  ) {
+    return "replace" as const;
+  }
+  if (
+    input.deploymentState === "failed" &&
+    input.deploymentErrorCode === "TEMPORAL_UNAVAILABLE"
+  ) {
+    return "reset_and_enqueue" as const;
+  }
+  return terminalDeploymentStates.has(input.deploymentState)
+    ? ("reuse" as const)
+    : ("enqueue" as const);
 }
 
 export function isPreviewReleaseCurrent(
@@ -7,4 +33,20 @@ export function isPreviewReleaseCurrent(
   desiredDeploymentDigest: string,
 ) {
   return currentDeploymentDigest === desiredDeploymentDigest;
+}
+
+export function previewAdmissionLockKey(input: {
+  appId: string;
+  gitRef: string;
+  sourceId: string;
+}) {
+  return `preview-admission:${input.sourceId}:${input.appId}:${input.gitRef}`;
+}
+
+export function previewDeploymentIdempotencyKey(input: {
+  commitSha: string;
+  deploymentDigest: string;
+  environmentId: string;
+}) {
+  return `preview:${input.environmentId}:${input.commitSha}:${input.deploymentDigest}`;
 }

--- a/apps/towbar-api/src/areas/previews/admission.ts
+++ b/apps/towbar-api/src/areas/previews/admission.ts
@@ -1,0 +1,394 @@
+import { randomUUID } from "node:crypto";
+
+import { and, eq, sql } from "drizzle-orm";
+
+import {
+  digestValue,
+  previewRef,
+  previewRuntimeId,
+} from "@workspace/towbar-core";
+import { deploymentWorkflowId } from "@workspace/towbar-core/temporal";
+import type { servers } from "@workspace/towbar-database/schema";
+import {
+  deployments,
+  previewEnvironments,
+  releases,
+} from "@workspace/towbar-database/schema";
+
+import { getTowbarDatabase } from "../../infrastructure/database.js";
+import {
+  isPreviewReleaseCurrent,
+  previewAdmissionLockKey,
+  previewAdmissionReplayAction,
+  previewDeploymentIdempotencyKey,
+  shouldDeferPreviewAdmission,
+} from "./admission-state.js";
+
+import type { NormalizedApp } from "@workspace/towbar-core";
+
+type Transaction = Parameters<
+  Parameters<ReturnType<typeof getTowbarDatabase>["transaction"]>[0]
+>[0];
+
+export async function admitPreviewDeployment(input: {
+  appId: string;
+  branch: string;
+  commitSha: string;
+  config: NormalizedApp;
+  deploymentDigest: string;
+  hostname: string;
+  manifestDigest: string;
+  pullRequestNumber: number;
+  server: (typeof servers.$inferSelect)["config"];
+  serverId: string;
+  sourceId: string;
+  sourceInputDigest: string | null;
+  ttlHours: number;
+  workspaceId: string;
+}) {
+  const database = getTowbarDatabase();
+  const gitRef = previewRef(input.pullRequestNumber);
+  const runtimeId = previewRuntimeId({
+    appId: input.config.id,
+    pullRequestNumber: input.pullRequestNumber,
+    sourceId: input.sourceId,
+  });
+  const deploymentId = randomUUID();
+  const expiresAt = new Date(Date.now() + input.ttlHours * 60 * 60_000);
+  return await database.transaction(async (transaction) => {
+    const admissionLockKey = previewAdmissionLockKey({
+      appId: input.appId,
+      gitRef,
+      sourceId: input.sourceId,
+    });
+    await transaction.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${admissionLockKey}, 0))`,
+    );
+    const [existingEnvironment] = await transaction
+      .select({
+        id: previewEnvironments.id,
+        latestDeploymentId: previewEnvironments.latestDeploymentId,
+        status: previewEnvironments.status,
+      })
+      .from(previewEnvironments)
+      .where(
+        and(
+          eq(previewEnvironments.sourceId, input.sourceId),
+          eq(previewEnvironments.appId, input.appId),
+          eq(previewEnvironments.gitRef, gitRef),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (
+      existingEnvironment &&
+      shouldDeferPreviewAdmission(existingEnvironment.status)
+    ) {
+      return {
+        created: false,
+        deferred: true,
+        deploymentId: null,
+        shouldEnqueue: false,
+        environmentId: existingEnvironment.id,
+        supersededDeploymentIds: [],
+      };
+    }
+    const [latestDeployment] = existingEnvironment?.latestDeploymentId
+      ? await transaction
+          .select({
+            commitSha: deployments.commitSha,
+            deploymentDigest: deployments.deploymentDigest,
+            errorCode: deployments.errorCode,
+            errorMessage: deployments.errorMessage,
+            id: deployments.id,
+            state: deployments.state,
+          })
+          .from(deployments)
+          .where(eq(deployments.id, existingEnvironment.latestDeploymentId))
+          .limit(1)
+      : [];
+    if (
+      existingEnvironment &&
+      latestDeployment?.commitSha === input.commitSha &&
+      latestDeployment.deploymentDigest === input.deploymentDigest
+    ) {
+      const replay = await replayPreviewDeployment(transaction, {
+        deployment: latestDeployment,
+        environment: existingEnvironment,
+        expiresAt,
+        input,
+        runtimeId,
+      });
+      if (replay) return replay;
+    }
+    const reopeningEnvironment =
+      existingEnvironment?.status === "deleted" ||
+      existingEnvironment?.status === "cleanup_failed";
+    const [environment] = await transaction
+      .insert(previewEnvironments)
+      .values({
+        appId: input.appId,
+        branch: input.branch,
+        expiresAt,
+        gitRef,
+        hostname: input.hostname,
+        latestCommitSha: input.commitSha,
+        pullRequestNumber: input.pullRequestNumber,
+        runtimeId,
+        serverId: input.serverId,
+        sourceId: input.sourceId,
+        workspaceId: input.workspaceId,
+      })
+      .onConflictDoUpdate({
+        target: [
+          previewEnvironments.sourceId,
+          previewEnvironments.appId,
+          previewEnvironments.gitRef,
+        ],
+        set: {
+          branch: input.branch,
+          deletedAt: null,
+          errorMessage: null,
+          expiresAt,
+          hostname: input.hostname,
+          latestCommitSha: input.commitSha,
+          pullRequestNumber: input.pullRequestNumber,
+          runtimeId,
+          serverId: input.serverId,
+          status: "building",
+          updatedAt: new Date(),
+        },
+      })
+      .returning();
+    if (!environment)
+      throw new Error("Unable to materialize Preview environment");
+
+    const baseIdempotencyKey = previewDeploymentIdempotencyKey({
+      commitSha: input.commitSha,
+      deploymentDigest: input.deploymentDigest,
+      environmentId: environment.id,
+    });
+    const idempotencyKey = reopeningEnvironment
+      ? `${baseIdempotencyKey}:${deploymentId}`
+      : baseIdempotencyKey;
+    const [existingDeployment] = await transaction
+      .select({
+        errorCode: deployments.errorCode,
+        errorMessage: deployments.errorMessage,
+        id: deployments.id,
+        state: deployments.state,
+      })
+      .from(deployments)
+      .where(
+        and(
+          eq(deployments.workspaceId, input.workspaceId),
+          eq(deployments.idempotencyKey, idempotencyKey),
+        ),
+      )
+      .limit(1);
+    if (existingDeployment) {
+      const replay = await replayPreviewDeployment(transaction, {
+        deployment: existingDeployment,
+        environment: {
+          id: environment.id,
+          status: existingEnvironment?.status ?? environment.status,
+        },
+        expiresAt,
+        input,
+        runtimeId,
+      });
+      if (replay) return replay;
+    }
+
+    const [current] = await transaction
+      .select({ deploymentDigest: releases.deploymentDigest })
+      .from(releases)
+      .where(
+        and(
+          eq(releases.previewEnvironmentId, environment.id),
+          eq(releases.status, "current"),
+        ),
+      )
+      .limit(1);
+    if (
+      !reopeningEnvironment &&
+      isPreviewReleaseCurrent(current?.deploymentDigest, input.deploymentDigest)
+    ) {
+      await transaction
+        .update(previewEnvironments)
+        .set({ status: "healthy", updatedAt: new Date() })
+        .where(eq(previewEnvironments.id, environment.id));
+      return {
+        created: false,
+        deferred: false,
+        deploymentId: null,
+        environmentId: environment.id,
+        shouldEnqueue: false,
+        supersededDeploymentIds: [],
+      };
+    }
+
+    const now = new Date();
+    const supersededDeployments = await transaction
+      .update(deployments)
+      .set({
+        errorCode: "PREVIEW_SUPERSEDED",
+        errorMessage: "Superseded by a newer Preview commit",
+        finishedAt: now,
+        state: "skipped",
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(deployments.previewEnvironmentId, environment.id),
+          eq(deployments.state, "queued"),
+        ),
+      )
+      .returning({ id: deployments.id });
+    const [insertedDeployment] = await transaction
+      .insert(deployments)
+      .values({
+        appId: input.appId,
+        appSnapshot: input.config,
+        commitSha: input.commitSha,
+        configDigest: digestValue(input.config),
+        deployableKind: "app",
+        deploymentDigest: input.deploymentDigest,
+        environment: "preview",
+        gitRef,
+        hostname: input.hostname,
+        id: deploymentId,
+        idempotencyKey,
+        manifestDigest: input.manifestDigest,
+        previewEnvironmentId: environment.id,
+        requestedBy: null,
+        serverId: input.serverId,
+        serverSnapshot: input.server,
+        sourceId: input.sourceId,
+        sourceInputDigest: input.sourceInputDigest,
+        temporalWorkflowId: deploymentWorkflowId(deploymentId),
+        workspaceId: input.workspaceId,
+      })
+      .onConflictDoNothing({
+        target: [deployments.workspaceId, deployments.idempotencyKey],
+      })
+      .returning({ id: deployments.id });
+    if (!insertedDeployment) {
+      const [acceptedDeployment] = await transaction
+        .select({
+          errorCode: deployments.errorCode,
+          errorMessage: deployments.errorMessage,
+          id: deployments.id,
+          state: deployments.state,
+        })
+        .from(deployments)
+        .where(
+          and(
+            eq(deployments.workspaceId, input.workspaceId),
+            eq(deployments.idempotencyKey, idempotencyKey),
+          ),
+        )
+        .limit(1);
+      if (!acceptedDeployment) {
+        throw new Error("Unable to recover idempotent Preview admission");
+      }
+      const replay = await replayPreviewDeployment(transaction, {
+        deployment: acceptedDeployment,
+        environment,
+        expiresAt,
+        input,
+        runtimeId,
+      });
+      if (!replay)
+        throw new Error("Unable to recover active Preview admission");
+      return replay;
+    }
+    await transaction
+      .update(previewEnvironments)
+      .set({ latestDeploymentId: deploymentId, updatedAt: now })
+      .where(eq(previewEnvironments.id, environment.id));
+    return {
+      created: true,
+      deferred: false,
+      deploymentId,
+      environmentId: environment.id,
+      shouldEnqueue: true,
+      supersededDeploymentIds: supersededDeployments.map(
+        (deployment) => deployment.id,
+      ),
+    };
+  });
+}
+
+async function replayPreviewDeployment(
+  transaction: Transaction,
+  replay: {
+    deployment: Pick<
+      typeof deployments.$inferSelect,
+      "errorCode" | "errorMessage" | "id" | "state"
+    >;
+    environment: Pick<typeof previewEnvironments.$inferSelect, "id" | "status">;
+    expiresAt: Date;
+    input: {
+      branch: string;
+      commitSha: string;
+      hostname: string;
+      pullRequestNumber: number;
+      serverId: string;
+    };
+    runtimeId: string;
+  },
+) {
+  const action = previewAdmissionReplayAction({
+    deploymentErrorCode: replay.deployment.errorCode,
+    deploymentState: replay.deployment.state,
+    environmentStatus: replay.environment.status,
+  });
+  if (action === "replace") return null;
+  const now = new Date();
+  if (action === "reset_and_enqueue") {
+    await transaction
+      .update(deployments)
+      .set({
+        errorCode: null,
+        errorMessage: null,
+        finishedAt: null,
+        startedAt: null,
+        state: "queued",
+        updatedAt: now,
+      })
+      .where(eq(deployments.id, replay.deployment.id));
+  }
+  const succeeded = ["succeeded", "succeeded_with_warnings"].includes(
+    replay.deployment.state,
+  );
+  await transaction
+    .update(previewEnvironments)
+    .set({
+      branch: replay.input.branch,
+      deletedAt: null,
+      errorMessage:
+        action === "reuse" && !succeeded
+          ? replay.deployment.errorMessage
+          : null,
+      expiresAt: replay.expiresAt,
+      hostname: replay.input.hostname,
+      latestCommitSha: replay.input.commitSha,
+      latestDeploymentId: replay.deployment.id,
+      pullRequestNumber: replay.input.pullRequestNumber,
+      runtimeId: replay.runtimeId,
+      serverId: replay.input.serverId,
+      status:
+        action === "reuse" ? (succeeded ? "healthy" : "failed") : "building",
+      updatedAt: now,
+    })
+    .where(eq(previewEnvironments.id, replay.environment.id));
+  return {
+    created: false,
+    deferred: false,
+    deploymentId: replay.deployment.id,
+    environmentId: replay.environment.id,
+    shouldEnqueue: action !== "reuse",
+    supersededDeploymentIds: [],
+  };
+}

--- a/apps/towbar-api/src/areas/previews/service.ts
+++ b/apps/towbar-api/src/areas/previews/service.ts
@@ -1,26 +1,16 @@
-import { randomUUID } from "node:crypto";
-
-import { and, desc, eq, isNull, ne, notInArray } from "drizzle-orm";
+import { and, desc, eq, isNull, ne } from "drizzle-orm";
 
 import {
   createPreviewAppSnapshot,
-  digestValue,
   isNormalizedResource,
   previewHostname,
-  previewRef,
-  previewRuntimeId,
   shouldDeployForChangedPaths,
 } from "@workspace/towbar-core";
-import {
-  deploymentWorkflowId,
-  previewPullRequestEventSchema,
-} from "@workspace/towbar-core/temporal";
+import { previewPullRequestEventSchema } from "@workspace/towbar-core/temporal";
 import {
   apps,
-  deployments,
   githubInstallations,
   previewEnvironments,
-  releases,
   servers,
   sources,
 } from "@workspace/towbar-database/schema";
@@ -43,10 +33,7 @@ import {
 import { calculateReleaseDeploymentDigest } from "../sources/deployment-digests.js";
 import { publishDeploymentPlanGitHubCheck } from "../plans/github-check.js";
 import { createPullRequestDeploymentPlan } from "../plans/service.js";
-import {
-  isPreviewReleaseCurrent,
-  shouldDeferPreviewAdmission,
-} from "./admission-state.js";
+import { admitPreviewDeployment } from "./admission.js";
 import {
   requestPreviewInputMismatchCleanups,
   requestPreviewPullRequestCleanup,
@@ -60,14 +47,6 @@ import {
 
 import type { PreviewPullRequestEvent } from "@workspace/towbar-core/temporal";
 import type { NormalizedApp } from "@workspace/towbar-core";
-
-const terminalStates = [
-  "cancelled",
-  "failed",
-  "skipped",
-  "succeeded",
-  "succeeded_with_warnings",
-] satisfies Array<(typeof deployments.$inferSelect)["state"]>;
 
 export { scheduleSourcePreviewReconciliations } from "./reconciliation-scheduler.js";
 
@@ -176,18 +155,16 @@ export async function processPreviewPullRequestEvent(
     repositoryName: source.repositoryName,
     repositoryOwner: source.repositoryOwner,
   });
-  try {
-    const plan = await createPullRequestDeploymentPlan({
-      pullRequest,
-      repositoryChanges: changedPaths,
-      sourceId: event.sourceId,
-      workspaceId: source.workspaceId,
-    });
-    await publishDeploymentPlanGitHubCheck(plan.id);
-  } catch {
-    // Planning and GitHub reporting are observational. Preview reconciliation
-    // remains independent and records its own result.
-  }
+  const plan = await createPullRequestDeploymentPlan({
+    pullRequest,
+    repositoryChanges: changedPaths,
+    sourceId: event.sourceId,
+    workspaceId: source.workspaceId,
+  });
+  await publishDeploymentPlanGitHubCheck(plan.id).catch(() => {
+    // The persisted plan remains valid when GitHub Check delivery needs its
+    // independent reporting retry.
+  });
   if (!source.latestManifestDigest) {
     return { cleanupIds: [], deploymentIds: [], retry: false };
   }
@@ -327,20 +304,19 @@ export async function processPreviewPullRequestEvent(
         admission.deploymentId,
         "queued",
       ).catch(() => undefined);
-      try {
-        await enqueueDeployment({
-          appId: candidate.appId,
-          buildConcurrency: candidate.server.buildConcurrency ?? 1,
-          deploymentId: admission.deploymentId,
-          previewBuildConcurrency:
-            candidate.server.previewBuildConcurrency ?? 1,
-          priority: "preview",
-          serverIp: candidate.server.ip,
-        });
-      } catch (error) {
-        await markPreviewAdmissionFailed(admission.deploymentId, error);
-        throw error;
-      }
+    }
+    if (admission.deploymentId && admission.shouldEnqueue) {
+      // Signal delivery is uncertain when Temporal is unavailable. Keep the
+      // accepted deployment queued so this Activity retry can safely signal
+      // the same deployment ID again.
+      await enqueueDeployment({
+        appId: candidate.appId,
+        buildConcurrency: candidate.server.buildConcurrency ?? 1,
+        deploymentId: admission.deploymentId,
+        previewBuildConcurrency: candidate.server.previewBuildConcurrency ?? 1,
+        priority: "preview",
+        serverIp: candidate.server.ip,
+      });
     }
   }
   await publishPreviewPullRequestComment({
@@ -354,225 +330,4 @@ export async function processPreviewPullRequestEvent(
       .filter((id): id is string => Boolean(id)),
     retry: admissions.some((admission) => admission.deferred),
   };
-}
-
-async function admitPreviewDeployment(input: {
-  appId: string;
-  branch: string;
-  commitSha: string;
-  config: NormalizedApp;
-  deploymentDigest: string;
-  hostname: string;
-  manifestDigest: string;
-  pullRequestNumber: number;
-  server: (typeof servers.$inferSelect)["config"];
-  serverId: string;
-  sourceId: string;
-  sourceInputDigest: string | null;
-  ttlHours: number;
-  workspaceId: string;
-}) {
-  const database = getTowbarDatabase();
-  const gitRef = previewRef(input.pullRequestNumber);
-  const runtimeId = previewRuntimeId({
-    appId: input.config.id,
-    pullRequestNumber: input.pullRequestNumber,
-    sourceId: input.sourceId,
-  });
-  const deploymentId = randomUUID();
-  const expiresAt = new Date(Date.now() + input.ttlHours * 60 * 60_000);
-  const admission = await database.transaction(async (transaction) => {
-    const [existingEnvironment] = await transaction
-      .select({
-        id: previewEnvironments.id,
-        status: previewEnvironments.status,
-      })
-      .from(previewEnvironments)
-      .where(
-        and(
-          eq(previewEnvironments.sourceId, input.sourceId),
-          eq(previewEnvironments.appId, input.appId),
-          eq(previewEnvironments.gitRef, gitRef),
-        ),
-      )
-      .for("update")
-      .limit(1);
-    if (
-      existingEnvironment &&
-      shouldDeferPreviewAdmission(existingEnvironment.status)
-    ) {
-      return {
-        created: false,
-        deferred: true,
-        deploymentId: null,
-        environmentId: existingEnvironment.id,
-        supersededDeploymentIds: [],
-      };
-    }
-    const [environment] = await transaction
-      .insert(previewEnvironments)
-      .values({
-        appId: input.appId,
-        branch: input.branch,
-        expiresAt,
-        gitRef,
-        hostname: input.hostname,
-        latestCommitSha: input.commitSha,
-        pullRequestNumber: input.pullRequestNumber,
-        runtimeId,
-        serverId: input.serverId,
-        sourceId: input.sourceId,
-        workspaceId: input.workspaceId,
-      })
-      .onConflictDoUpdate({
-        target: [
-          previewEnvironments.sourceId,
-          previewEnvironments.appId,
-          previewEnvironments.gitRef,
-        ],
-        set: {
-          branch: input.branch,
-          deletedAt: null,
-          errorMessage: null,
-          expiresAt,
-          hostname: input.hostname,
-          latestCommitSha: input.commitSha,
-          pullRequestNumber: input.pullRequestNumber,
-          runtimeId,
-          serverId: input.serverId,
-          status: "building",
-          updatedAt: new Date(),
-        },
-      })
-      .returning();
-    if (!environment)
-      throw new Error("Unable to materialize Preview environment");
-
-    const [current] = await transaction
-      .select({
-        deploymentDigest: releases.deploymentDigest,
-      })
-      .from(releases)
-      .where(
-        and(
-          eq(releases.previewEnvironmentId, environment.id),
-          eq(releases.status, "current"),
-        ),
-      )
-      .limit(1);
-    if (
-      isPreviewReleaseCurrent(current?.deploymentDigest, input.deploymentDigest)
-    ) {
-      await transaction
-        .update(previewEnvironments)
-        .set({ status: "healthy", updatedAt: new Date() })
-        .where(eq(previewEnvironments.id, environment.id));
-      return {
-        created: false,
-        deferred: false,
-        deploymentId: null,
-        environmentId: environment.id,
-        supersededDeploymentIds: [],
-      };
-    }
-
-    const [active] = await transaction
-      .select({ id: deployments.id })
-      .from(deployments)
-      .where(
-        and(
-          eq(deployments.previewEnvironmentId, environment.id),
-          eq(deployments.commitSha, input.commitSha),
-          eq(deployments.deploymentDigest, input.deploymentDigest),
-          notInArray(deployments.state, terminalStates),
-        ),
-      )
-      .orderBy(desc(deployments.createdAt))
-      .limit(1);
-    if (active) {
-      return {
-        created: false,
-        deferred: false,
-        deploymentId: active.id,
-        environmentId: environment.id,
-        supersededDeploymentIds: [],
-      };
-    }
-
-    const now = new Date();
-    const supersededDeployments = await transaction
-      .update(deployments)
-      .set({
-        errorCode: "PREVIEW_SUPERSEDED",
-        errorMessage: "Superseded by a newer Preview commit",
-        finishedAt: now,
-        state: "skipped",
-        updatedAt: now,
-      })
-      .where(
-        and(
-          eq(deployments.previewEnvironmentId, environment.id),
-          eq(deployments.state, "queued"),
-        ),
-      )
-      .returning({ id: deployments.id });
-    await transaction.insert(deployments).values({
-      appId: input.appId,
-      appSnapshot: input.config,
-      commitSha: input.commitSha,
-      configDigest: digestValue(input.config),
-      deployableKind: "app",
-      deploymentDigest: input.deploymentDigest,
-      environment: "preview",
-      gitRef,
-      hostname: input.hostname,
-      id: deploymentId,
-      idempotencyKey: `preview:${environment.id}:${input.commitSha}:${input.deploymentDigest}`,
-      manifestDigest: input.manifestDigest,
-      previewEnvironmentId: environment.id,
-      requestedBy: null,
-      serverId: input.serverId,
-      serverSnapshot: input.server,
-      sourceId: input.sourceId,
-      sourceInputDigest: input.sourceInputDigest,
-      temporalWorkflowId: deploymentWorkflowId(deploymentId),
-      workspaceId: input.workspaceId,
-    });
-    await transaction
-      .update(previewEnvironments)
-      .set({ latestDeploymentId: deploymentId, updatedAt: now })
-      .where(eq(previewEnvironments.id, environment.id));
-    return {
-      created: true,
-      deferred: false,
-      deploymentId,
-      environmentId: environment.id,
-      supersededDeploymentIds: supersededDeployments.map(
-        (deployment) => deployment.id,
-      ),
-    };
-  });
-  return admission;
-}
-
-async function markPreviewAdmissionFailed(
-  deploymentId: string,
-  error: unknown,
-) {
-  const message =
-    error instanceof Error
-      ? error.message.slice(0, 1_000)
-      : "Preview deployment queue is unavailable";
-  const now = new Date();
-  await getTowbarDatabase()
-    .update(deployments)
-    .set({
-      errorCode: "TEMPORAL_UNAVAILABLE",
-      errorMessage: message,
-      finishedAt: now,
-      state: "failed",
-      updatedAt: now,
-    })
-    .where(eq(deployments.id, deploymentId));
-  await propagatePreviewDeploymentState(deploymentId, "failed");
 }

--- a/apps/towbar-worker/src/workflows/server-scheduling.test.ts
+++ b/apps/towbar-worker/src/workflows/server-scheduling.test.ts
@@ -246,3 +246,17 @@ void test("deduplicates one scan cycle without dropping a controlled rescan", ()
     serverWorkIdentity({ ...scan, cycle: 2 }),
   );
 });
+
+void test("deduplicates repeated Preview signals for one accepted deployment", () => {
+  const preview = {
+    ...deployment("preview-deployment", "website"),
+    previewBuildConcurrency: 1,
+    priority: "preview" as const,
+  };
+
+  assert.equal(serverWorkIdentity(preview), serverWorkIdentity({ ...preview }));
+  assert.notEqual(
+    serverWorkIdentity(preview),
+    serverWorkIdentity({ ...preview, id: "next-preview-deployment" }),
+  );
+});

--- a/packages/towbar-core/README.md
+++ b/packages/towbar-core/README.md
@@ -49,8 +49,10 @@ Deployment planning is deterministic domain logic in this package. Given the
 same normalized candidate, materialized inventory, repository changes, target
 deployment digests, and validation checks, it emits the same ordered plan.
 Full plans include explicit no-op rows; pull-request plans omit deployables
-whose input patterns and configuration are unchanged. The plan reports field
-paths and reasons, never field values or mutable inventory objects.
+whose input patterns and configuration are unchanged. A pull-request plan with
+no actionable rows is `skipped`, while warnings remain non-blocking and failed
+checks produce a `blocked` plan. The plan reports field paths and reasons, never
+field values or mutable inventory objects.
 
 Root `secrets.build` and `secrets.deployment` arrays declare Source-wide JSON
 environment bundles. Apps merge those with their own bundles; app keys override

--- a/packages/towbar-core/src/deployment-plan.test.ts
+++ b/packages/towbar-core/src/deployment-plan.test.ts
@@ -121,10 +121,35 @@ void test("omits irrelevant pull request no-op rows", () => {
   });
 
   assert.deepEqual(plan.items, []);
+  assert.equal(plan.status, "skipped");
   assert.deepEqual(plan.summary, {
     archive: 0,
     create: 0,
     no_op: 0,
+    restore: 0,
+    update: 0,
+  });
+});
+
+void test("skips pull request plans that contain only no-op rows", () => {
+  const plan = buildDeploymentPlan({
+    currentApps: [currentApp],
+    currentResources: [],
+    currentServers: [currentServer],
+    desired: manifest,
+    mode: "pull_request",
+    repositoryChanges: {
+      complete: true,
+      paths: ["apps/website/src/page.tsx"],
+    },
+    targetDeploymentDigests: new Map([["website", "old-digest"]]),
+  });
+
+  assert.equal(plan.status, "skipped");
+  assert.deepEqual(plan.summary, {
+    archive: 0,
+    create: 0,
+    no_op: 1,
     restore: 0,
     update: 0,
   });

--- a/packages/towbar-core/src/deployment-plan.ts
+++ b/packages/towbar-core/src/deployment-plan.ts
@@ -79,12 +79,15 @@ export function buildDeploymentPlan(input: {
     )
     .sort(comparePlanItems);
   const checks = [...(input.checks ?? [])].sort(comparePlanChecks);
+  const hasActionableChanges = items.some((item) => item.action !== "no_op");
   return {
     checks,
     items,
     status: checks.some((check) => check.status === "failed")
       ? "blocked"
-      : "ready",
+      : input.mode === "pull_request" && !hasActionableChanges
+        ? "skipped"
+        : "ready",
     summary: summarizePlanItems(items),
   };
 }

--- a/packages/towbar-core/src/deployment-plan.types.ts
+++ b/packages/towbar-core/src/deployment-plan.types.ts
@@ -9,7 +9,7 @@ export type DeploymentPlanAction =
   "archive" | "create" | "no_op" | "restore" | "update";
 export type DeploymentPlanEntityKind = "app" | "resource" | "server";
 export type DeploymentPlanCheckStatus = "failed" | "passed" | "warning";
-export type DeploymentPlanStatus = "blocked" | "ready";
+export type DeploymentPlanStatus = "blocked" | "ready" | "skipped";
 
 export type DeploymentPlanItem = {
   action: DeploymentPlanAction;

--- a/packages/towbar-database/drizzle/0034_fuzzy_synch.sql
+++ b/packages/towbar-database/drizzle/0034_fuzzy_synch.sql
@@ -1,0 +1,16 @@
+ALTER TYPE "public"."towbar_deployment_plan_status" ADD VALUE 'skipped';--> statement-breakpoint
+WITH "ranked_pull_request_plans" AS (
+	SELECT
+		"id",
+		row_number() OVER (
+			PARTITION BY "source_id", "pull_request_number", "target_commit_sha"
+			ORDER BY "created_at" DESC, "id" DESC
+		) AS "duplicate_rank"
+	FROM "towbar_deployment_plans"
+	WHERE "trigger" = 'pull_request'
+)
+DELETE FROM "towbar_deployment_plans"
+USING "ranked_pull_request_plans"
+WHERE "towbar_deployment_plans"."id" = "ranked_pull_request_plans"."id"
+	AND "ranked_pull_request_plans"."duplicate_rank" > 1;--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_towbar_deployment_plans_pull_request_head" ON "towbar_deployment_plans" USING btree ("source_id","pull_request_number","target_commit_sha") WHERE "towbar_deployment_plans"."trigger" = 'pull_request';

--- a/packages/towbar-database/drizzle/meta/0034_snapshot.json
+++ b/packages/towbar-database/drizzle/meta/0034_snapshot.json
@@ -1,0 +1,5537 @@
+{
+  "id": "f11bc50e-9f21-4bcc-ad8e-e6d44424b51e",
+  "prevId": "dbbbc6e3-2078-4973-9c1f-81061e619a55",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.towbar_apps": {
+      "name": "towbar_apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_id": {
+          "name": "manifest_id",
+          "type": "varchar(63)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "towbar_deployable_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'app'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_digest": {
+          "name": "config_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_digest": {
+          "name": "deployment_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_input_digest": {
+          "name": "source_input_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_deploy_paused": {
+          "name": "auto_deploy_paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deferred_automatic_deployment": {
+          "name": "deferred_automatic_deployment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_apps_source_manifest_id": {
+          "name": "uq_towbar_apps_source_manifest_id",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "manifest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_apps_workspace": {
+          "name": "idx_towbar_apps_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_apps_server": {
+          "name": "idx_towbar_apps_server",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_apps_archived_at": {
+          "name": "idx_towbar_apps_archived_at",
+          "columns": [
+            {
+              "expression": "archived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_apps_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_apps_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_apps",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_apps_source_id_towbar_sources_id_fk": {
+          "name": "towbar_apps_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_apps",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_apps_server_id_towbar_servers_id_fk": {
+          "name": "towbar_apps_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_apps",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_audit_events": {
+      "name": "towbar_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_audit_workspace_created": {
+          "name": "idx_towbar_audit_workspace_created",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_audit_events_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_audit_events_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_audit_events",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_audit_events_actor_user_id_towbar_users_id_fk": {
+          "name": "towbar_audit_events_actor_user_id_towbar_users_id_fk",
+          "tableFrom": "towbar_audit_events",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_auth_rate_limit_buckets": {
+      "name": "towbar_auth_rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_auth_rate_limit_expires": {
+          "name": "idx_towbar_auth_rate_limit_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_deployable_runtime_states": {
+      "name": "towbar_deployable_runtime_states",
+      "schema": "",
+      "columns": {
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "desired_state": {
+          "name": "desired_state",
+          "type": "towbar_runtime_desired_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "observed_state": {
+          "name": "observed_state",
+          "type": "towbar_runtime_observed_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "health_status": {
+          "name": "health_status",
+          "type": "towbar_runtime_health_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "drift_status": {
+          "name": "drift_status",
+          "type": "towbar_runtime_drift_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "drift_reasons": {
+          "name": "drift_reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "observed_container_name": {
+          "name": "observed_container_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_image": {
+          "name": "observed_image",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_check_id": {
+          "name": "last_check_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_runtime_drift": {
+          "name": "idx_towbar_runtime_drift",
+          "columns": [
+            {
+              "expression": "drift_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_deployable_runtime_states_app_id_towbar_apps_id_fk": {
+          "name": "towbar_deployable_runtime_states_app_id_towbar_apps_id_fk",
+          "tableFrom": "towbar_deployable_runtime_states",
+          "tableTo": "towbar_apps",
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_deployable_runtime_states_last_check_id_towbar_server_checks_id_fk": {
+          "name": "towbar_deployable_runtime_states_last_check_id_towbar_server_checks_id_fk",
+          "tableFrom": "towbar_deployable_runtime_states",
+          "tableTo": "towbar_server_checks",
+          "columnsFrom": ["last_check_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_deployment_log_chunks": {
+      "name": "towbar_deployment_log_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stream": {
+          "name": "stream",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_deployment_logs_sequence": {
+          "name": "uq_towbar_deployment_logs_sequence",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_deployment_logs_created": {
+          "name": "idx_towbar_deployment_logs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_deployment_log_chunks_deployment_id_towbar_deployments_id_fk": {
+          "name": "towbar_deployment_log_chunks_deployment_id_towbar_deployments_id_fk",
+          "tableFrom": "towbar_deployment_log_chunks",
+          "tableTo": "towbar_deployments",
+          "columnsFrom": ["deployment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_deployment_plan_github_checks": {
+      "name": "towbar_deployment_plan_github_checks",
+      "schema": "",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "check_run_id": {
+          "name": "check_run_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_deployment_plan_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_at": {
+          "name": "last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_deployment_plan_checks_status": {
+          "name": "idx_towbar_deployment_plan_checks_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_deployment_plan_github_checks_plan_id_towbar_deployment_plans_id_fk": {
+          "name": "towbar_deployment_plan_github_checks_plan_id_towbar_deployment_plans_id_fk",
+          "tableFrom": "towbar_deployment_plan_github_checks",
+          "tableTo": "towbar_deployment_plans",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_deployment_plans": {
+      "name": "towbar_deployment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_digest": {
+          "name": "identity_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "towbar_deployment_plan_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_deployment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_commit_sha": {
+          "name": "current_commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_commit_sha": {
+          "name": "target_commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_manifest_digest": {
+          "name": "current_manifest_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_manifest_digest": {
+          "name": "target_manifest_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_digest": {
+          "name": "candidate_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_deployment_plans_identity": {
+          "name": "uq_towbar_deployment_plans_identity",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identity_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_towbar_deployment_plans_pull_request_head": {
+          "name": "uq_towbar_deployment_plans_pull_request_head",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pull_request_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"towbar_deployment_plans\".\"trigger\" = 'pull_request'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_deployment_plans_source_created": {
+          "name": "idx_towbar_deployment_plans_source_created",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_deployment_plans_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_deployment_plans_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_deployment_plans",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_deployment_plans_source_id_towbar_sources_id_fk": {
+          "name": "towbar_deployment_plans_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_deployment_plans",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_deployment_plans_requested_by_towbar_users_id_fk": {
+          "name": "towbar_deployment_plans_requested_by_towbar_users_id_fk",
+          "tableFrom": "towbar_deployment_plans",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["requested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_towbar_deployment_plans_trigger": {
+          "name": "chk_towbar_deployment_plans_trigger",
+          "value": "(\"towbar_deployment_plans\".\"trigger\" = 'manual' AND \"towbar_deployment_plans\".\"pull_request_number\" IS NULL) OR (\"towbar_deployment_plans\".\"trigger\" = 'pull_request' AND \"towbar_deployment_plans\".\"pull_request_number\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.towbar_deployment_steps": {
+      "name": "towbar_deployment_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "towbar_deployment_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_deployment_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_deployment_steps_sequence": {
+          "name": "uq_towbar_deployment_steps_sequence",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_deployment_steps_deployment_id_towbar_deployments_id_fk": {
+          "name": "towbar_deployment_steps_deployment_id_towbar_deployments_id_fk",
+          "tableFrom": "towbar_deployment_steps",
+          "tableTo": "towbar_deployments",
+          "columnsFrom": ["deployment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_deployments": {
+      "name": "towbar_deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "temporal_workflow_id": {
+          "name": "temporal_workflow_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "towbar_deployment_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deploy'"
+        },
+        "environment": {
+          "name": "environment",
+          "type": "towbar_deployment_environment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "git_ref": {
+          "name": "git_ref",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_deployment_id": {
+          "name": "github_deployment_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_environment_id": {
+          "name": "preview_environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployable_kind": {
+          "name": "deployable_kind",
+          "type": "towbar_deployable_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'app'"
+        },
+        "state": {
+          "name": "state",
+          "type": "towbar_deployment_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_digest": {
+          "name": "config_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_digest": {
+          "name": "deployment_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_input_digest": {
+          "name": "source_input_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_digest": {
+          "name": "manifest_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_digest": {
+          "name": "image_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_platform": {
+          "name": "image_platform",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_snapshot": {
+          "name": "app_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_snapshot": {
+          "name": "server_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollback_release_snapshot": {
+          "name": "rollback_release_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_deployments_idempotency": {
+          "name": "uq_towbar_deployments_idempotency",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_towbar_deployments_workflow_id": {
+          "name": "uq_towbar_deployments_workflow_id",
+          "columns": [
+            {
+              "expression": "temporal_workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_deployments_app_created": {
+          "name": "idx_towbar_deployments_app_created",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_deployments_server_state": {
+          "name": "idx_towbar_deployments_server_state",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_deployments_preview_created": {
+          "name": "idx_towbar_deployments_preview_created",
+          "columns": [
+            {
+              "expression": "preview_environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_deployments_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_deployments_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_deployments",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_deployments_source_id_towbar_sources_id_fk": {
+          "name": "towbar_deployments_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_deployments",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "towbar_deployments_app_id_towbar_apps_id_fk": {
+          "name": "towbar_deployments_app_id_towbar_apps_id_fk",
+          "tableFrom": "towbar_deployments",
+          "tableTo": "towbar_apps",
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "towbar_deployments_server_id_towbar_servers_id_fk": {
+          "name": "towbar_deployments_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_deployments",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "towbar_deployments_requested_by_towbar_users_id_fk": {
+          "name": "towbar_deployments_requested_by_towbar_users_id_fk",
+          "tableFrom": "towbar_deployments",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["requested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "towbar_deployments_preview_environment_id_towbar_preview_environments_id_fk": {
+          "name": "towbar_deployments_preview_environment_id_towbar_preview_environments_id_fk",
+          "tableFrom": "towbar_deployments",
+          "tableTo": "towbar_preview_environments",
+          "columnsFrom": ["preview_environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_towbar_deployments_rollback_snapshot": {
+          "name": "chk_towbar_deployments_rollback_snapshot",
+          "value": "(\"towbar_deployments\".\"kind\" = 'deploy' AND \"towbar_deployments\".\"rollback_release_snapshot\" IS NULL) OR (\"towbar_deployments\".\"kind\" = 'rollback' AND \"towbar_deployments\".\"rollback_release_snapshot\" IS NOT NULL)"
+        },
+        "chk_towbar_deployments_environment": {
+          "name": "chk_towbar_deployments_environment",
+          "value": "(\"towbar_deployments\".\"environment\" = 'production' AND \"towbar_deployments\".\"preview_environment_id\" IS NULL AND \"towbar_deployments\".\"git_ref\" IS NULL AND \"towbar_deployments\".\"hostname\" IS NULL) OR (\"towbar_deployments\".\"environment\" = 'preview' AND \"towbar_deployments\".\"preview_environment_id\" IS NOT NULL AND \"towbar_deployments\".\"git_ref\" IS NOT NULL AND \"towbar_deployments\".\"hostname\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.towbar_github_installations": {
+      "name": "towbar_github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_github_installation_id": {
+          "name": "uq_towbar_github_installation_id",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_towbar_github_installations_workspace": {
+          "name": "uq_towbar_github_installations_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_github_installations_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_github_installations_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_github_installations",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_github_webhook_deliveries": {
+      "name": "towbar_github_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_digest": {
+          "name": "payload_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_towbar_webhooks_accepted_at": {
+          "name": "idx_towbar_webhooks_accepted_at",
+          "columns": [
+            {
+              "expression": "accepted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_github_webhook_deliveries_source_id_towbar_sources_id_fk": {
+          "name": "towbar_github_webhook_deliveries_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_github_webhook_deliveries",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_image_vulnerability_findings": {
+      "name": "towbar_image_vulnerability_findings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "advisory_id": {
+          "name": "advisory_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "towbar_vulnerability_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_version": {
+          "name": "installed_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fixed_version": {
+          "name": "fixed_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target": {
+          "name": "target",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_vulnerability_findings_scan_severity": {
+          "name": "idx_towbar_vulnerability_findings_scan_severity",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_image_vulnerability_findings_scan_id_towbar_image_vulnerability_scans_id_fk": {
+          "name": "towbar_image_vulnerability_findings_scan_id_towbar_image_vulnerability_scans_id_fk",
+          "tableFrom": "towbar_image_vulnerability_findings",
+          "tableTo": "towbar_image_vulnerability_scans",
+          "columnsFrom": ["scan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_image_vulnerability_scans": {
+      "name": "towbar_image_vulnerability_scans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_digest": {
+          "name": "image_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "towbar_vulnerability_scan_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "scanner_name": {
+          "name": "scanner_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scanner_version": {
+          "name": "scanner_version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_database_updated_at": {
+          "name": "vulnerability_database_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity_totals": {
+          "name": "severity_totals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "findings_truncated": {
+          "name": "findings_truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_vulnerability_scans_workspace_digest": {
+          "name": "uq_towbar_vulnerability_scans_workspace_digest",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "image_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_vulnerability_scans_state_requested": {
+          "name": "idx_towbar_vulnerability_scans_state_requested",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_vulnerability_scans_deployment": {
+          "name": "idx_towbar_vulnerability_scans_deployment",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_image_vulnerability_scans_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_image_vulnerability_scans_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_image_vulnerability_scans",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_image_vulnerability_scans_source_id_towbar_sources_id_fk": {
+          "name": "towbar_image_vulnerability_scans_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_image_vulnerability_scans",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "towbar_image_vulnerability_scans_app_id_towbar_apps_id_fk": {
+          "name": "towbar_image_vulnerability_scans_app_id_towbar_apps_id_fk",
+          "tableFrom": "towbar_image_vulnerability_scans",
+          "tableTo": "towbar_apps",
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "towbar_image_vulnerability_scans_server_id_towbar_servers_id_fk": {
+          "name": "towbar_image_vulnerability_scans_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_image_vulnerability_scans",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "towbar_image_vulnerability_scans_deployment_id_towbar_deployments_id_fk": {
+          "name": "towbar_image_vulnerability_scans_deployment_id_towbar_deployments_id_fk",
+          "tableFrom": "towbar_image_vulnerability_scans",
+          "tableTo": "towbar_deployments",
+          "columnsFrom": ["deployment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_notification_deliveries": {
+      "name": "towbar_notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "towbar_notification_delivery_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_at": {
+          "name": "last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_notification_deliveries_event_destination": {
+          "name": "uq_towbar_notification_deliveries_event_destination",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_notification_deliveries_state_next": {
+          "name": "idx_towbar_notification_deliveries_state_next",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_notification_deliveries_destination_created": {
+          "name": "idx_towbar_notification_deliveries_destination_created",
+          "columns": [
+            {
+              "expression": "destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_notification_deliveries_event_id_towbar_notification_events_id_fk": {
+          "name": "towbar_notification_deliveries_event_id_towbar_notification_events_id_fk",
+          "tableFrom": "towbar_notification_deliveries",
+          "tableTo": "towbar_notification_events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_notification_deliveries_destination_id_towbar_notification_destinations_id_fk": {
+          "name": "towbar_notification_deliveries_destination_id_towbar_notification_destinations_id_fk",
+          "tableFrom": "towbar_notification_deliveries",
+          "tableTo": "towbar_notification_destinations",
+          "columnsFrom": ["destination_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_notification_delivery_attempts": {
+      "name": "towbar_notification_delivery_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "towbar_notification_attempt_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_towbar_notification_attempts_identity": {
+          "name": "uq_towbar_notification_attempts_identity",
+          "columns": [
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_notification_attempts_delivery": {
+          "name": "idx_towbar_notification_attempts_delivery",
+          "columns": [
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_notification_delivery_attempts_delivery_id_towbar_notification_deliveries_id_fk": {
+          "name": "towbar_notification_delivery_attempts_delivery_id_towbar_notification_deliveries_id_fk",
+          "tableFrom": "towbar_notification_delivery_attempts",
+          "tableTo": "towbar_notification_deliveries",
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_notification_destinations": {
+      "name": "towbar_notification_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "towbar_notification_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_notification_destinations_source": {
+          "name": "idx_towbar_notification_destinations_source",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_notification_destinations_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_notification_destinations_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_notification_destinations",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_notification_destinations_source_id_towbar_sources_id_fk": {
+          "name": "towbar_notification_destinations_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_notification_destinations",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_notification_events": {
+      "name": "towbar_notification_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_notification_events_dedupe": {
+          "name": "uq_towbar_notification_events_dedupe",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_notification_events_source_created": {
+          "name": "idx_towbar_notification_events_source_created",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_notification_events_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_notification_events_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_notification_events",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_notification_events_source_id_towbar_sources_id_fk": {
+          "name": "towbar_notification_events_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_notification_events",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_notification_threads": {
+      "name": "towbar_notification_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_kind": {
+          "name": "entity_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creating_delivery_id": {
+          "name": "creating_delivery_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_event_at": {
+          "name": "latest_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_notification_threads_destination_entity": {
+          "name": "uq_towbar_notification_threads_destination_entity",
+          "columns": [
+            {
+              "expression": "destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_notification_threads_destination": {
+          "name": "idx_towbar_notification_threads_destination",
+          "columns": [
+            {
+              "expression": "destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_notification_threads_destination_id_towbar_notification_destinations_id_fk": {
+          "name": "towbar_notification_threads_destination_id_towbar_notification_destinations_id_fk",
+          "tableFrom": "towbar_notification_threads",
+          "tableTo": "towbar_notification_destinations",
+          "columnsFrom": ["destination_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_notification_threads_creating_delivery_id_towbar_notification_deliveries_id_fk": {
+          "name": "towbar_notification_threads_creating_delivery_id_towbar_notification_deliveries_id_fk",
+          "tableFrom": "towbar_notification_threads",
+          "tableTo": "towbar_notification_deliveries",
+          "columnsFrom": ["creating_delivery_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_password_credentials": {
+      "name": "towbar_password_credentials",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_reset_fingerprint": {
+          "name": "operator_reset_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "towbar_password_credentials_user_id_towbar_users_id_fk": {
+          "name": "towbar_password_credentials_user_id_towbar_users_id_fk",
+          "tableFrom": "towbar_password_credentials",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_preview_environments": {
+      "name": "towbar_preview_environments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "git_ref": {
+          "name": "git_ref",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_id": {
+          "name": "runtime_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_commit_sha": {
+          "name": "latest_commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_deployment_id": {
+          "name": "latest_deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_preview_environment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'building'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_attempts": {
+          "name": "cleanup_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_cleanup_attempt_at": {
+          "name": "last_cleanup_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_cleanup_attempt_at": {
+          "name": "next_cleanup_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_preview_environment_ref": {
+          "name": "uq_towbar_preview_environment_ref",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "git_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_towbar_preview_environment_hostname": {
+          "name": "uq_towbar_preview_environment_hostname",
+          "columns": [
+            {
+              "expression": "hostname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_preview_environment_source_status": {
+          "name": "idx_towbar_preview_environment_source_status",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_preview_environment_expires": {
+          "name": "idx_towbar_preview_environment_expires",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_preview_environments_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_preview_environments_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_preview_environments",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_preview_environments_source_id_towbar_sources_id_fk": {
+          "name": "towbar_preview_environments_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_preview_environments",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_preview_environments_app_id_towbar_apps_id_fk": {
+          "name": "towbar_preview_environments_app_id_towbar_apps_id_fk",
+          "tableFrom": "towbar_preview_environments",
+          "tableTo": "towbar_apps",
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_preview_environments_server_id_towbar_servers_id_fk": {
+          "name": "towbar_preview_environments_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_preview_environments",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_preview_pull_request_reports": {
+      "name": "towbar_preview_pull_request_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_commit_sha": {
+          "name": "latest_commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skipped_apps": {
+          "name": "skipped_apps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "comment_delivery_status": {
+          "name": "comment_delivery_status",
+          "type": "towbar_preview_report_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "comment_delivery_error": {
+          "name": "comment_delivery_error",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_last_attempted_at": {
+          "name": "comment_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_published_at": {
+          "name": "comment_published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_delivery_status": {
+          "name": "deployment_delivery_status",
+          "type": "towbar_preview_report_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "deployment_delivery_error": {
+          "name": "deployment_delivery_error",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_last_attempted_at": {
+          "name": "deployment_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_published_at": {
+          "name": "deployment_published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_preview_report_source_pr": {
+          "name": "uq_towbar_preview_report_source_pr",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pull_request_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_preview_report_workspace_comment": {
+          "name": "idx_towbar_preview_report_workspace_comment",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "comment_delivery_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_preview_report_workspace_deployment": {
+          "name": "idx_towbar_preview_report_workspace_deployment",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deployment_delivery_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_preview_pull_request_reports_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_preview_pull_request_reports_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_preview_pull_request_reports",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_preview_pull_request_reports_source_id_towbar_sources_id_fk": {
+          "name": "towbar_preview_pull_request_reports_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_preview_pull_request_reports",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_releases": {
+      "name": "towbar_releases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "towbar_deployment_environment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "git_ref": {
+          "name": "git_ref",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_environment_id": {
+          "name": "preview_environment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_release_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_digest": {
+          "name": "config_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_digest": {
+          "name": "deployment_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_input_digest": {
+          "name": "source_input_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_digest": {
+          "name": "image_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_platform": {
+          "name": "image_platform",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_tag": {
+          "name": "image_tag",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_towbar_releases_deployment": {
+          "name": "uq_towbar_releases_deployment",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_releases_app_status": {
+          "name": "idx_towbar_releases_app_status",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_releases_preview_status": {
+          "name": "idx_towbar_releases_preview_status",
+          "columns": [
+            {
+              "expression": "preview_environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_releases_app_id_towbar_apps_id_fk": {
+          "name": "towbar_releases_app_id_towbar_apps_id_fk",
+          "tableFrom": "towbar_releases",
+          "tableTo": "towbar_apps",
+          "columnsFrom": ["app_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_releases_deployment_id_towbar_deployments_id_fk": {
+          "name": "towbar_releases_deployment_id_towbar_deployments_id_fk",
+          "tableFrom": "towbar_releases",
+          "tableTo": "towbar_deployments",
+          "columnsFrom": ["deployment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "towbar_releases_preview_environment_id_towbar_preview_environments_id_fk": {
+          "name": "towbar_releases_preview_environment_id_towbar_preview_environments_id_fk",
+          "tableFrom": "towbar_releases",
+          "tableTo": "towbar_preview_environments",
+          "columnsFrom": ["preview_environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_towbar_releases_environment": {
+          "name": "chk_towbar_releases_environment",
+          "value": "(\"towbar_releases\".\"environment\" = 'production' AND \"towbar_releases\".\"preview_environment_id\" IS NULL AND \"towbar_releases\".\"git_ref\" IS NULL) OR (\"towbar_releases\".\"environment\" = 'preview' AND \"towbar_releases\".\"preview_environment_id\" IS NOT NULL AND \"towbar_releases\".\"git_ref\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.towbar_request_nonces": {
+      "name": "towbar_request_nonces",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_request_nonces_expires": {
+          "name": "idx_towbar_request_nonces_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pk_towbar_request_nonces": {
+          "name": "pk_towbar_request_nonces",
+          "columns": ["scope", "nonce"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_resource_backup_assurances": {
+      "name": "towbar_resource_backup_assurances",
+      "schema": "",
+      "columns": {
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_operation_id": {
+          "name": "backup_operation_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_backup_assurance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restore_ready": {
+          "name": "restore_ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "checks": {
+          "name": "checks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_backup_assurances_resource": {
+          "name": "idx_towbar_backup_assurances_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_backup_assurances_status": {
+          "name": "idx_towbar_backup_assurances_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_resource_backup_assurances_resource_id_towbar_apps_id_fk": {
+          "name": "towbar_resource_backup_assurances_resource_id_towbar_apps_id_fk",
+          "tableFrom": "towbar_resource_backup_assurances",
+          "tableTo": "towbar_apps",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_resource_backup_assurances_backup_operation_id_towbar_resource_operations_id_fk": {
+          "name": "towbar_resource_backup_assurances_backup_operation_id_towbar_resource_operations_id_fk",
+          "tableFrom": "towbar_resource_backup_assurances",
+          "tableTo": "towbar_resource_operations",
+          "columnsFrom": ["backup_operation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_resource_operation_events": {
+      "name": "towbar_resource_operation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_resource_operation_events_sequence": {
+          "name": "uq_towbar_resource_operation_events_sequence",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_resource_operation_events_created": {
+          "name": "idx_towbar_resource_operation_events_created",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_resource_operation_events_operation_id_towbar_resource_operations_id_fk": {
+          "name": "towbar_resource_operation_events_operation_id_towbar_resource_operations_id_fk",
+          "tableFrom": "towbar_resource_operation_events",
+          "tableTo": "towbar_resource_operations",
+          "columnsFrom": ["operation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_resource_operations": {
+      "name": "towbar_resource_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "temporal_workflow_id": {
+          "name": "temporal_workflow_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "towbar_resource_operation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "towbar_resource_operation_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "phase": {
+          "name": "phase",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_snapshot": {
+          "name": "app_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_snapshot": {
+          "name": "server_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_resource_operations_idempotency": {
+          "name": "uq_towbar_resource_operations_idempotency",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_towbar_resource_operations_workflow": {
+          "name": "uq_towbar_resource_operations_workflow",
+          "columns": [
+            {
+              "expression": "temporal_workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_resource_operations_resource_created": {
+          "name": "idx_towbar_resource_operations_resource_created",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_resource_operations_server_state": {
+          "name": "idx_towbar_resource_operations_server_state",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_resource_operations_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_resource_operations_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_resource_operations",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_resource_operations_source_id_towbar_sources_id_fk": {
+          "name": "towbar_resource_operations_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_resource_operations",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_resource_operations_resource_id_towbar_apps_id_fk": {
+          "name": "towbar_resource_operations_resource_id_towbar_apps_id_fk",
+          "tableFrom": "towbar_resource_operations",
+          "tableTo": "towbar_apps",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_resource_operations_server_id_towbar_servers_id_fk": {
+          "name": "towbar_resource_operations_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_resource_operations",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_resource_operations_requested_by_towbar_users_id_fk": {
+          "name": "towbar_resource_operations_requested_by_towbar_users_id_fk",
+          "tableFrom": "towbar_resource_operations",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["requested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_server_checks": {
+      "name": "towbar_server_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_check_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_server_checks_server": {
+          "name": "idx_towbar_server_checks_server",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_server_checks_server_id_towbar_servers_id_fk": {
+          "name": "towbar_server_checks_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_server_checks",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_server_checks_requested_by_towbar_users_id_fk": {
+          "name": "towbar_server_checks_requested_by_towbar_users_id_fk",
+          "tableFrom": "towbar_server_checks",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["requested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_server_preparations": {
+      "name": "towbar_server_preparations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_digest": {
+          "name": "config_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_check_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_server_preparations_server_created": {
+          "name": "idx_towbar_server_preparations_server_created",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_towbar_server_preparations_active": {
+          "name": "uq_towbar_server_preparations_active",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"towbar_server_preparations\".\"status\" in ('queued', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_server_preparations_server_id_towbar_servers_id_fk": {
+          "name": "towbar_server_preparations_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_server_preparations",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_server_preparations_requested_by_towbar_users_id_fk": {
+          "name": "towbar_server_preparations_requested_by_towbar_users_id_fk",
+          "tableFrom": "towbar_server_preparations",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["requested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_servers": {
+      "name": "towbar_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_ip": {
+          "name": "canonical_ip",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_digest": {
+          "name": "config_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prepared_at": {
+          "name": "prepared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prepared_config_digest": {
+          "name": "prepared_config_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_servers_source_ip": {
+          "name": "uq_towbar_servers_source_ip",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "canonical_ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_servers_workspace": {
+          "name": "idx_towbar_servers_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_servers_archived_at": {
+          "name": "idx_towbar_servers_archived_at",
+          "columns": [
+            {
+              "expression": "archived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_servers_source_id_towbar_sources_id_fk": {
+          "name": "towbar_servers_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_servers",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_servers_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_servers_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_servers",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_sessions": {
+      "name": "towbar_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_sessions_token_hash": {
+          "name": "uq_towbar_sessions_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_sessions_user_id": {
+          "name": "idx_towbar_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_sessions_expires_at": {
+          "name": "idx_towbar_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_sessions_user_id_towbar_users_id_fk": {
+          "name": "towbar_sessions_user_id_towbar_users_id_fk",
+          "tableFrom": "towbar_sessions",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_source_aws_credentials": {
+      "name": "towbar_source_aws_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_payload": {
+          "name": "encrypted_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_key_suffix": {
+          "name": "access_key_suffix",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "towbar_credential_verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unverified'"
+        },
+        "verification_message": {
+          "name": "verification_message",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_aws_credentials_source": {
+          "name": "uq_towbar_aws_credentials_source",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_aws_credentials_workspace": {
+          "name": "idx_towbar_aws_credentials_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_source_aws_credentials_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_source_aws_credentials_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_source_aws_credentials",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_source_aws_credentials_source_id_towbar_sources_id_fk": {
+          "name": "towbar_source_aws_credentials_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_source_aws_credentials",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_source_syncs": {
+      "name": "towbar_source_syncs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_source_sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_digest": {
+          "name": "manifest_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_manifest": {
+          "name": "raw_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_manifest": {
+          "name": "normalized_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciliation": {
+          "name": "reconciliation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issues": {
+          "name": "issues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_source_syncs_source_created": {
+          "name": "idx_towbar_source_syncs_source_created",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_source_syncs_source_id_towbar_sources_id_fk": {
+          "name": "towbar_source_syncs_source_id_towbar_sources_id_fk",
+          "tableFrom": "towbar_source_syncs",
+          "tableTo": "towbar_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_source_syncs_requested_by_towbar_users_id_fk": {
+          "name": "towbar_source_syncs_requested_by_towbar_users_id_fk",
+          "tableFrom": "towbar_source_syncs",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["requested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_sources": {
+      "name": "towbar_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_owner": {
+          "name": "repository_owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_name": {
+          "name": "repository_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "towbar_source_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "latest_commit_sha": {
+          "name": "latest_commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_manifest_digest": {
+          "name": "latest_manifest_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_successful_sync_id": {
+          "name": "latest_successful_sync_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_deploy_paused": {
+          "name": "auto_deploy_paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_sources_repository_branch": {
+          "name": "uq_towbar_sources_repository_branch",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_towbar_sources_workspace": {
+          "name": "idx_towbar_sources_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_sources_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_sources_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_sources",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_sources_github_installation_id_towbar_github_installations_id_fk": {
+          "name": "towbar_sources_github_installation_id_towbar_github_installations_id_fk",
+          "tableFrom": "towbar_sources",
+          "tableTo": "towbar_github_installations",
+          "columnsFrom": ["github_installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_ssh_host_keys": {
+      "name": "towbar_ssh_host_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trusted_by": {
+          "name": "trusted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_ssh_host_keys_active": {
+          "name": "uq_towbar_ssh_host_keys_active",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_ssh_host_keys_server_id_towbar_servers_id_fk": {
+          "name": "towbar_ssh_host_keys_server_id_towbar_servers_id_fk",
+          "tableFrom": "towbar_ssh_host_keys",
+          "tableTo": "towbar_servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_ssh_host_keys_trusted_by_towbar_users_id_fk": {
+          "name": "towbar_ssh_host_keys_trusted_by_towbar_users_id_fk",
+          "tableFrom": "towbar_ssh_host_keys",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["trusted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_system_health_signals": {
+      "name": "towbar_system_health_signals",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "component": {
+          "name": "component",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_system_health_workspace": {
+          "name": "idx_towbar_system_health_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "component",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_system_health_signals_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_system_health_signals_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_system_health_signals",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_users": {
+      "name": "towbar_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_users_email": {
+          "name": "uq_towbar_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_workspace_members": {
+      "name": "towbar_workspace_members",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "towbar_workspace_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_towbar_workspace_members_user_id": {
+          "name": "idx_towbar_workspace_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "towbar_workspace_members_workspace_id_towbar_workspaces_id_fk": {
+          "name": "towbar_workspace_members_workspace_id_towbar_workspaces_id_fk",
+          "tableFrom": "towbar_workspace_members",
+          "tableTo": "towbar_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "towbar_workspace_members_user_id_towbar_users_id_fk": {
+          "name": "towbar_workspace_members_user_id_towbar_users_id_fk",
+          "tableFrom": "towbar_workspace_members",
+          "tableTo": "towbar_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pk_towbar_workspace_members": {
+          "name": "pk_towbar_workspace_members",
+          "columns": ["workspace_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towbar_workspaces": {
+      "name": "towbar_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_towbar_workspaces_slug": {
+          "name": "uq_towbar_workspaces_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.towbar_backup_assurance_status": {
+      "name": "towbar_backup_assurance_status",
+      "schema": "public",
+      "values": ["missing", "stale", "not_restore_ready", "restore_ready"]
+    },
+    "public.towbar_check_status": {
+      "name": "towbar_check_status",
+      "schema": "public",
+      "values": ["queued", "running", "succeeded", "failed"]
+    },
+    "public.towbar_credential_verification_status": {
+      "name": "towbar_credential_verification_status",
+      "schema": "public",
+      "values": ["unverified", "verified", "failed"]
+    },
+    "public.towbar_deployable_kind": {
+      "name": "towbar_deployable_kind",
+      "schema": "public",
+      "values": ["app", "image", "postgres", "redis"]
+    },
+    "public.towbar_deployment_environment": {
+      "name": "towbar_deployment_environment",
+      "schema": "public",
+      "values": ["production", "preview"]
+    },
+    "public.towbar_deployment_kind": {
+      "name": "towbar_deployment_kind",
+      "schema": "public",
+      "values": ["deploy", "rollback"]
+    },
+    "public.towbar_deployment_plan_delivery_status": {
+      "name": "towbar_deployment_plan_delivery_status",
+      "schema": "public",
+      "values": ["pending", "published", "failed"]
+    },
+    "public.towbar_deployment_plan_status": {
+      "name": "towbar_deployment_plan_status",
+      "schema": "public",
+      "values": ["ready", "blocked", "skipped"]
+    },
+    "public.towbar_deployment_plan_trigger": {
+      "name": "towbar_deployment_plan_trigger",
+      "schema": "public",
+      "values": ["manual", "pull_request"]
+    },
+    "public.towbar_deployment_state": {
+      "name": "towbar_deployment_state",
+      "schema": "public",
+      "values": [
+        "queued",
+        "waiting_for_server",
+        "preparing",
+        "validating_credentials",
+        "checking_server",
+        "fetching_source",
+        "resolving_secrets",
+        "transferring",
+        "building",
+        "running_pre_deploy",
+        "starting_candidate",
+        "checking_health",
+        "configuring_routing",
+        "provisioning_tls",
+        "checking_public_endpoint",
+        "switching_traffic",
+        "running_post_deploy",
+        "cleaning_up",
+        "succeeded",
+        "succeeded_with_warnings",
+        "skipped",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.towbar_deployment_step_status": {
+      "name": "towbar_deployment_step_status",
+      "schema": "public",
+      "values": ["waiting", "running", "succeeded", "failed", "skipped"]
+    },
+    "public.towbar_notification_attempt_state": {
+      "name": "towbar_notification_attempt_state",
+      "schema": "public",
+      "values": [
+        "running",
+        "succeeded",
+        "retryable_failure",
+        "terminal_failure"
+      ]
+    },
+    "public.towbar_notification_delivery_state": {
+      "name": "towbar_notification_delivery_state",
+      "schema": "public",
+      "values": ["pending", "delivering", "retrying", "succeeded", "failed"]
+    },
+    "public.towbar_notification_provider": {
+      "name": "towbar_notification_provider",
+      "schema": "public",
+      "values": ["slack", "smtp"]
+    },
+    "public.towbar_preview_environment_status": {
+      "name": "towbar_preview_environment_status",
+      "schema": "public",
+      "values": [
+        "building",
+        "healthy",
+        "failed",
+        "deleting",
+        "cleanup_failed",
+        "deleted"
+      ]
+    },
+    "public.towbar_preview_report_delivery_status": {
+      "name": "towbar_preview_report_delivery_status",
+      "schema": "public",
+      "values": ["pending", "published", "failed"]
+    },
+    "public.towbar_release_status": {
+      "name": "towbar_release_status",
+      "schema": "public",
+      "values": ["current", "previous", "superseded"]
+    },
+    "public.towbar_resource_operation_state": {
+      "name": "towbar_resource_operation_state",
+      "schema": "public",
+      "values": ["queued", "running", "succeeded", "failed", "cancelled"]
+    },
+    "public.towbar_resource_operation_type": {
+      "name": "towbar_resource_operation_type",
+      "schema": "public",
+      "values": [
+        "backup",
+        "capture_logs",
+        "cleanup_orphans",
+        "restart",
+        "restore",
+        "restore_cleanup",
+        "start",
+        "stop"
+      ]
+    },
+    "public.towbar_runtime_desired_state": {
+      "name": "towbar_runtime_desired_state",
+      "schema": "public",
+      "values": ["running", "stopped"]
+    },
+    "public.towbar_runtime_drift_state": {
+      "name": "towbar_runtime_drift_state",
+      "schema": "public",
+      "values": ["drifted", "in_sync", "unknown"]
+    },
+    "public.towbar_runtime_health_state": {
+      "name": "towbar_runtime_health_state",
+      "schema": "public",
+      "values": ["healthy", "none", "starting", "unhealthy", "unknown"]
+    },
+    "public.towbar_runtime_observed_state": {
+      "name": "towbar_runtime_observed_state",
+      "schema": "public",
+      "values": ["missing", "running", "stopped", "unknown"]
+    },
+    "public.towbar_source_status": {
+      "name": "towbar_source_status",
+      "schema": "public",
+      "values": ["active", "archived"]
+    },
+    "public.towbar_source_sync_status": {
+      "name": "towbar_source_sync_status",
+      "schema": "public",
+      "values": ["queued", "running", "succeeded", "failed"]
+    },
+    "public.towbar_vulnerability_scan_state": {
+      "name": "towbar_vulnerability_scan_state",
+      "schema": "public",
+      "values": ["pending", "running", "clean", "findings", "failed"]
+    },
+    "public.towbar_vulnerability_severity": {
+      "name": "towbar_vulnerability_severity",
+      "schema": "public",
+      "values": ["critical", "high", "medium", "low", "unknown"]
+    },
+    "public.towbar_workspace_role": {
+      "name": "towbar_workspace_role",
+      "schema": "public",
+      "values": ["owner", "member"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/towbar-database/drizzle/meta/_journal.json
+++ b/packages/towbar-database/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1788108667897,
       "tag": "0033_panoramic_calypso",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1788119547510,
+      "tag": "0034_fuzzy_synch",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/towbar-database/src/schema/index.ts
+++ b/packages/towbar-database/src/schema/index.ts
@@ -106,7 +106,7 @@ export const deploymentPlanTriggerEnum = pgEnum(
 );
 export const deploymentPlanStatusEnum = pgEnum(
   "towbar_deployment_plan_status",
-  ["ready", "blocked"],
+  ["ready", "blocked", "skipped"],
 );
 export const deploymentPlanDeliveryStatusEnum = pgEnum(
   "towbar_deployment_plan_delivery_status",
@@ -615,6 +615,9 @@ export const deploymentPlans = pgTable(
       table.sourceId,
       table.identityDigest,
     ),
+    uniqueIndex("uq_towbar_deployment_plans_pull_request_head")
+      .on(table.sourceId, table.pullRequestNumber, table.targetCommitSha)
+      .where(sql`${table.trigger} = 'pull_request'`),
     index("idx_towbar_deployment_plans_source_created").on(
       table.sourceId,
       table.createdAt,

--- a/packages/towbar-web-client/src/types.ts
+++ b/packages/towbar-web-client/src/types.ts
@@ -69,12 +69,12 @@ export type DeploymentPlan = {
       name: string;
       reasons: string[];
     }>;
-    status: "blocked" | "ready";
+    status: "blocked" | "ready" | "skipped";
     summary: Record<DeploymentPlanAction, number>;
   };
   pullRequestNumber: number | null;
   sourceId: string;
-  status: "blocked" | "ready";
+  status: "blocked" | "ready" | "skipped";
   targetCommitSha: string;
   targetManifestDigest: string | null;
   trigger: "manual" | "pull_request";


### PR DESCRIPTION
## Summary

- persist one plan per Source, pull request, and head SHA, refreshing legacy blocked rows in place
- retry transient GitHub reads with accurate timeout, connectivity, and rate-limit classification while keeping mutating POSTs replay-safe
- report no-change pull requests as neutral `skipped` plans and scope dynamic validation to affected deployables and servers
- treat CPU overcommit and active operations as warnings instead of permanent plan blockers
- make Preview admission retry-safe across duplicate webhooks, Temporal signal uncertainty, terminal work, and cleaned environments
- add the `skipped` plan status migration, deduplicate existing PR-head rows, and enforce the database uniqueness invariant

## Operational notes

- `13.207.129.215` remains in the monorepo manifest because Towbar Website still targets it; scoped validation prevents it from blocking unrelated PRs.
- Source IAM policy version `v6` is already active with least-privilege `secretsmanager:DescribeSecret` alongside `GetSecretValue` for the existing permitted secret ARN patterns.

## Validation

- `pnpm verify`
- fresh PostgreSQL migration through `0034`
- upgrade migration from `0033` with duplicate PR-head plans: retained the newest row, cascaded the duplicate Check record, added `skipped`, and enforced the partial unique index
- IAM simulation for the Towbar Source principal: `DescribeSecret` and `GetSecretValue` both `allowed`

Production duplicate-storm verification remains pending until this PR is merged and deployed.