### PR TITLE
Track GitHub repository clicks as a DataFast goal

### DIFF
--- a/docs/datafast.js
+++ b/docs/datafast.js
@@ -8,6 +8,43 @@
   // Custom scripts can run again during navigation or preview updates.
   if (document.getElementById("towbar-datafast")) return;
 
+  // Queue goals clicked before the analytics script has finished loading.
+  window.datafast =
+    window.datafast ||
+    function () {
+      window.datafast.q = window.datafast.q || [];
+      window.datafast.q.push(arguments);
+    };
+
+  function trackGitHubClick(event) {
+    if (event.type === "auxclick" ? event.button !== 1 : event.button !== 0) {
+      return;
+    }
+    const link =
+      event.target instanceof Element ? event.target.closest("a[href]") : null;
+    if (!link) return;
+
+    const url = new URL(link.href);
+    if (
+      url.hostname !== "github.com" ||
+      !/^\/avgeek-inc\/towbar\/?$/i.test(url.pathname)
+    ) {
+      return;
+    }
+
+    window.datafast("github_click", {
+      placement: link.closest("#navbar")
+        ? "navbar"
+        : link.closest(".towbar-home")
+          ? "homepage"
+          : "docs",
+    });
+  }
+
+  // Delegation also covers links rendered after client-side navigation.
+  document.addEventListener("click", trackGitHubClick, { capture: true });
+  document.addEventListener("auxclick", trackGitHubClick, { capture: true });
+
   const script = document.createElement("script");
   script.id = "towbar-datafast";
   script.src = "https://datafa.st/js/script.js";

--- a/docs/privacy.mdx
+++ b/docs/privacy.mdx
@@ -18,6 +18,6 @@ the separately operated Towbar dashboard. Those services apply their own
 privacy terms when you use them.
 
 We use DataFast on the public website and documentation to understand page views,
-referral sources, and site usage. DataFast uses first-party cookies to recognize
+referral sources, GitHub repository link clicks, and site usage. DataFast uses first-party cookies to recognize
 visitors and sessions. See [DataFast's privacy policy](https://datafa.st/privacy-policy)
 for more information.


### PR DESCRIPTION
Track clicks to the Towbar GitHub repository as the DataFast custom goal `github_click`, with `placement` set to `navbar`, `homepage`, or `docs`.

Use delegated click handlers so client-side navigation and nested icons work, including middle-clicks. Queue events until DataFast loads using its documented queue, preserve the production-domain guard, and avoid registering duplicate listeners. Update the privacy disclosure to mention repository link clicks.

Validation: JavaScript syntax, repository-wide Prettier, 132-page docs checks, and git diff checks passed. An isolated browser-event harness verified queued and loaded tracking, all placements, nested targets, middle-clicks, unrelated links, right-click exclusion, duplicate initialization, and local/preview exclusion. No production analytics events were sent; confirm receipt in DataFast after deployment and a real click.

Reference: https://datafa.st/docs/custom-goals
