### PR TITLE
Release v1.5.0: example app, onboarding, and upgrade notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to Towbar are documented in this file. This project follows
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-09-05
+
+### Added
+
+- Workspace-wide server management, with one server per IP shared across Sources,
+  Apps, and Resources, plus detected instance type and capacity information.
+- Shared workspace secrets with Source defaults and App/Resource overrides,
+  separated by production/preview environment and execution stage.
+- Dedicated Apps, Resources, Deployments, and Integrations pages, source inventory
+  counts, live allocation meters, and separate server Apps and Resources tables.
+- Integration health checks for GitHub and connected AWS credentials.
+- A ready-to-fork [example app](https://github.com/avgeek-inc/towbar-example)
+  with a Dockerfile, health endpoint, and deployment manifest.
+- A new public homepage and feature guides with light/dark screenshots,
+  installation instructions, and a first-deployment walkthrough.
+
+### Changed
+
+- AWS credentials are configured once per workspace under Integrations. Slack
+  and SMTP provider credentials are configured through installation environment
+  variables; notification destinations remain managed in Towbar.
+- Tables show timezone-aware timestamps, relative times, running operation
+  durations, and consistent workload identity and status indicators.
+- Empty states, tables, tooltips, secrets editors, and navigation use consistent
+  layouts and compact spacing throughout the dashboard.
+
+### Removed
+
+- Source-owned server configuration and the top-level `servers` manifest field.
+  Manifests retain each App/Resource's `server` IP reference; configure hosts in
+  Towbar's Servers page instead.
+- Deployment plan UI, APIs, stored plans, and their GitHub checks.
+
+### Upgrade notes
+
+This release changes the manifest contract and resets some stored configuration.
+Existing 1.4.0 installations must follow the
+[1.5.0 upgrade steps](https://www.towbar.dev/docs/self-hosting/upgrades#upgrading-from-140-to-150)
+before resuming deployments:
+
+- Back up the control-plane database and preserve `.env` and
+  `TOWBAR_CREDENTIALS_KEY`. Older application images cannot undo these migrations.
+- Remove top-level `servers` from manifests while preserving deployable server IPs.
+- Re-enter server SSH/Cloudflare credentials and workspace AWS credentials.
+  Server migration deduplicates records by workspace and IP and deletes stored
+  server credential records; the previous source AWS credential table is dropped.
+- Configure Slack/SMTP provider environment variables. Previously stored
+  notification provider secrets are deleted.
+- Verify server trust/configuration, Source sync, integrations, and an actual app
+  deployment. Duplicate server check/preparation/host-key records and deployment
+  plan history are removed by the migrations.
+
 ## [1.4.0] - 2026-09-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ HTTPS ingress, then [Your first deployment](https://www.towbar.dev/docs/getting-
 to connect a GitHub App, prepare a server, and deploy an app. GitHub webhooks need
 an API origin reachable over HTTPS.
 
+For a working app to start with, [use the Hello Towbar template](https://github.com/avgeek-inc/towbar-example/generate)
+or [fork the example repository](https://github.com/avgeek-inc/towbar-example).
+It includes the Dockerfile, health endpoint, and manifest; replace the server IP
+and domain, then follow the first-deployment guide.
+
 You operate the hosts, network access, and control-plane backups. The
 [self-hosting security guide](https://www.towbar.dev/docs/self-hosting/security)
 explains the installation's trust boundaries and credential handling.

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -3,7 +3,7 @@ title: "Your first deployment"
 description: "Take a Dockerfile app from a GitHub repository to a verified deployment on your Ubuntu server."
 ---
 
-This guide takes one app through Source sync, server preparation, deployment, and route verification. Start with a small service whose Dockerfile and health endpoint already work locally.
+This guide takes one app through Source sync, server preparation, deployment, and route verification. Use the [Hello Towbar example](https://github.com/avgeek-inc/towbar-example) for a working Dockerfile app and health endpoint, or bring your own app.
 
 ## Before you begin
 
@@ -11,30 +11,37 @@ You need a running Towbar installation with an owner account, a connected GitHub
 
 Use a domain you control for a public app. The examples use documentation-only IPs and hostnames; replace them with your own values.
 
-## 1. Commit a manifest
+## 1. Create your app repository
 
-Create `.towbar/deployment.yml` in the app repository:
+[Use the Hello Towbar template](https://github.com/avgeek-inc/towbar-example/generate)
+or fork the [example repository](https://github.com/avgeek-inc/towbar-example).
+Grant the connected GitHub App access to your copy. The example needs no package
+installation or application secrets and can be checked locally with `npm test`
+and `npm start` on Node.js 24 or newer.
+
+Edit the included `.towbar/deployment.yml`, replacing the server IP and domain.
+If you are bringing your own app, create the file with this configuration:
 
 ```yaml
 version: 1
 source:
   branch: main
 apps:
-  - id: web
-    name: Web
+  - id: hello-towbar
+    name: Hello Towbar
     server: 203.0.113.10
     dockerfile: Dockerfile
     context: .
     container:
       port: 3000
       resources:
-        cpus: 1
-        memory: 1g
+        cpus: 0.5
+        memory: 256m
     health:
       path: /health
       timeoutSeconds: 60
     domains:
-      primary: app.example.com
+      primary: hello.example.com
     tls:
       mode: direct
 ```
@@ -47,7 +54,7 @@ Commit this file to the branch in `source.branch`. Automatic deployment is delib
 
 Open **Sources → Add source** and select the repository. Wait for the initial sync, then open its result.
 
-A successful sync imports **Web** into the Source's Apps list. If it fails, correct the reported manifest field or missing server reference and sync again. A successful sync accepts configuration; it does not mean the app is running.
+A successful sync imports **Hello Towbar** into the Source's Apps list. If it fails, correct the reported manifest field or missing server reference and sync again. A successful sync accepts configuration; it does not mean the app is running.
 
 <div className="towbar-doc-screenshot">
   <div className="towbar-product-light">
@@ -68,6 +75,8 @@ Choose **Prepare Server** and follow the steps until the host is **Ready**. If p
 ## 4. Save application secrets
 
 Open **App → Settings → Secrets** and select Production. Add build, runtime, or hook values as needed, then save. Values inherited from workspace Shared secrets and the Source appear with their origin.
+
+The Hello Towbar example needs no secrets, so you can skip this step for your first deployment.
 
 Saved values are write-only. Leaving a replacement field untouched preserves its value. Saving does not start a deployment. See [Shared secrets](/docs/secrets) for precedence and rotation.
 
@@ -99,5 +108,9 @@ Confirm all four conditions:
 For an app without a public domain, verify it through its intended private client instead.
 
 ## Next steps
+
+For your second deployment, edit the heading in `src/index.html`, commit to
+`main`, and deploy again. Reload the public page to verify that your new code is
+running.
 
 Enable [automatic deployment](/docs/deployments#automatic-deployments), add [pull request previews](/docs/previews), or connect a [database resource](/docs/resources). Configure [notifications](/docs/integrations/notifications) so failed operations reach the people who need to act.

--- a/docs/docs/self-hosting/upgrades.md
+++ b/docs/docs/self-hosting/upgrades.md
@@ -23,6 +23,49 @@ docker compose logs --tail 200 migrate api worker
 
 A previous image alone is not a recovery plan for a database migration. Review migration compatibility before reverting a release. Do not replace `TOWBAR_CREDENTIALS_KEY`: existing encrypted records require the matching key.
 
+## Upgrading from 1.4.0 to 1.5.0
+
+1.5.0 changes server ownership, manifest configuration, and integration storage.
+The migrations intentionally reset the settings listed below; they do not copy
+old credential values into the new ownership model.
+
+1. Pause automatic deployments and wait for active deployments, backups, and
+   restores to finish. Back up the Towbar database and preserve `.env` and the
+   matching `TOWBAR_CREDENTIALS_KEY`. Confirm you can retrieve the server SSH keys,
+   Cloudflare tokens, AWS credentials, and notification provider credentials from
+   your own secure records before starting. Towbar's secret fields are write-only.
+2. Update each repository's manifest: remove its top-level `servers` block and
+   retain the `server` IP on every App and Resource. Host SSH/proxy/concurrency
+   settings now belong in **Servers → server → Settings → Configuration**.
+3. Set notification provider configuration in the installation `.env` before
+   recreating the stack. Slack uses `TOWBAR_SLACK_BOT_TOKEN`; SMTP uses
+   `TOWBAR_SMTP_HOST`, `TOWBAR_SMTP_FROM`, and the port/TLS/authentication settings
+   your provider requires. See [environment variables](/docs/reference/environment-variables).
+4. Check out the reviewed `v1.5.0` release and recreate the stack as shown above.
+   Inspect migration and startup output before continuing.
+5. Review every server. Servers are deduplicated by workspace and IP, and existing
+   server credential records are deleted. Re-enter SSH and any Cloudflare
+   credentials, review configuration and trusted host keys, and run server checks.
+   Checks, preparation records, and host keys belonging to removed duplicates do
+   not transfer to the retained record.
+6. Open **Integrations → Cloud providers → AWS** and add the workspace credential
+   if you use S3 backups/restores. The former source AWS credential table is
+   dropped without importing its values. Verify that the workspace credential can
+   access every bucket and prefix used by your Resources.
+7. Verify GitHub, AWS, and notification provider setup and send a test notification
+   to the configured destinations. The old stored Slack/SMTP provider secrets are
+   deleted; provider setup now comes from the environment variables in step 3.
+8. Sync Sources, resolve reported configuration errors, and deploy a small app.
+   Verify its actual HTTPS route before resuming automatic deployments. If you
+   use backups, verify a backup and a restore on a disposable Resource.
+
+Stored deployment plans and their GitHub checks are also removed. Deployment
+history remains the place to inspect actual deployment attempts.
+
+If recovery is needed after migrations run, stop the upgraded services and restore
+both the pre-upgrade database backup and the matching previous release/configuration.
+The release workflow's image/checkout fallback does **not** restore the database.
+
 ## Forgotten owner password
 
 Towbar deliberately exposes no public forgot-password or reset-password route.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "towbar",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Opinionated, source-driven deployments to Ubuntu servers you own.",
   "keywords": [
     "deployment",


### PR DESCRIPTION
Towbar's next release now has a working first-app example and explicit upgrade instructions. This prepares v1.5.0; publishing a tag or GitHub release remains a separate step.

- Bump the root package version to 1.5.0 so it matches the release workflow's tag validation.
- Add release notes for workspace-owned servers, shared secrets, integrations, inventory improvements, and the public documentation.
- Document the manifest changes, credential resets, server deduplication, removed deployment plans, and database recovery requirements for 1.4.0 installations.
- Link the public [Hello Towbar template](https://github.com/avgeek-inc/towbar-example) from the README and first-deployment guide. The example includes a non-root Dockerfile, `/health`, a manually deployed Towbar manifest, tests, and container CI.

Validation: documentation sync and internal-link checks; published YAML examples against Towbar's parser; formatting and diff checks. The separate example passes Node.js tests, builds and runs in Docker with healthy status, serves `/health` with HTTP 200, and was visually checked on desktop/light and mobile/dark layouts.

A clean-host Towbar installation and a 1.4.0 database-upgrade rehearsal have not been performed as part of this PR. Complete those before publishing the release. Existing integrations require the reconfiguration described in the upgrade guide.
