### PR TITLE
Fix AVG-5 preview environment names and report releases to Linear

### DIFF
--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -1,0 +1,55 @@
+name: Report release to Linear
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: linear-release-${{ github.event.release.id }}
+  cancel-in-progress: false
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Prepare release notes and commit range
+        id: release
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, os, pathlib
+          event = json.loads(pathlib.Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+          notes = pathlib.Path(os.environ["RUNNER_TEMP"]) / "linear-release-notes.md"
+          notes.write_text(event["release"].get("body") or "")
+          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+              output.write(f"notes={notes}\n")
+          PY
+          # Bound the first sync and reruns to this release, not just its final commit.
+          previous_tag="$(git describe --tags --abbrev=0 --match 'v[0-9]*' HEAD^ 2>/dev/null || true)"
+          echo "base=$previous_tag" >> "$GITHUB_OUTPUT"
+
+      # v0.17.2
+      - name: Sync published release
+        uses: linear/linear-release-action@53ad0f863963e7f8e270fba18426bbb55ef55384
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          cli_version: v0.17.2
+          command: sync
+          name: Towbar ${{ github.event.release.tag_name }}
+          version: ${{ github.event.release.tag_name }}
+          base_ref: ${{ steps.release.outputs.base }}
+          release_notes: ${{ steps.release.outputs.notes }}
+          links: |
+            GitHub release=${{ github.event.release.html_url }}
+            Workflow run=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,21 @@ documentation path.
 - Explain security, migration, and rollback implications when applicable.
 - Preserve Source scoping and avoid logging secret values.
 
+## Linear release reporting
+
+Publishing a GitHub release runs `Report release to Linear`. It checks out the
+released tag and syncs its version, release notes, GitHub link, and commits since
+the previous version tag to the Linear pipeline. Include Linear issue identifiers
+such as `AVG-5` in branch names or commit messages so they can be linked to the
+release; linked GitHub pull requests are also detected.
+
+Set the repository secret `LINEAR_ACCESS_KEY` to the pipeline access key from
+Linear. A continuous pipeline creates completed releases on sync; a scheduled
+pipeline collects the release for its configured stage workflow. This reports
+GitHub publication; production deployment success is tracked separately by
+`Deploy release`. To retry reporting, rerun the failed reporting job. The release
+tag is the version identifier, so retries target the same Linear release.
+
 Project stewardship and the current code owner are recorded in
 [MAINTAINERS.md](MAINTAINERS.md).
 

--- a/apps/towbar-api/src/areas/deployments/preview-status.ts
+++ b/apps/towbar-api/src/areas/deployments/preview-status.ts
@@ -124,14 +124,11 @@ export async function publishPreviewDeploymentStatus(
     if (state !== "inactive" || githubDeploymentId) {
       if (!githubDeploymentId) {
         githubDeploymentId = await createGitHubPreviewDeployment({
+          appName: deployment.app.name,
           commitSha: deployment.commitSha,
-          environment:
-            `Preview · ${deployment.app.name} · PR #${deployment.pullRequestNumber}`.slice(
-              0,
-              255,
-            ),
           environmentUrl: `https://${deployment.hostname}`,
           installationId: deployment.installationId,
+          pullRequestNumber: deployment.pullRequestNumber,
           repositoryName: deployment.repositoryName,
           repositoryOwner: deployment.repositoryOwner,
         });

--- a/apps/towbar-api/src/areas/github/client.ts
+++ b/apps/towbar-api/src/areas/github/client.ts
@@ -375,10 +375,11 @@ export async function createInstallationToken(installationId: string) {
 }
 
 export async function createGitHubPreviewDeployment(input: {
+  appName: string;
   commitSha: string;
-  environment: string;
   environmentUrl: string;
   installationId: string;
+  pullRequestNumber: number;
   repositoryName: string;
   repositoryOwner: string;
 }) {
@@ -388,8 +389,8 @@ export async function createGitHubPreviewDeployment(input: {
     await githubRequest(`/repos/${repository}/deployments`, {
       body: {
         auto_merge: false,
-        description: "Towbar Preview deployment",
-        environment: input.environment,
+        description: `Towbar Preview deployment for PR #${input.pullRequestNumber}`,
+        environment: `${input.appName.slice(0, 245)} · Preview`,
         payload: { environmentUrl: input.environmentUrl, managedBy: "towbar" },
         production_environment: false,
         ref: input.commitSha,
@@ -418,6 +419,8 @@ export async function updateGitHubPreviewDeployment(input: {
     `/repos/${repository}/deployments/${encodeURIComponent(input.deploymentId)}/statuses`,
     {
       body: {
+        // Each PR has its own lifecycle even when previews share an environment.
+        auto_inactive: false,
         environment_url: input.environmentUrl,
         state: input.state,
       },

--- a/apps/towbar-api/src/areas/github/preview-deployment.test.ts
+++ b/apps/towbar-api/src/areas/github/preview-deployment.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+import test from "node:test";
+
+void test("GitHub groups app previews while preserving each PR's identity and lifecycle", async (t) => {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const environment = {
+    DATABASE_TOWBAR_URL: "postgres://localhost/unused_test",
+    TOWBAR_CREDENTIALS_KEY: Buffer.alloc(32, 1).toString("base64"),
+    TOWBAR_INTERNAL_HMAC_SECRET: "test-hmac-secret".repeat(3),
+    GITHUB_APP_ID: "1001",
+    GITHUB_APP_SLUG: "towbar-test",
+    GITHUB_APP_PRIVATE_KEY: privateKey
+      .export({ type: "pkcs8", format: "pem" })
+      .toString(),
+    GITHUB_WEBHOOK_SECRET: "test-webhook-secret",
+  };
+  for (const [key, value] of Object.entries(environment)) {
+    const previous = process.env[key];
+    process.env[key] = value;
+    t.after(() => {
+      if (previous === undefined) delete process.env[key];
+      else process.env[key] = previous;
+    });
+  }
+  const requests: { url: string; body: Record<string, unknown> }[] = [];
+  t.mock.method(globalThis, "fetch", (url: string, init: RequestInit) => {
+    if (url.endsWith("/access_tokens")) {
+      return Promise.resolve(
+        Response.json({
+          token: "test-token",
+          expires_at: "2099-01-01T00:00:00Z",
+        }),
+      );
+    }
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+    requests.push({ url, body });
+    return Promise.resolve(Response.json({ id: requests.length }));
+  });
+  // Import after installing the transport stub: requests must never reach GitHub.
+  const { createGitHubPreviewDeployment, updateGitHubPreviewDeployment } =
+    await import("./client.js");
+  const repository = {
+    installationId: "123",
+    repositoryName: "platform",
+    repositoryOwner: "example-inc",
+  };
+  for (const pullRequestNumber of [135, 136]) {
+    await createGitHubPreviewDeployment({
+      ...repository,
+      appName: "Company Website",
+      commitSha: String(pullRequestNumber).padStart(40, "0"),
+      environmentUrl: `https://pr-${pullRequestNumber}.example.com`,
+      pullRequestNumber,
+    });
+  }
+  assert.equal(requests[0]?.body.environment, "Company Website · Preview");
+  assert.equal(requests[1]?.body.environment, requests[0]?.body.environment);
+  assert.equal(
+    requests[0]?.body.description,
+    "Towbar Preview deployment for PR #135",
+  );
+  assert.equal(
+    requests[1]?.body.description,
+    "Towbar Preview deployment for PR #136",
+  );
+  assert.notEqual(requests[0]?.body.ref, requests[1]?.body.ref);
+  assert.notDeepEqual(requests[0]?.body.payload, requests[1]?.body.payload);
+  assert.equal(requests[0]?.body.transient_environment, true);
+  assert.equal(requests[0]?.body.production_environment, false);
+
+  await createGitHubPreviewDeployment({
+    ...repository,
+    appName: "A".repeat(255),
+    commitSha: "a".repeat(40),
+    environmentUrl: "https://long-name.example.com",
+    pullRequestNumber: 137,
+  });
+  const name = String(requests[2]?.body.environment);
+  assert.equal(name.length, 255);
+  assert.ok(name.endsWith(" · Preview"));
+
+  for (const [deploymentId, state] of [
+    ["1", "success"],
+    ["2", "success"],
+    ["1", "inactive"],
+  ] as const) {
+    await updateGitHubPreviewDeployment({
+      ...repository,
+      deploymentId,
+      state,
+      environmentUrl: `https://preview-${deploymentId}.example.com`,
+    });
+    assert.equal(requests.at(-1)?.body.auto_inactive, false);
+    assert.equal(requests.at(-1)?.body.state, state);
+    assert.ok(
+      requests.at(-1)?.url.endsWith(`/deployments/${deploymentId}/statuses`),
+    );
+  }
+});

--- a/docs/docs/previews.md
+++ b/docs/docs/previews.md
@@ -76,6 +76,12 @@ commit.
 
 ## GitHub status
 
+GitHub groups preview deployments under one environment per App, named
+`App name · Preview`. The PR number appears in the deployment description.
+Each preview keeps its own URL and status; deploying one PR does not deactivate
+another PR's preview. Older environments with PR numbers in their names remain
+in GitHub until you remove them there.
+
 Towbar also maintains one comment per Source and pull request with every App's
 build status, Preview URL, and deployment details link. A hidden stable marker
 lets Towbar update the same GitHub comment instead of posting a new comment for


### PR DESCRIPTION
## Changes

Fixes [AVG-5](https://linear.app/avgeek-inc/issue/AVG-5/environment-name-creation-is-incorrect). GitHub previously received a different environment name for every PR, cluttering the environment list. Preview deployments now use `App name · Preview`; the PR number remains in the deployment description and each deployment keeps its own URL, commit, and status. Status updates explicitly disable automatic inactivation. Existing GitHub environment history is retained.

Add the official Linear release action, pinned to v0.17.2's commit and CLI version. Publishing a GitHub release reports its exact tag, release notes, links, and commits since the previous version tag to the Towbar Releases continuous pipeline. The workflow has read-only GitHub permissions and runs independently of production deployment. Reruns target the same version.

The repository secret `LINEAR_ACCESS_KEY` has been configured and verified against the intended pipeline. No release was created during verification.

## Validation

- 13 focused GitHub/preview-reporting tests passed, including multiple PRs sharing an environment, separate URLs and commits, long names, and targeted success/inactive updates.
- API typecheck and affected-file ESLint passed.
- Formatting, docs validation (133 pages), and actionlint passed.
- Executed the workflow metadata step locally: exact multiline release notes preserved and previous tag selected correctly.
- Checksum-verified Linear CLI dry run against the configured pipeline; no write calls. It detects AVG-5 and the preceding merged PRs.

GitHub CI will provide the full repository, documentation, and Compose gates. The published-release workflow will first run after this PR is merged and a release is published.
