### PR TITLE
docs: add DataFast website analytics

### DIFF
--- a/docs/datafast.js
+++ b/docs/datafast.js
@@ -1,0 +1,19 @@
+// Mintlify loads custom JavaScript on every page after it becomes interactive.
+(() => {
+  // Keep local development and Mintlify previews out of production analytics.
+  if (!["towbar.dev", "www.towbar.dev"].includes(window.location.hostname)) {
+    return;
+  }
+
+  // Custom scripts can run again during navigation or preview updates.
+  if (document.getElementById("towbar-datafast")) return;
+
+  const script = document.createElement("script");
+  script.id = "towbar-datafast";
+  script.src = "https://datafa.st/js/script.js";
+  script.async = true;
+  script.defer = true;
+  script.dataset.websiteId = "dfid_pFhOpbhEzeuHAKKFF418i";
+  script.dataset.domain = "towbar.dev";
+  document.head.appendChild(script);
+})();

--- a/docs/privacy.mdx
+++ b/docs/privacy.mdx
@@ -16,3 +16,8 @@ plaintext secret values.
 The hosted documentation is published through Mintlify and links to GitHub and
 the separately operated Towbar dashboard. Those services apply their own
 privacy terms when you use them.
+
+We use DataFast on the public website and documentation to understand page views,
+referral sources, and site usage. DataFast uses first-party cookies to recognize
+visitors and sessions. See [DataFast's privacy policy](https://datafa.st/privacy-policy)
+for more information.


### PR DESCRIPTION
Adds DataFast analytics to Towbar's Mintlify homepage and documentation using website ID `dfid_pFhOpbhEzeuHAKKFF418i` and root domain `towbar.dev`.

Mintlify loads `docs/datafast.js` globally after pages become interactive. The loader asynchronously injects DataFast's standard script once per document, only on `towbar.dev` and `www.towbar.dev`, so local development and Mintlify preview visits do not enter production analytics. DataFast handles client-side page navigation itself. The privacy page now identifies DataFast and its use of first-party cookies.

Validation: JavaScript syntax check, Prettier check, documentation artifact/link checks across 132 pages, and Mintlify validation passed. Live analytics ingestion can be checked in DataFast after this PR is merged and Mintlify deploys it.

References: [Mintlify custom scripts](https://www.mintlify.com/docs/customize/custom-scripts), [DataFast script configuration](https://datafa.st/docs/script-configuration).
