### PR TITLE
Improve website gold contrast and responsive image delivery

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -15,6 +15,7 @@ mode: "custom"
   </section>
 
 {/* Image sizes mirror the homepage width, padding, borders, and feature grid in style.css. */}
+
 <div className="towbar-product">
   <div className="towbar-product-frame">
     <div className="towbar-product-light">

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -14,6 +14,7 @@ mode: "custom"
     </div>
   </section>
 
+{/* Image sizes mirror the homepage width, padding, borders, and feature grid in style.css. */}
 <div className="towbar-product">
   <div className="towbar-product-frame">
     <div className="towbar-product-light">
@@ -22,6 +23,7 @@ mode: "custom"
         alt="Towbar deployment dashboard"
         width="1600"
         height="860"
+        sizes="(max-width: 640px) calc(100vw - 42px), (max-width: 1200px) calc(100vw - 66px), 1134px"
         fetchPriority="high"
       />
     </div>
@@ -31,6 +33,7 @@ mode: "custom"
         alt="Towbar deployment dashboard"
         width="1600"
         height="860"
+        sizes="(max-width: 640px) calc(100vw - 42px), (max-width: 1200px) calc(100vw - 66px), 1134px"
         fetchPriority="high"
       />
     </div>
@@ -80,10 +83,10 @@ mode: "custom"
     </div>
     <div className="towbar-feature-image">
       <div className="towbar-product-light">
-        <img src="/assets/features/sources-light.webp" alt="Four example GitHub sources showing app, resource, and distinct server counts alongside production branches and sync status." width="1800" height="624" loading="lazy" />
+        <img src="/assets/features/sources-light.webp" alt="Four example GitHub sources showing app, resource, and distinct server counts alongside production branches and sync status." width="1800" height="624" sizes="(max-width: 640px) calc(100vw - 42px), (max-width: 900px) calc(100vw - 66px), (max-width: 1200px) calc(59.524vw - 78.19px), 636px" loading="lazy" />
       </div>
       <div className="towbar-product-dark">
-        <img src="/assets/features/sources-dark.webp" alt="Four example GitHub sources showing app, resource, and distinct server counts alongside production branches and sync status." width="1800" height="624" loading="lazy" />
+        <img src="/assets/features/sources-dark.webp" alt="Four example GitHub sources showing app, resource, and distinct server counts alongside production branches and sync status." width="1800" height="624" sizes="(max-width: 640px) calc(100vw - 42px), (max-width: 900px) calc(100vw - 66px), (max-width: 1200px) calc(59.524vw - 78.19px), 636px" loading="lazy" />
       </div>
     </div>
   </section>
@@ -108,6 +111,7 @@ mode: "custom"
         alt="An example Towbar app showing its health, running state, server, and latest deployment."
         width="1440"
         height="930"
+        sizes="(max-width: 640px) calc(100vw - 42px), (max-width: 900px) calc(100vw - 66px), (max-width: 1200px) calc(59.524vw - 78.19px), 636px"
         loading="lazy"
       />
     </div>
@@ -117,6 +121,7 @@ mode: "custom"
         alt="An example Towbar app showing its health, running state, server, and latest deployment."
         width="1440"
         height="930"
+        sizes="(max-width: 640px) calc(100vw - 42px), (max-width: 900px) calc(100vw - 66px), (max-width: 1200px) calc(59.524vw - 78.19px), 636px"
         loading="lazy"
       />
     </div>
@@ -143,6 +148,7 @@ mode: "custom"
         alt="Example PostgreSQL, Redis, and container image resources in the Towbar inventory."
         width="1440"
         height="720"
+        sizes="(max-width: 640px) calc(100vw - 42px), (max-width: 900px) calc(100vw - 66px), (max-width: 1200px) calc(59.524vw - 78.19px), 636px"
         loading="lazy"
       />
     </div>
@@ -152,6 +158,7 @@ mode: "custom"
         alt="Example PostgreSQL, Redis, and container image resources in the Towbar inventory."
         width="1440"
         height="720"
+        sizes="(max-width: 640px) calc(100vw - 42px), (max-width: 900px) calc(100vw - 66px), (max-width: 1200px) calc(59.524vw - 78.19px), 636px"
         loading="lazy"
       />
     </div>
@@ -178,6 +185,7 @@ mode: "custom"
         alt="An example server’s host capacity panel showing CPU, memory, disk usage, and uptime."
         width="1344"
         height="360"
+        sizes="(max-width: 640px) calc(100vw - 42px), (max-width: 900px) calc(100vw - 66px), (max-width: 1200px) calc(59.524vw - 78.19px), 636px"
         loading="lazy"
       />
     </div>
@@ -187,6 +195,7 @@ mode: "custom"
         alt="An example server’s host capacity panel showing CPU, memory, disk usage, and uptime."
         width="1344"
         height="360"
