### PR TITLE
Release v1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to Towbar are documented in this file. This project follows
 
 ## [Unreleased]
 
+## [1.5.3] - 2026-09-05
+
+### Fixed
+
+- Server preparation loads the existing Cloudflare environment file when validating
+  Caddy, allowing servers already using DNS TLS to complete preparation.
+- Preparation failures preserve the useful diagnostic, redact Cloudflare token
+  values, and no longer append unrelated conflicting-installation advice.
+- Server checks support workloads from multiple Sources on workspace-owned servers,
+  fixing the missing-source `replaceAll` crash while preserving ownership checks.
+- The website uses darker gold in light mode for readable text and buttons, and
+  requests screenshots at sizes appropriate to their displayed layout.
+
+### Added
+
+- Production website analytics through DataFast, including a goal for GitHub
+  repository clicks and updated privacy disclosures.
+
 ## [1.5.2] - 2026-09-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "towbar",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Opinionated, source-driven deployments to Ubuntu servers you own.",
   "keywords": [
     "deployment",


### PR DESCRIPTION
Release Towbar v1.5.3 with the server preparation and runtime-check fixes from #73, plus the website improvements from #70, #71, and #72.

- Load the existing Cloudflare environment file during Caddy validation and preserve actionable preparation errors.
- Fix the missing-source `replaceAll` crash when checking workspace-owned servers with workloads from multiple Sources.
- Include improved website contrast, responsive screenshot delivery, DataFast analytics, and GitHub-click goal tracking.

This PR updates only the root package version and changelog. No database migrations or additional behavior changes.

Validation: `pnpm install --frozen-lockfile` and full `pnpm verify` passed locally. The implementation PR #73 passed CI, Compose builds, and CodeQL. Release-branch CI will run before publication.

After publishing v1.5.3 and confirming deployment, rerun preparation and checks on affected servers to update their control-plane status.
