### PR TITLE
Fix vulnerability scans over non-root SSH sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,10 @@ jobs:
       - run: pnpm docs:api:check
       - run: pnpm typecheck
       - run: pnpm test
+      - name: Verify Trivy archive permissions as a non-root Docker user
+        run: pnpm --filter towbar-worker exec tsx --test src/vulnerability-scanners/trivy.docker.test.ts
+        env:
+          TOWBAR_DOCKER_TESTS: "1"
       - run: pnpm build
         env:
           SENTRY_ALLOW_MISSING: "true"

--- a/apps/towbar-worker/src/activities/vulnerability-scan.test.ts
+++ b/apps/towbar-worker/src/activities/vulnerability-scan.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { CommandError } from "@workspace/towbar-deployer";
+
 import { safeScanError } from "./vulnerability-scan.js";
 
 void test("bounds and redacts scanner failures before reporting them", () => {
@@ -11,4 +13,54 @@ void test("bounds and redacts scanner failures before reporting them", () => {
   assert.doesNotMatch(message, /scanner-secret/u);
   assert.doesNotMatch(message, /[\n\r]/u);
   assert.ok(message.length <= 1_000);
+});
+
+void test("preserves the final SSH stderr cause without including the image report", () => {
+  const error = new CommandError(
+    "ssh exited unsuccessfully",
+    "private image report",
+    `${"progress ".repeat(300)}\nopen /scan/image.tar: permission denied`,
+  );
+  const message = safeScanError(error);
+  assert.match(message, /open \/scan\/image.tar: permission denied$/u);
+  assert.doesNotMatch(message, /private image report/u);
+  assert.ok(message.length <= 1_000);
+});
+
+void test("sanitizes credentials and control characters in SSH diagnostics", () => {
+  const message = safeScanError(
+    new CommandError(
+      "ssh exited unsuccessfully",
+      "ignored",
+      [
+        "Bearer bearer-secret",
+        "Basic basic-secret",
+        "password=password-secret",
+        "https://user:url-secret@example.com/db?token=query-secret&signature=signed-secret",
+        "-----BEGIN PRIVATE KEY-----\nkey-secret\n-----END PRIVATE KEY-----",
+        "\u0000open /scan/image.tar: permission denied\u007f",
+      ].join("\n"),
+    ),
+  );
+  assert.doesNotMatch(
+    message,
+    /(?:bearer|basic|password|url|query|signed|key)-secret/u,
+  );
+  assert.ok(
+    [...message].every(
+      (character) =>
+        character.charCodeAt(0) > 31 && character.charCodeAt(0) !== 127,
+    ),
+  );
+  assert.match(message, /permission denied/u);
+});
+
+void test("uses the generic command message when stderr is empty", () => {
+  assert.equal(
+    safeScanError(
+      new CommandError("ssh exited unsuccessfully", "private report", ""),
+    ),
+    "ssh exited unsuccessfully",
+  );
+  assert.equal(safeScanError(undefined), "Image vulnerability scan failed");
 });

--- a/apps/towbar-worker/src/activities/vulnerability-scan.ts
+++ b/apps/towbar-worker/src/activities/vulnerability-scan.ts
@@ -1,6 +1,6 @@
 import { ApplicationFailure, Context } from "@temporalio/activity";
 
-import { SshSession } from "@workspace/towbar-deployer";
+import { CommandError, SshSession } from "@workspace/towbar-deployer";
 
 import { getEnv } from "../env.js";
 import { signedApiRequest } from "../infrastructure/towbar-api.js";
@@ -87,11 +87,32 @@ export async function executeVulnerabilityScanActivity(input: {
 
 export function safeScanError(error: unknown) {
   if (!(error instanceof Error)) return "Image vulnerability scan failed";
-  return [...error.message.replace(/Bearer\s+\S+/giu, "Bearer [REDACTED]")]
+  // SSH already captures stderr separately. Never include stdout: it may contain
+  // an image report rather than a diagnostic. The final lines hold Trivy's cause.
+  const detail =
+    error instanceof CommandError
+      ? error.stderr.trim() || error.message
+      : error.message;
+  const sanitized = detail
+    .replace(
+      /-----BEGIN [^-]*PRIVATE KEY-----[\s\S]*?-----END [^-]*PRIVATE KEY-----/gu,
+      "[REDACTED]",
+    )
+    .replace(/(?:Bearer|Basic)\s+\S+/giu, "[REDACTED]")
+    .replace(/(https?:\/\/)[^\s/@]+@/giu, "$1[REDACTED]@")
+    .replace(/([?&](?:[^=\s&]+)=)[^&\s]+/gu, "$1[REDACTED]")
+    .replace(
+      /((?:password|token|secret|api[_-]?key)\s*[:=]\s*)(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s,;]+)/giu,
+      "$1[REDACTED]",
+    );
+  const message = [...sanitized]
     .map((character) => {
       const codePoint = character.codePointAt(0) ?? 0;
       return codePoint <= 31 || codePoint === 127 ? " " : character;
     })
     .join("")
-    .slice(0, 1_000);
+    .trim();
+  return message.length > 1_000
+    ? `…${message.slice(-999)}`
+    : message || "Image vulnerability scan failed";
 }

--- a/apps/towbar-worker/src/vulnerability-scanners/trivy.docker.test.ts
+++ b/apps/towbar-worker/src/vulnerability-scanners/trivy.docker.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { parseTrivyScanResult, trivyScanScript } from "./trivy.js";
+
+// Opt in on a native Linux Docker host. macOS bind-mount permission emulation
+// cannot establish the non-root SSH-user regression this test guards.
+void test(
+  "Trivy reads a non-root user's private archive with capabilities dropped",
+  {
+    skip: process.env.TOWBAR_DOCKER_TESTS !== "1",
+    timeout: 600_000,
+  },
+  () => {
+    assert.equal(process.platform, "linux");
+    assert.notEqual(
+      process.getuid?.(),
+      0,
+      "Run as a non-root Docker user, like deploy",
+    );
+    const scanner =
+      "aquasec/trivy:0.74.0@sha256:62b1e65e8869bc4b4c6aa4fa2b21595256c7c2f6018a9d9ad61caf87187c1969";
+    const target = "alpine:3.22";
+    const directory = mkdtempSync(
+      path.join(tmpdir(), "towbar-trivy-regression-"),
+    );
+    const cache = `towbar-trivy-test-${process.pid}-${Date.now()}`;
+    // Isolate test cache only; run the production script and all its restrictions.
+    const script = trivyScanScript.replaceAll("towbar-trivy-cache", cache);
+    const run = (image: string, candidate = script) =>
+      spawnSync("bash", ["-s", "--", scanner, image], {
+        input: candidate,
+        env: { ...process.env, TMPDIR: directory },
+        encoding: "utf8",
+        timeout: 540_000,
+        maxBuffer: 8 * 1024 * 1024,
+      });
+    try {
+      assert.equal(statSync(directory).mode & 0o777, 0o700);
+      execFileSync("docker", ["pull", target], { stdio: "pipe" });
+      const digest = execFileSync(
+        "docker",
+        ["image", "inspect", "--format", "{{.Id}}", target],
+        { encoding: "utf8" },
+      ).trim();
+      const success = run(digest);
+      assert.equal(success.status, 0, success.stderr);
+      assert.equal(parseTrivyScanResult(success.stdout).scannerName, "trivy");
+      assert.deepEqual(
+        readdirSync(directory),
+        [],
+        "Successful scans remove their private archives",
+      );
+      // Negative control: the previous directory mount must fail under the same
+      // identity and restrictions, proving this host enforces Linux DAC checks.
+      const inaccessible = run(
+        digest,
+        script.replace(
+          '--volume "$image_file:/scan/image.tar:ro"',
+          '--volume "$work_dir:/scan:ro"',
+        ),
+      );
+      assert.notEqual(inaccessible.status, 0);
+      assert.match(inaccessible.stderr, /permission denied/iu);
+      assert.deepEqual(readdirSync(directory), []);
+      const failure = run(`sha256:${"0".repeat(64)}`);
+      assert.notEqual(failure.status, 0);
+      assert.deepEqual(
+        readdirSync(directory),
+        [],
+        "Failed scans also remove their temporary directories",
+      );
+    } finally {
+      rmSync(directory, { force: true, recursive: true });
+      spawnSync("docker", ["volume", "rm", cache], { stdio: "pipe" });
+    }
+  },
+);

--- a/apps/towbar-worker/src/vulnerability-scanners/trivy.ts
+++ b/apps/towbar-worker/src/vulnerability-scanners/trivy.ts
@@ -38,6 +38,9 @@ if [ "$image_size" -gt 8589934592 ]; then
   exit 1
 fi
 docker image save --output "$image_file" "$image_digest"
+# Keep the directory private to the SSH user. Bind only the readable archive:
+# container root with no capabilities cannot traverse a deploy-owned 0700 directory.
+chmod 0444 "$image_file"
 
 docker pull "$scanner_image" >/dev/null
 docker run --rm \
@@ -61,7 +64,7 @@ docker run --rm \
   --cap-drop ALL \
   --read-only \
   --tmpfs /tmp:rw,noexec,nosuid,size=512m \
-  --volume "$work_dir:/scan:ro" \
+  --volume "$image_file:/scan/image.tar:ro" \
   --volume towbar-trivy-cache:/root/.cache/trivy \
   "$scanner_image" image \
   --input /scan/image.tar \

--- a/packages/towbar-deployer/src/index.ts
+++ b/packages/towbar-deployer/src/index.ts
@@ -18,3 +18,4 @@ export * from "./source-fetch.js";
 export * from "./ssh.js";
 export * from "./types.js";
 export * from "./monitoring-agent.js";
+export { CommandError } from "./process.js";


### PR DESCRIPTION
Trivy scans fail when Towbar connects as a non-root SSH user such as `deploy`: the capability-restricted scanner cannot traverse the user's `0700` temporary directory. Mount only the read-only image archive, with read permission inside the container, while keeping the enclosing host directory private. Capability drops, read-only rootfs, offline scanning, resource limits, and cleanup remain intact.

Scan failures now retain the useful tail of SSH stderr instead of only `ssh exited unsuccessfully`. Diagnostics exclude stdout, redact credentials, strip control characters, and remain capped at 1,000 characters.

Validation:
- Worker tests, worker typecheck/lint, and deployer lint passed locally. Diagnostic regression tests cover permission errors after noisy output, redaction, bounds, and empty stderr.
- Added a CI test using real Trivy on a native Linux Docker host as a non-root user. It verifies the fixed scan, a negative control using the old directory mount, and cleanup after success and failure.
- Ran the patched script on the affected EC2 host as `deploy` (UID 1001), against the current Internal HQ API deployment image. It completed with findings: 4 critical, 56 high, 96 medium, 82 low, and 6 unknown; 70 actionable findings retained. This establishes scanner execution, not image cleanliness.

The currently published release is v1.6.1. A terminal scan through the deployed Towbar API remains to be verified after this worker fix is released and deployed. No database migration or Internal HQ redeployment is required.
