### PR TITLE
Release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to Towbar are documented in this file. This project follows
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-09-05
+
+### Added
+
+- Towbar now stores Source, App, Resource, and Preview secrets encrypted in its
+  database. Owners manage write-only values in the editor, with Source-wide
+  production defaults, local overrides, isolated Preview values, explicit
+  deployment after edits, revision conflicts, and pending-change visibility.
+- Server SSH and Cloudflare credentials, plus installation Slack and SMTP
+  credentials, now use the same encrypted, write-only settings flow.
+
+### Changed
+
+- Deployments resolve a consistent set of current values when execution starts,
+  preserve BuildKit secret mounts and runtime and hook injection, and record only
+  the encrypted-setting revisions used. Image rollbacks and server, resource,
+  and notification operations use current credentials.
+- Sources can be synchronized and inventoried before credentials are configured.
+  Plan validation reports missing Towbar-managed configuration with links to the
+  relevant editor, while optional S3 backup and restore retain Source AWS
+  credentials.
+
+### Removed
+
+- AWS Secrets Manager integration, secret-reference APIs, reveal controls, and
+  all secret fields and provider references in deployment manifests have been
+  removed. Existing values are not imported; operators must re-enter required
+  values in Towbar before resuming deployments.
+
 ## [1.3.4] - 2026-09-03
 
 ### Added
@@ -188,7 +217,8 @@ All notable changes to Towbar are documented in this file. This project follows
 - Source-scoped AWS Secrets Manager integration and environment editors.
 - A same-domain owner setup, authentication, and operations dashboard.
 
-[Unreleased]: https://github.com/avgeek-inc/towbar/compare/v1.3.4...HEAD
+[Unreleased]: https://github.com/avgeek-inc/towbar/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/avgeek-inc/towbar/compare/v1.3.4...v1.4.0
 [1.3.4]: https://github.com/avgeek-inc/towbar/compare/v1.3.3...v1.3.4
 [1.3.3]: https://github.com/avgeek-inc/towbar/compare/v1.3.2...v1.3.3
 [1.3.2]: https://github.com/avgeek-inc/towbar/compare/v1.3.1...v1.3.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "towbar",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "Opinionated, source-driven deployments to Ubuntu servers you own.",
   "keywords": [
     "deployment",


### PR DESCRIPTION
## Summary

- bump Towbar to version 1.4.0
- publish encrypted, editor-managed Source, App, Resource, Preview, server, and notification credentials
- remove AWS Secrets Manager integration and legacy manifest secret references
- retain Source AWS credentials only for optional S3 backup and restore

## Breaking cutover

Existing AWS secret references are not imported or resolved. Operators must remove legacy manifest fields and re-enter required values through Towbar before resuming deployments. Recovery requires both the database and the matching `TOWBAR_CREDENTIALS_KEY`.

## Validation

- `pnpm verify`
- `git diff --check`

After merge, publish the v1.4.0 GitHub release so the release workflow deploys the exact tagged commit.
