### PR TITLE
Release v1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to Towbar are documented in this file. This project follows
 
 ## [Unreleased]
 
+## [1.5.4] - 2026-09-06
+
+### Fixed
+
+- Deleting a Source preserves workload ownership for subsequent server checks,
+  allowing leftover Towbar Docker objects to appear in Cleanup for on-demand
+  removal. Existing services keep running until explicitly cleaned up.
+- GitHub preview deployments use one environment per App, named
+  `App name · Preview`, instead of creating an environment for every PR. Each
+  preview retains its own URL and status without deactivating other previews.
+
+### Added
+
+- Remove server in Settings, with matching API and MCP support. Removal is hidden
+  and rejected while source-backed Apps, Resources, or undeleted previews remain,
+  and running operations also block removal. Removing an unused server forgets
+  its credentials and trust without terminating the machine or its services.
+- Observed instance type and compact cloud-provider logos in server connection
+  details and shared server metadata.
+- Published GitHub releases sync their versions, notes, links, and associated
+  issues to the Towbar Releases pipeline in Linear.
+
 ## [1.5.3] - 2026-09-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "towbar",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Opinionated, source-driven deployments to Ubuntu servers you own.",
   "keywords": [
     "deployment",


### PR DESCRIPTION
Prepare Towbar v1.5.4 by updating the root package version and changelog. Includes merged PRs #75, #76, and #77:

- Show observed provider logos and instance type in server metadata.
- Preserve source-deletion ownership for on-demand orphan cleanup and add guarded server removal through the control plane, API, and MCP.
- Fix AVG-5 by grouping GitHub preview environments per app while preserving individual PR URLs and statuses.
- Report published GitHub releases to the configured Towbar Releases pipeline in Linear.

This release includes database migration 0041 for retained server/workload ownership and server admission guards. Source deletion keeps existing services running; server removal does not terminate cloud instances or services.

Validation: version consistency, formatting, documentation checks (133 pages), and diff checks passed. The feature PR checks passed; main and release-PR CI are tracked separately. This PR only changes package.json and CHANGELOG.md.

After merge and successful checks, publish v1.5.4 against the merged release commit. Publication triggers the production deployment and Linear release-reporting workflows.
