### PR TITLE
Fix server preparation and multi-source server checks

### DIFF
--- a/apps/towbar-api/src/areas/servers/service.ts
+++ b/apps/towbar-api/src/areas/servers/service.ts
@@ -2,6 +2,7 @@ import { and, desc, eq, inArray, isNull, ne } from "drizzle-orm";
 import { z } from "zod";
 
 import {
+  type RuntimeExpectation,
   isNormalizedResource,
   serverHardwareFromCheck,
 } from "@workspace/towbar-core";
@@ -313,6 +314,7 @@ export async function getServerCheckExecutionContext(checkId: string) {
     .select({
       config: apps.config,
       deployableId: apps.id,
+      sourceId: apps.sourceId,
       desiredState: deployableRuntimeStates.desiredState,
     })
     .from(apps)
@@ -350,7 +352,7 @@ export async function getServerCheckExecutionContext(checkId: string) {
   return {
     ...context,
     expectedContainerNames: selectCurrentContainerNames(retainedReleases),
-    expectedDeployables: deployables.map((deployable) => {
+    expectedDeployables: deployables.map((deployable): RuntimeExpectation => {
       const release = currentReleaseByDeployable.get(deployable.deployableId);
       const resource = isNormalizedResource(deployable.config)
         ? deployable.config
@@ -366,9 +368,10 @@ export async function getServerCheckExecutionContext(checkId: string) {
             }
           : null,
         deployableId: deployable.deployableId,
+        sourceId: deployable.sourceId,
         desiredState: deployable.desiredState ?? "running",
-        health: resource
-          ? resource.health
+        health: isNormalizedResource(deployable.config)
+          ? deployable.config.health
           : { ...deployable.config.health, type: "http" as const },
         release: release
           ? {

--- a/apps/towbar-worker/src/activities/server-preparation.ts
+++ b/apps/towbar-worker/src/activities/server-preparation.ts
@@ -59,7 +59,7 @@ export async function executeServerPreparationActivity(preparationId: string) {
       { result, status: "succeeded", steps },
     );
   } catch (error) {
-    const errorMessage = preparationFailureMessage(error);
+    const errorMessage = safeErrorMessage(error);
     await signedApiRequest(
       "POST",
       `/v1/internal/server-preparations/${preparationId}/events`,
@@ -103,14 +103,6 @@ function normalizeFailedSteps(steps: ServerPreparationStep[], error: unknown) {
     }
   }
   return steps;
-}
-
-function preparationFailureMessage(error: unknown) {
-  const detail = safeErrorMessage(error).replace(/[.\s]+$/u, "");
-  return `${detail}. Towbar stopped without removing existing services. Use a fresh Ubuntu server, or clean up the conflicting installation before trying again.`.slice(
-    0,
-    1_000,
-  );
 }
 
 function safeErrorMessage(error: unknown) {

--- a/packages/towbar-core/src/resource-operations.ts
+++ b/packages/towbar-core/src/resource-operations.ts
@@ -61,6 +61,23 @@ export const orphanItemSchema = z
 
 export type OrphanItem = z.infer<typeof orphanItemSchema>;
 
+export type RuntimeExpectation = {
+  connectivity: {
+    containerPort: number;
+    hostPort: number | null;
+    network: string | null;
+    networkAlias: string | null;
+  } | null;
+  deployableId: string;
+  sourceId: string;
+  desiredState: RuntimeDesiredState;
+  health:
+    | { command: string[]; timeoutSeconds: number; type: "command" }
+    | { path: string; timeoutSeconds: number; type: "http" }
+    | { timeoutSeconds: number; type: "container" };
+  release: { containerName: string; imageTag: string } | null;
+};
+
 export type RuntimeInspection = {
   cpuPercent: number | null;
   deployableId: string;

--- a/packages/towbar-deployer/src/runtime-inspection.test.ts
+++ b/packages/towbar-deployer/src/runtime-inspection.test.ts
@@ -1,7 +1,15 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { RuntimeExpectation } from "@workspace/towbar-core";
+import type { SshSession } from "./ssh.js";
 import { describe, it } from "node:test";
 
 import {
+  inspectServerRuntime,
   parseRuntimeInspectionOutput,
   runtimeInspectionScript,
 } from "./runtime-inspection.js";
@@ -84,4 +92,147 @@ void describe("runtime inspection", () => {
     assert.match(runtimeInspectionScript, /memoryUsageBytes/);
     assert.match(runtimeInspectionScript, /cpuPercent/);
   });
+});
+
+void it("inspects multiple sources on one server without adopting foreign objects", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "towbar-runtime-test-"));
+  try {
+    const deployables: RuntimeExpectation[] = ["a", "b"].map((name, index) => ({
+      connectivity: null,
+      deployableId: `10000000-0000-4000-8000-00000000000${index + 1}`,
+      sourceId: `source-${name}`,
+      desiredState: "running",
+      health: { timeoutSeconds: 5, type: "container" },
+      release: { containerName: name, imageTag: `towbar/${name}:current` },
+    }));
+    const objects: Record<string, unknown> = {};
+    for (const item of deployables) {
+      const name = item.release!.containerName;
+      const labels = {
+        "towbar.managed": "true",
+        "towbar.source": item.sourceId,
+        "towbar.deployable": item.deployableId,
+      };
+      objects[`container:${name}`] = {
+        Name: `/${name}`,
+        Config: { Labels: labels, Image: item.release!.imageTag },
+        State: { Running: true, Health: { Status: "healthy" } },
+      };
+      objects[`container:${name}-previous`] = {
+        Name: `/${name}-previous`,
+        Config: { Labels: labels },
+      };
+      objects[`container:${name}-old`] = {
+        Name: `/${name}-old`,
+        Config: { Labels: labels },
+      };
+      objects[`image:towbar/${name}:current`] = { Config: { Labels: labels } };
+      objects[`image:towbar/${name}:previous`] = { Config: { Labels: labels } };
+      objects[`image:towbar/${name}:old`] = { Config: { Labels: labels } };
+      objects[`volume:${name}-data`] = { Labels: labels };
+      objects[`volume:${name}-removed`] = {
+        Labels: { ...labels, "towbar.deployable": "removed" },
+      };
+    }
+    const foreign = {
+      "towbar.managed": "true",
+      "towbar.source": "unrelated-source",
+      "towbar.deployable": "unrelated-app",
+    };
+    objects["container:foreign"] = {
+      Name: "/foreign",
+      Config: { Labels: foreign },
+    };
+    objects["image:towbar/foreign:old"] = { Config: { Labels: foreign } };
+    objects["volume:foreign"] = { Labels: foreign };
+    await writeFile(
+      path.join(directory, "objects.json"),
+      JSON.stringify(objects),
+    );
+    await writeFile(
+      path.join(directory, "docker"),
+      `#!${process.execPath}
+const objects = JSON.parse(require('node:fs').readFileSync(${JSON.stringify(path.join(directory, "objects.json"))}, 'utf8'));
+const args = process.argv.slice(2);
+if (args[1] === 'inspect') {
+  const object = objects[args[0] + ':' + args[2]];
+  if (!object) process.exit(1);
+  console.log(JSON.stringify([object]));
+} else if (args[0] !== 'stats') {
+  const kind = args[0] === 'ps' ? 'container' : args[0];
+  console.log(Object.keys(objects).filter(key => key.startsWith(kind + ':')).map(key => key.slice(kind.length + 1)).join('\\n'));
+}
+`,
+      { mode: 0o700 },
+    );
+    const session = {
+      run: (script: string, args: string[]) =>
+        Promise.resolve({
+          stderr: "",
+          stdout: execFileSync(
+            "bash",
+            [
+              "-c",
+              `export PATH="$1:$PATH"; shift\n${script}`,
+              "runtime-test",
+              directory,
+              ...args,
+            ],
+            {
+              encoding: "utf8",
+            },
+          ),
+        }),
+    } as unknown as SshSession;
+    const input = {
+      containerNames: ["a", "a-previous", "b", "b-previous"],
+      deployables,
+      imageTags: [
+        "towbar/a:current",
+        "towbar/a:previous",
+        "towbar/b:current",
+        "towbar/b:previous",
+      ],
+      session,
+    };
+    const result = await inspectServerRuntime(input);
+    assert.deepEqual(
+      result.runtime.map((item) => item.driftStatus),
+      ["in_sync", "in_sync"],
+    );
+    assert.deepEqual(
+      result.runtime.map((item) => item.healthStatus),
+      ["healthy", "healthy"],
+    );
+    assert.deepEqual(
+      result.orphans.map((item) => `${item.kind}:${item.name}`),
+      [
+        "container:a-old",
+        "container:b-old",
+        "image:towbar/a:old",
+        "image:towbar/b:old",
+        "volume:a-removed",
+        "volume:b-removed",
+      ],
+    );
+    assert.deepEqual(
+      await inspectServerRuntime({ ...input, deployables: [] }),
+      { runtime: [], orphans: [] },
+    );
+    objects["container:b"] = {
+      Name: "/b",
+      Config: { Labels: foreign, Image: "towbar/b:current" },
+      State: { Running: true },
+    };
+    await writeFile(
+      path.join(directory, "objects.json"),
+      JSON.stringify(objects),
+    );
+    assert.equal(
+      (await inspectServerRuntime(input)).runtime[1]?.driftStatus,
+      "drifted",
+    );
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
 });

--- a/packages/towbar-deployer/src/runtime-inspection.ts
+++ b/packages/towbar-deployer/src/runtime-inspection.ts
@@ -4,7 +4,7 @@ import { orphanItemSchema } from "@workspace/towbar-core";
 
 import type { SshSession } from "./ssh.js";
 import type {
-  RuntimeDesiredState,
+  RuntimeExpectation,
   RuntimeInspection,
 } from "@workspace/towbar-core";
 
@@ -40,17 +40,16 @@ const inspectionSchema = z
 
 export const runtimeInspectionScript = String.raw`
 set -euo pipefail
-source_id="$1"
-expected_json="$2"
-python3 - "$source_id" "$expected_json" <<'PYTHON'
+expected_json="$1"
+python3 - "$expected_json" <<'PYTHON'
 import json
 import subprocess
 import sys
 import urllib.request
 import re
 
-source_id = sys.argv[1]
-expected = json.loads(sys.argv[2])
+expected = json.loads(sys.argv[1])
+source_ids = {item["sourceId"] for item in expected["deployables"]}
 
 def command(*args):
     return subprocess.run(args, check=False, capture_output=True, text=True)
@@ -227,7 +226,7 @@ for item in expected["deployables"]:
         reasons.append("Container is running but Towbar expects it to be stopped")
     if health == "unhealthy":
         reasons.append("Container health check is failing")
-    if labels.get("towbar.source") != source_id or labels.get("towbar.deployable") != deployable_id:
+    if labels.get("towbar.source") != item["sourceId"] or labels.get("towbar.deployable") != deployable_id:
         reasons.append("Container predates Source ownership labels; redeploy before cleanup")
     connectivity = item.get("connectivity")
     if connectivity:
@@ -268,7 +267,7 @@ for name in containers.stdout.splitlines():
         continue
     labels = container.get("Config", {}).get("Labels") or {}
     container_name = container.get("Name", "").lstrip("/")
-    if labels.get("towbar.source") == source_id and container_name not in expected_containers:
+    if labels.get("towbar.source") in source_ids and container_name not in expected_containers:
         orphans.append({
             "kind": "container",
             "name": container_name,
@@ -281,7 +280,7 @@ for name in volumes.stdout.splitlines():
     if not volume:
         continue
     labels = volume.get("Labels") or {}
-    if labels.get("towbar.source") == source_id and labels.get("towbar.deployable") not in expected_deployables:
+    if labels.get("towbar.source") in source_ids and labels.get("towbar.deployable") not in expected_deployables:
         orphans.append({
             "kind": "volume",
             "name": name,
@@ -296,7 +295,7 @@ for name in images.stdout.splitlines():
     if not image:
         continue
     labels = (image.get("Config") or {}).get("Labels") or {}
-    if labels.get("towbar.source") == source_id and name not in expected_images:
+    if labels.get("towbar.source") in source_ids and name not in expected_images:
         orphans.append({
             "kind": "image",
             "name": name,
@@ -310,29 +309,13 @@ PYTHON
 
 export async function inspectServerRuntime(input: {
   containerNames: string[];
-  deployables: Array<{
-    connectivity: {
-      containerPort: number;
-      hostPort: number | null;
-      network: string | null;
-      networkAlias: string | null;
-    } | null;
-    deployableId: string;
-    desiredState: RuntimeDesiredState;
-    health:
-      | { command: string[]; timeoutSeconds: number; type: "command" }
-      | { path: string; timeoutSeconds: number; type: "http" }
-      | { timeoutSeconds: number; type: "container" };
-    release: { containerName: string; imageTag: string } | null;
-  }>;
+  deployables: RuntimeExpectation[];
   imageTags: string[];
   session: SshSession;
-  sourceId: string;
 }) {
   const { stdout } = await input.session.run(
     runtimeInspectionScript,
     [
-      input.sourceId,
       JSON.stringify({
         containerNames: input.containerNames,
         deployables: input.deployables,

--- a/packages/towbar-deployer/src/server-check.ts
+++ b/packages/towbar-deployer/src/server-check.ts
@@ -97,7 +97,6 @@ export async function checkServer(
       deployables: context.expectedDeployables,
       imageTags: context.expectedImageTags,
       session,
-      sourceId: context.sourceId,
     });
     return {
       caddyVersion,

--- a/packages/towbar-deployer/src/server-preparation.test.ts
+++ b/packages/towbar-deployer/src/server-preparation.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { execFileSync } from "node:child_process";
 
-import { serverPreparationScripts } from "./server-preparation.js";
+import { CommandError } from "./process.js";
+
+import {
+  preparationErrorMessage,
+  serverPreparationScripts,
+} from "./server-preparation.js";
 
 void test("uses signed upstream package repositories and pinned Caddy inputs", () => {
   assert.match(
@@ -75,4 +81,73 @@ void test("fully consumes Caddy module output under pipefail", () => {
     assert.match(script, /grep -Fx dns\.providers\.cloudflare >\/dev\/null/);
     assert.doesNotMatch(script, /grep -Fxq dns\.providers\.cloudflare/);
   }
+});
+
+void test("validates with the installed Caddy environment and supports a fresh server", () => {
+  const script = serverPreparationScripts.verifyServer;
+  const validation = script.slice(
+    script.indexOf("validate_args="),
+    script.indexOf("disk_available="),
+  );
+  for (const envExists of [true, false]) {
+    const output = execFileSync(
+      "bash",
+      [
+        "-c",
+        `
+set -euo pipefail
+SUDO=(privileged)
+privileged() {
+  if test "$1" = test; then return ${envExists ? 0 : 1}; fi
+  test "$1" = caddy
+  test "$2" = validate
+  test "$3" = --config
+  test "$4" = /etc/caddy/Caddyfile
+  test "$#" -eq ${envExists ? 6 : 4}
+  ${envExists ? 'test "$5" = --envfile; test "$6" = /etc/caddy/towbar/cloudflare.env' : ":"}
+}
+${validation}
+`,
+      ],
+      { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+    assert.equal(output, "");
+  }
+});
+
+void test("preserves the Caddy failure after noisy startup output and redacts tokens", () => {
+  const noise = Array.from({ length: 30 }, () =>
+    JSON.stringify({ level: "info", msg: "starting certificate maintenance" }),
+  ).join("\n");
+  const error = new CommandError(
+    "bash exited unsuccessfully",
+    "",
+    `${noise}\nError: loading DNS provider: API token 'sensitive-token' appears invalid`,
+  );
+  assert.equal(
+    preparationErrorMessage(error),
+    "Error: loading DNS provider: API token '[redacted]' appears invalid",
+  );
+});
+
+void test("retains the end of long diagnostics and actual conflict guidance", () => {
+  const message = preparationErrorMessage(
+    new CommandError(
+      "failed",
+      "",
+      `Error: ${"nested module: ".repeat(100)}certificate could not be loaded`,
+    ),
+  );
+  assert.equal(message.length, 800);
+  assert.ok(message.endsWith("certificate could not be loaded"));
+  const conflict =
+    "An incompatible Docker installation is already present. Remove the conflicting installation before continuing.";
+  assert.equal(
+    preparationErrorMessage(new CommandError("failed", "", conflict)),
+    conflict,
+  );
+  assert.equal(
+    preparationErrorMessage(new Error("SSH connection timed out")),
+    "SSH connection timed out",
+  );
 });

--- a/packages/towbar-deployer/src/server-preparation.ts
+++ b/packages/towbar-deployer/src/server-preparation.ts
@@ -194,7 +194,11 @@ if test "$requires_cloudflare" = true; then
   caddy list-modules | grep -Fx dns.providers.cloudflare >/dev/null
 fi
 "${"$"}{SUDO[@]}" test -d /etc/caddy/towbar
-"${"$"}{SUDO[@]}" caddy validate --config /etc/caddy/Caddyfile >/dev/null
+validate_args=(--config /etc/caddy/Caddyfile)
+if "${"$"}{SUDO[@]}" test -s /etc/caddy/towbar/cloudflare.env; then
+  validate_args+=(--envfile /etc/caddy/towbar/cloudflare.env)
+fi
+"${"$"}{SUDO[@]}" caddy validate "${"$"}{validate_args[@]}" >/dev/null
 disk_available="$(df -Pk /var/lib/docker | awk 'NR==2 {print $4}')"
 if test "$disk_available" -le 1048576; then
   printf 'At least 1 GiB of free space is required under /var/lib/docker.\n' >&2
@@ -384,7 +388,7 @@ async function runStep(input: {
   }
 }
 
-function preparationErrorMessage(error: unknown) {
+export function preparationErrorMessage(error: unknown) {
   if (error instanceof HostKeyNotTrustedError) {
     return "The server SSH host key is not trusted";
   }
@@ -394,12 +398,31 @@ function preparationErrorMessage(error: unknown) {
       : error instanceof Error
         ? error.message
         : "Server preparation failed";
-  return [...detail]
+  // Caddy writes informational JSON before its actual validation error.
+  // Retain actionable output before applying the persisted message limit.
+  const diagnostic =
+    detail
+      .split("\n")
+      .filter((line) => {
+        try {
+          const entry = JSON.parse(line) as { level?: string };
+          return !["debug", "info", "warn"].includes(entry?.level ?? "");
+        } catch {
+          return true;
+        }
+      })
+      .join("\n")
+      .trim() || detail;
+  const safeDiagnostic = diagnostic.replace(
+    /API token '[^']*'/gi,
+    "API token '[redacted]'",
+  );
+  const message = [...safeDiagnostic]
     .map((character) => {
       const codePoint = character.codePointAt(0) ?? 0;
       return codePoint < 32 || codePoint === 127 ? " " : character;
     })
     .join("")
-    .trim()
-    .slice(0, 800);
+    .trim();
+  return message.length > 800 ? `…${message.slice(-799)}` : message;
 }

--- a/packages/towbar-deployer/src/types.ts
+++ b/packages/towbar-deployer/src/types.ts
@@ -5,7 +5,7 @@ import type {
   OrphanItem,
   ResourceOperationRequest,
   ResourceOperationResult,
-  RuntimeDesiredState,
+  RuntimeExpectation,
   RuntimeInspection,
   ServerPreparationStepId,
   ServerPreparationStepStatus,
@@ -74,24 +74,9 @@ export type ServerCheckContext = {
   checkId: string;
   config: NormalizedServer;
   expectedContainerNames: string[];
-  expectedDeployables: Array<{
-    connectivity: {
-      containerPort: number;
-      hostPort: number | null;
-      network: string | null;
-      networkAlias: string | null;
-    } | null;
-    deployableId: string;
-    desiredState: RuntimeDesiredState;
-    health:
-      | { command: string[]; timeoutSeconds: number; type: "command" }
-      | { path: string; timeoutSeconds: number; type: "http" }
-      | { timeoutSeconds: number; type: "container" };
-    release: { containerName: string; imageTag: string } | null;
-  }>;
+  expectedDeployables: RuntimeExpectation[];
   expectedImageTags: string[];
   login: SshLoginSecret;
-  sourceId: string;
   trustedHostKeys: TrustedHostKey[];
 };
 


### PR DESCRIPTION
Server preparation on a host already using Cloudflare DNS TLS fails because `caddy validate` does not load the service environment file. Its actual error is then hidden behind startup logs and generic advice about a conflicting installation. Server checks also crash with `Cannot read properties of undefined (reading 'replaceAll')` because workspace-owned servers no longer have a single source ID.

This change:

- Loads the existing Cloudflare environment file during Caddy validation, while allowing preparation on fresh hosts without one.
- Preserves the useful end of validation errors, redacts token values in Cloudflare diagnostics, and removes unconditional conflicting-installation advice. Actual package conflicts retain their specific instructions.
- Carries source ownership on each expected deployable and shares that contract between the API and executor. Runtime inspection supports multiple sources on one server and limits orphan discovery to the sources represented there.

Validation: affected deployer, API, and worker lint/typecheck/test tasks passed (232 tests passed; two database integration tests skipped locally). Regression tests execute the shell validation block with and without an environment file and run the Python runtime inspection against a fake Docker inventory covering multiple sources, retained releases, foreign objects, empty inventories, and mismatched labels. Documentation and formatting checks passed.

Live diagnosis confirmed that Caddy validation succeeds on both affected servers when its environment file is supplied. This PR still needs a release, followed by rerunning server preparation and checks, to resolve the failed status in the control plane.
