### PR TITLE
Fix Preview reconciliation heartbeat timeouts

### DIFF
--- a/apps/towbar-worker/src/activities/preview.ts
+++ b/apps/towbar-worker/src/activities/preview.ts
@@ -1,4 +1,5 @@
 import { signedApiRequest } from "../infrastructure/towbar-api.js";
+import { Context } from "@temporalio/activity";
 import {
   cleanupPreviewEnvironment,
   deleteCloudflarePreviewDns,
@@ -13,11 +14,24 @@ import type {
 export async function processPreviewPullRequestEventActivity(
   event: PreviewPullRequestEvent,
 ) {
-  return await signedApiRequest<{
-    cleanupIds: string[];
-    deploymentIds: string[];
-    retry: boolean;
-  }>("POST", "/v1/internal/previews/events", event, { timeoutMs: 120_000 });
+  const activity = Context.current();
+  const pulse = setInterval(
+    () =>
+      activity.heartbeat({
+        pullRequestNumber: event.pullRequestNumber,
+        sourceId: event.sourceId,
+      }),
+    10_000,
+  );
+  try {
+    return await signedApiRequest<{
+      cleanupIds: string[];
+      deploymentIds: string[];
+      retry: boolean;
+    }>("POST", "/v1/internal/previews/events", event, { timeoutMs: 120_000 });
+  } finally {
+    clearInterval(pulse);
+  }
 }
 
 export async function executePreviewCleanupActivity(


### PR DESCRIPTION
## Summary
- heartbeat long-running Preview reconciliation activity every 10 seconds
- keep the existing 30-second Temporal liveness timeout effective
- stop retries of already-successful API evaluations

## Production evidence
A concurrent replay of monorepo PR #58 on v1.3.2 correctly reused one plan and changed it from blocked to ready, but the activity retried because the 120-second API request emitted no heartbeat. Temporal reported `activity Heartbeat timeout` while the API-side work had already completed.

## Verification
- `pnpm --filter towbar-worker typecheck`
- `pnpm --filter towbar-worker lint`
- `pnpm --filter towbar-worker test` (22 tests)
- `pnpm verify`

Follow-up to TW-45.