### PR TITLE
Release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to Towbar are documented in this file. This project follows
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-09-06
+
+### Added
+
+- Scout Agent: opt-in server, app, and resource monitoring with observations every
+  30 seconds. Install, update, and uninstall it from Server → Settings → Scout Agent.
+  Linux AMD64 and ARM64 binaries are bundled with the Towbar worker and run as
+  separate collector and sender systemd services with bounded resource use.
+- Dedicated Scout Agent tabs with CPU, memory, disk, network, and workload
+  performance history; relative time ranges, average/peak views, instance and
+  preview filters, and deployment/restart markers with time-zone-aware tooltips.
+- Deployment and restart events scoped to the selected duration, shown 10 per page
+  and capped at the latest 200 events. Missing measurements use dotted connectors.
+- Per-server history retention of 7, 15, 30, or 60 days, defaulting to 15 days,
+  with backend aggregation and expiry. Online status requires a received report.
+- API and MCP support for Scout Agent configuration and performance history,
+  plus a dedicated Mintlify guide and the Scout Agent mascot in setup and empty states.
+
+### Changed
+
+- Chart filters retain previous data while updates load, with deferred rendering
+  for off-screen charts and stable layouts during duration changes.
+- Server Host Keys now lives under Settings. Removing an unused server uninstalls
+  Scout Agent before forgetting SSH credentials, with retries for interrupted operations.
+- Simplified the README with a feature table, Scout Agent introduction, and links
+  to Mintlify as the source for installation and configuration instructions.
+
+### Upgrade notes
+
+- Includes database migrations 0042 and 0043 for monitoring storage and durable
+  agent operations. Deploy the matching API and worker builds before installing
+  Scout Agent on servers. Existing servers remain opted out until installation
+  is acknowledged. Uninstalling retains collected history until its expiry.
+
 ## [1.5.4] - 2026-09-06
 
 ### Fixed
@@ -350,7 +384,10 @@ before resuming deployments:
 - Source-scoped AWS Secrets Manager integration and environment editors.
 - A same-domain owner setup, authentication, and operations dashboard.
 
-[Unreleased]: https://github.com/avgeek-inc/towbar/compare/v1.5.2...HEAD
+[Unreleased]: https://github.com/avgeek-inc/towbar/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/avgeek-inc/towbar/compare/v1.5.4...v1.6.0
+[1.5.4]: https://github.com/avgeek-inc/towbar/compare/v1.5.3...v1.5.4
+[1.5.3]: https://github.com/avgeek-inc/towbar/compare/v1.5.2...v1.5.3
 [1.5.2]: https://github.com/avgeek-inc/towbar/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/avgeek-inc/towbar/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/avgeek-inc/towbar/compare/v1.4.0...v1.5.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "towbar",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "description": "Opinionated, source-driven deployments to Ubuntu servers you own.",
   "keywords": [
     "deployment",


### PR DESCRIPTION
Prepare Towbar v1.6.0 from merged PR #79, introducing Scout Agent for opt-in server and workload monitoring.

- Capture host and container metrics every 30 seconds, with configurable retention, durable installation/removal, and bounded collector/sender services.
- Add Scout Agent tabs, interactive performance history, time-zone-aware deployment/restart markers, paginated events, and responsive chart updates.
- Move Host Keys into server settings and uninstall the agent before completing server removal.
- Introduce Scout Agent branding, mascot artwork, API/MCP references, and a dedicated Mintlify guide; simplify the README around features and documentation links.

Includes database migrations 0042 and 0043. Deploy matching API and worker builds before installing Scout Agent. Existing servers remain opted out until the owner acknowledges installation. Collected history follows retention after uninstall.

Validation: all feature-PR checks passed. This release PR changes only package.json and CHANGELOG.md. Version bump, formatting, documentation checks (141 pages), and diff checks passed; main and release-PR CI are tracked separately.

After merge and successful checks, publish v1.6.0 against the merged release commit. Publication triggers production deployment and Linear release reporting.

Related: [AVG-6](https://linear.app/avgeek-inc/issue/AVG-6).