+        sizes="(max-width: 640px) calc(100vw - 42px), (max-width: 900px) calc(100vw - 66px), (max-width: 1200px) calc(59.524vw - 78.19px), 636px"
         loading="lazy"
       />
     </div>
@@ -213,6 +222,7 @@ mode: "custom"
         alt="Example Towbar pull request previews showing URLs, commits, expiry times, health status, and cleanup retry details."
         width="2120"
         height="508"
+        sizes="(max-width: 640px) calc(100vw - 42px), (max-width: 900px) calc(100vw - 66px), (max-width: 1200px) calc(59.524vw - 78.19px), 636px"
         loading="lazy"
       />
     </div>
@@ -222,6 +232,7 @@ mode: "custom"
         alt="Example Towbar pull request previews showing URLs, commits, expiry times, health status, and cleanup retry details."
         width="2120"
         height="508"
+        sizes="(max-width: 640px) calc(100vw - 42px), (max-width: 900px) calc(100vw - 66px), (max-width: 1200px) calc(59.524vw - 78.19px), 636px"
         loading="lazy"
       />
     </div>
@@ -237,10 +248,10 @@ mode: "custom"
     </div>
     <div className="towbar-feature-image">
       <div className="towbar-product-light">
-        <img src="/assets/features/secrets-light.webp" alt="Shared secret settings in an example Towbar workspace. Stored values are hidden, with separate production, preview, and deployment stages." width="1440" height="600" loading="lazy" />
+        <img src="/assets/features/secrets-light.webp" alt="Shared secret settings in an example Towbar workspace. Stored values are hidden, with separate production, preview, and deployment stages." width="1440" height="600" sizes="(max-width: 640px) calc(100vw - 42px), (max-width: 900px) calc(100vw - 66px), (max-width: 1200px) calc(59.524vw - 78.19px), 636px" loading="lazy" />
       </div>
       <div className="towbar-product-dark">
-        <img src="/assets/features/secrets-dark.webp" alt="Shared secret settings in an example Towbar workspace. Stored values are hidden, with separate production, preview, and deployment stages." width="1440" height="600" loading="lazy" />
+        <img src="/assets/features/secrets-dark.webp" alt="Shared secret settings in an example Towbar workspace. Stored values are hidden, with separate production, preview, and deployment stages." width="1440" height="600" sizes="(max-width: 640px) calc(100vw - 42px), (max-width: 900px) calc(100vw - 66px), (max-width: 1200px) calc(59.524vw - 78.19px), 636px" loading="lazy" />
       </div>
     </div>
   </section>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,14 +1,20 @@
 /* Brand colors for the native Mintlify navigation and custom homepage. */
 :root {
-  --towbar-yellow: oklch(0.64 0.13 85);
-  --towbar-yellow-hover: color-mix(in oklch, var(--towbar-yellow) 90%, white);
+  --towbar-yellow: oklch(0.55 0.11 85);
+  --towbar-yellow-hover: color-mix(in oklch, var(--towbar-yellow) 92%, black);
   --towbar-on-yellow: oklch(1 0 0);
 }
 .dark {
+  --towbar-yellow: oklch(0.64 0.13 85);
+  --towbar-yellow-hover: color-mix(in oklch, var(--towbar-yellow) 90%, white);
   --towbar-on-yellow: oklch(0.23 0.01 85);
 }
 #navbar a:has(> .bg-primary-dark) > .bg-primary-dark {
   background-color: var(--towbar-yellow);
+}
+#navbar a:has(> .bg-primary-dark):hover > .bg-primary-dark {
+  background-color: var(--towbar-yellow-hover);
+  opacity: 1;
 }
 #navbar a:has(> .bg-primary-dark) .text-white,
 #navbar a:has(> .bg-primary-dark) svg {


### PR DESCRIPTION
The homepage gold failed contrast checks, and its screenshot images advertised full viewport width even inside narrower feature columns.

Darken the light-mode gold from approximately #B08505 to #8F6B09, raising contrast against white from 3.40:1 to 4.90:1. Preserve the existing dark-mode gold, darken the light-mode hover shade, and prevent the navbar CTA from fading on hover.

Add responsive sizes hints to all 14 homepage screenshots across both themes. Match the hero to its 1,134px maximum, feature images to their approximately 636px desktop column, and stacked images to the available mobile width. Preserve full-resolution originals, intrinsic aspect ratios, lazy loading, and Mintlify CDN optimization.

Validation: local light/dark visual review and computed navbar hover colors; image sizes matched rendered widths at 390px, 1024px, and 1280px viewports; documentation sync, 132-page metadata/navigation/link checks, CSS formatting, and git diff checks passed. Local Mintlify serves unoptimized assets, so published CDN bandwidth savings and Lighthouse must be verified after deployment.
