### PR TITLE
Release v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Towbar are documented in this file. This project follows
 
 ## [Unreleased]
 
+## [1.3.3] - 2026-08-31
+
+### Fixed
+
+- Preview pull request reconciliation now heartbeats while long-running Source
+  evaluation is in progress, preventing Temporal from retrying successful API
+  evaluations after a false heartbeat timeout.
+
 ## [1.3.2] - 2026-08-31
 
 ### Fixed
@@ -168,7 +176,8 @@ All notable changes to Towbar are documented in this file. This project follows
 - Source-scoped AWS Secrets Manager integration and environment editors.
 - A same-domain owner setup, authentication, and operations dashboard.
 
-[Unreleased]: https://github.com/avgeek-inc/towbar/compare/v1.3.2...HEAD
+[Unreleased]: https://github.com/avgeek-inc/towbar/compare/v1.3.3...HEAD
+[1.3.3]: https://github.com/avgeek-inc/towbar/compare/v1.3.2...v1.3.3
 [1.3.2]: https://github.com/avgeek-inc/towbar/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/avgeek-inc/towbar/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/avgeek-inc/towbar/compare/v1.2.0...v1.3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "towbar",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Opinionated, source-driven deployments to Ubuntu servers you own.",
   "keywords": [
     "deployment",


### PR DESCRIPTION
## Summary
- bump Towbar to `1.3.3`
- publish the Preview reconciliation heartbeat fix in the changelog

## Validation
- `pnpm exec prettier --check package.json CHANGELOG.md`
- package version assertion
- `git diff --check`

After merge, publish the `v1.3.3` GitHub release so the release workflow deploys the exact tagged commit. Production acceptance for TW-45 will then replay concurrent PR signals and verify a single Preview evaluation without a heartbeat timeout.