### PR TITLE
Align status colors and fix YAML scrolling

### DIFF
--- a/apps/towbar-web-app/src/components/app-detail.tsx
+++ b/apps/towbar-web-app/src/components/app-detail.tsx
@@ -180,7 +180,10 @@ export function AppDetail() {
                     />
                   </Attributes.Item>
                   <Attributes.Item label="Running state">
-                    <StatusBadge status={item.runtimeState.observedState} />
+                    <StatusBadge
+                      context="runtime"
+                      status={item.runtimeState.observedState}
+                    />
                   </Attributes.Item>
                   <Attributes.Item label="Configuration">
                     <StatusBadge status={item.runtimeState.driftStatus} />

--- a/apps/towbar-web-app/src/components/credential-editor.tsx
+++ b/apps/towbar-web-app/src/components/credential-editor.tsx
@@ -2,7 +2,12 @@
 
 import { HugeiconsIcon } from "@hugeicons/react";
 
-import { Key01Icon } from "@hugeicons/core-free-icons";
+import {
+  Key01Icon,
+  CheckmarkCircle01Icon,
+  InformationCircleIcon,
+  Delete02Icon,
+} from "@hugeicons/core-free-icons";
 
 import { useState, type FormEvent } from "react";
 import type { SecretMetadata, Server } from "@workspace/towbar-web-client";
@@ -286,6 +291,17 @@ function CredentialField({
         <FieldLabel htmlFor={id}>{label}</FieldLabel>
         <Chip
           size="small"
+          icon={
+            <HugeiconsIcon
+              icon={
+                deleted
+                  ? Delete02Icon
+                  : configured
+                    ? CheckmarkCircle01Icon
+                    : InformationCircleIcon
+              }
+            />
+          }
           variant={deleted ? "warning" : configured ? "success" : "secondary"}
         >
           {deleted

--- a/apps/towbar-web-app/src/components/dashboard-overview.tsx
+++ b/apps/towbar-web-app/src/components/dashboard-overview.tsx
@@ -19,7 +19,7 @@ import type {
 } from "@workspace/towbar-web-client";
 import { LineChart } from "@workspace/web-design-system/charts/line-chart";
 import { ButtonLink } from "@workspace/web-design-system/buttons/button";
-import { Chip } from "@workspace/web-design-system/data-display/chip";
+import { StatusBadge } from "@workspace/towbar-web-ui/status-badge";
 import { EmptyState } from "@workspace/web-design-system/data-display/empty-state";
 import { Widget } from "@workspace/web-design-system/data-display/widget";
 import { QueryError, QueryLoading } from "@workspace/towbar-web-ui/query-state";
@@ -250,9 +250,10 @@ function OverviewMetricIcon({
 
 function HealthChip({ unhealthyCount }: { unhealthyCount: number }) {
   return (
-    <Chip variant={unhealthyCount ? "destructive" : "success"}>
-      {unhealthyCount ? `${unhealthyCount} unhealthy` : "All healthy"}
-    </Chip>
+    <StatusBadge
+      status={unhealthyCount ? "unhealthy" : "healthy"}
+      label={unhealthyCount ? `${unhealthyCount} unhealthy` : "All healthy"}
+    />
   );
 }
 

--- a/apps/towbar-web-app/src/components/deployment-detail.tsx
+++ b/apps/towbar-web-app/src/components/deployment-detail.tsx
@@ -43,7 +43,7 @@ import { useDeploymentStream } from "@/hooks/use-deployment-stream";
 import { useApiQuery } from "@/hooks/use-api-query";
 import { api } from "@/lib/api";
 import { formatDate } from "./dashboard-overview";
-import { formatDeploymentTrigger } from "./deployment-table";
+import { DeploymentTriggerChip } from "./deployment-table";
 import { DeploymentVulnerabilityScanPanel } from "./deployment-vulnerability-scan";
 import { useSourceBreadcrumbs } from "./source-breadcrumbs";
 import { getDeploymentDisplayStatus } from "@/lib/deployment-status";
@@ -286,7 +286,7 @@ export function DeploymentDetail() {
                       <StatusBadge status={item.environment} />
                     </Attributes.Item>
                     <Attributes.Item label="Trigger">
-                      {formatDeploymentTrigger(item.trigger)}
+                      <DeploymentTriggerChip trigger={item.trigger} />
                     </Attributes.Item>
                     <Attributes.Item label="Requested">
                       {formatDate(item.createdAt)}

--- a/apps/towbar-web-app/src/components/deployment-table.tsx
+++ b/apps/towbar-web-app/src/components/deployment-table.tsx
@@ -1,5 +1,11 @@
 "use client";
 
+import {
+  GitBranchIcon,
+  PlayIcon,
+  RefreshIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import type { Deployment } from "@workspace/towbar-web-client";
 import { Chip } from "@workspace/web-design-system/data-display/chip";
 import { useTablePagination } from "@workspace/web-design-system/hooks/use-table-pagination";
@@ -53,9 +59,7 @@ export function DeploymentTable({
       key: "trigger",
       header: "Trigger",
       cell: (deployment) => (
-        <Chip size="small" variant="secondary">
-          {formatDeploymentTrigger(deployment.trigger)}
-        </Chip>
+        <DeploymentTriggerChip trigger={deployment.trigger} />
       ),
       className: "hidden whitespace-nowrap sm:table-cell",
       headerClassName: "hidden sm:table-cell",
@@ -116,4 +120,30 @@ export function formatDeploymentTrigger(trigger: Deployment["trigger"]) {
   if (trigger === "auto_deploy") return "Auto-deploy";
   if (trigger === "rollback") return "Rollback";
   return "Manual";
+}
+
+export function DeploymentTriggerChip({
+  trigger,
+}: {
+  trigger: Deployment["trigger"];
+}) {
+  return (
+    <Chip
+      size="small"
+      variant="secondary"
+      icon={
+        <HugeiconsIcon
+          icon={
+            trigger === "auto_deploy"
+              ? GitBranchIcon
+              : trigger === "rollback"
+                ? RefreshIcon
+                : PlayIcon
+          }
+        />
+      }
+    >
+      {formatDeploymentTrigger(trigger)}
+    </Chip>
+  );
 }

--- a/apps/towbar-web-app/src/components/deployments-index.tsx
+++ b/apps/towbar-web-app/src/components/deployments-index.tsx
@@ -25,7 +25,7 @@ import { TypographyCode } from "@workspace/web-design-system/typography/typograp
 import { DashboardPage, InlineLink } from "@/components/page-parts";
 import { useApiQuery } from "@/hooks/use-api-query";
 import { getDeploymentDisplayStatus } from "@/lib/deployment-status";
-import { formatDeploymentTrigger } from "./deployment-table";
+import { DeploymentTriggerChip } from "./deployment-table";
 import { DeploymentDuration } from "./elapsed-time";
 import { RelativeTime } from "./last-synced-time";
 
@@ -57,7 +57,11 @@ const columns: ResourceTableColumn<DeploymentHistoryItem>[] = [
           {item.deployableName}
         </InlineLink>
         {item.environment === "preview" ? (
-          <Chip size="small" variant="secondary">
+          <Chip
+            size="small"
+            variant="secondary"
+            icon={<HugeiconsIcon icon={Rocket01Icon} />}
+          >
             Preview
           </Chip>
         ) : null}
@@ -68,11 +72,7 @@ const columns: ResourceTableColumn<DeploymentHistoryItem>[] = [
   {
     key: "trigger",
     header: "Trigger",
-    cell: (item) => (
-      <Chip size="small" variant="secondary">
-        {formatDeploymentTrigger(item.trigger)}
-      </Chip>
-    ),
+    cell: (item) => <DeploymentTriggerChip trigger={item.trigger} />,
     className: "whitespace-nowrap",
   },
   {

--- a/apps/towbar-web-app/src/components/monitoring-agent-settings.tsx
+++ b/apps/towbar-web-app/src/components/monitoring-agent-settings.tsx
@@ -269,6 +269,19 @@ export function MonitoringStatus({ agent }: { agent: MonitoringAgentStatus }) {
   return (
     <Chip
       size="small"
+      icon={
+        <ScoutIcon
+          name={
+            agent.status === "online"
+              ? "resolved"
+              : agent.status === "failed"
+                ? "critical"
+                : agent.status === "offline"
+                  ? "warning"
+                  : "time"
+          }
+        />
+      }
       variant={
         agent.status === "online"
           ? "success"

--- a/apps/towbar-web-app/src/components/monitoring-agent-settings.tsx
+++ b/apps/towbar-web-app/src/components/monitoring-agent-settings.tsx
@@ -272,9 +272,11 @@ export function MonitoringStatus({ agent }: { agent: MonitoringAgentStatus }) {
       variant={
         agent.status === "online"
           ? "success"
-          : ["offline", "failed"].includes(agent.status)
-            ? "warning"
-            : "secondary"
+          : agent.status === "failed"
+            ? "destructive"
+            : agent.status === "offline"
+              ? "warning"
+              : "secondary"
       }
     >
       {labels[agent.status] ?? agent.status}

--- a/apps/towbar-web-app/src/components/monitoring-events.tsx
+++ b/apps/towbar-web-app/src/components/monitoring-events.tsx
@@ -39,7 +39,7 @@ const columns: ResourceTableColumn<Event>[] = [
       event.type === "deployment" ? (
         <StatusBadge status={event.state} />
       ) : (
-        "Restarted"
+        <StatusBadge status="restarted" />
       ),
   },
   {

--- a/apps/towbar-web-app/src/components/notification-integration.tsx
+++ b/apps/towbar-web-app/src/components/notification-integration.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { Mail01Icon, SlackIcon } from "@hugeicons/core-free-icons";
+import {
+  Alert02Icon,
+  CheckmarkCircle01Icon,
+  Mail01Icon,
+  SlackIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { QueryError, QueryLoading } from "@workspace/towbar-web-ui/query-state";
 import { ButtonLink } from "@workspace/web-design-system/buttons/button";
@@ -29,7 +34,15 @@ export function NotificationIntegration({
     <Widget>
       <Widget.Header
         endContent={
-          <Chip size="small" variant={configured ? "success" : "warning"}>
+          <Chip
+            size="small"
+            variant={configured ? "success" : "warning"}
+            icon={
+              <HugeiconsIcon
+                icon={configured ? CheckmarkCircle01Icon : Alert02Icon}
+              />
+            }
+          >
             {configured ? "Configured" : "Not configured"}
           </Chip>
         }

--- a/apps/towbar-web-app/src/components/resource-detail.tsx
+++ b/apps/towbar-web-app/src/components/resource-detail.tsx
@@ -144,7 +144,10 @@ export function ResourceDetail() {
               />
             </Attributes.Item>
             <Attributes.Item label="Running state">
-              <StatusBadge status={item.runtimeState.observedState} />
+              <StatusBadge
+                context="runtime"
+                status={item.runtimeState.observedState}
+              />
             </Attributes.Item>
             <Attributes.Item label="Configuration">
               <StatusBadge status={item.runtimeState.driftStatus} />

--- a/apps/towbar-web-app/src/components/scout-alerts.tsx
+++ b/apps/towbar-web-app/src/components/scout-alerts.tsx
@@ -120,10 +120,16 @@ export function ScoutAlerts({
               (r.mutedUntil && new Date(r.mutedUntil).getTime() > Date.now())
                 ? "secondary"
                 : r.evaluationState === "firing"
-                  ? "destructive"
+                  ? r.severity === "critical"
+                    ? "destructive"
+                    : "warning"
                   : r.evaluationState === "healthy"
                     ? "success"
-                    : "secondary"
+                    : r.evaluationState === "error"
+                      ? "destructive"
+                      : r.evaluationState === "pending"
+                        ? "warning"
+                        : "secondary"
             }
           >
             {!r.enabled
@@ -217,7 +223,9 @@ export function ScoutAlerts({
           size="small"
           variant={
             i.resolvedAt
-              ? "secondary"
+              ? i.resolutionReason === "recovered"
+                ? "success"
+                : "secondary"
               : i.severity === "critical"
                 ? "destructive"
                 : "warning"

--- a/apps/towbar-web-app/src/components/scout-alerts.tsx
+++ b/apps/towbar-web-app/src/components/scout-alerts.tsx
@@ -115,6 +115,25 @@ export function ScoutAlerts({
         <div className="grid justify-items-start gap-1">
           <Chip
             size="small"
+            icon={
+              <ScoutIcon
+                name={
+                  !r.enabled ||
+                  (r.mutedUntil &&
+                    new Date(r.mutedUntil).getTime() > Date.now())
+                    ? "mute"
+                    : r.evaluationState === "healthy"
+                      ? "resolved"
+                      : r.evaluationState === "firing"
+                        ? r.severity === "critical"
+                          ? "critical"
+                          : "warning"
+                        : r.evaluationState === "error"
+                          ? "critical"
+                          : "time"
+                }
+              />
+            }
             variant={
               !r.enabled ||
               (r.mutedUntil && new Date(r.mutedUntil).getTime() > Date.now())
@@ -221,6 +240,19 @@ export function ScoutAlerts({
       cell: (i) => (
         <Chip
           size="small"
+          icon={
+            <ScoutIcon
+              name={
+                i.resolvedAt
+                  ? i.resolutionReason === "recovered"
+                    ? "resolved"
+                    : "close"
+                  : i.severity === "critical"
+                    ? "critical"
+                    : "warning"
+              }
+            />
+          }
           variant={
             i.resolvedAt
               ? i.resolutionReason === "recovered"

--- a/apps/towbar-web-app/src/components/scout-incident-drawer.tsx
+++ b/apps/towbar-web-app/src/components/scout-incident-drawer.tsx
@@ -139,6 +139,19 @@ function IncidentBody({
       <div className="flex items-center gap-2">
         <Chip
           size="small"
+          icon={
+            <ScoutIcon
+              name={
+                incident.resolvedAt
+                  ? incident.resolutionReason === "recovered"
+                    ? "resolved"
+                    : "close"
+                  : incident.severity === "critical"
+                    ? "critical"
+                    : "warning"
+              }
+            />
+          }
           variant={
             incident.resolvedAt
               ? incident.resolutionReason === "recovered"
@@ -157,6 +170,11 @@ function IncidentBody({
         </Chip>
         <Chip
           size="small"
+          icon={
+            <ScoutIcon
+              name={incident.severity === "critical" ? "critical" : "warning"}
+            />
+          }
           variant={incident.severity === "critical" ? "destructive" : "warning"}
         >
           {incident.severity === "critical" ? "Critical" : "Warning"}

--- a/apps/towbar-web-app/src/components/scout-incident-drawer.tsx
+++ b/apps/towbar-web-app/src/components/scout-incident-drawer.tsx
@@ -139,7 +139,15 @@ function IncidentBody({
       <div className="flex items-center gap-2">
         <Chip
           size="small"
-          variant={incident.resolvedAt ? "secondary" : "destructive"}
+          variant={
+            incident.resolvedAt
+              ? incident.resolutionReason === "recovered"
+                ? "success"
+                : "secondary"
+              : incident.severity === "critical"
+                ? "destructive"
+                : "warning"
+          }
         >
           {incident.resolvedAt
             ? incident.resolutionReason === "recovered"

--- a/apps/towbar-web-app/src/components/scout-incident-notifications.tsx
+++ b/apps/towbar-web-app/src/components/scout-incident-notifications.tsx
@@ -60,6 +60,17 @@ export function ScoutIncidentNotifications({
         <div className="grid min-w-20 gap-1">
           <Chip
             size="small"
+            icon={
+              <ScoutIcon
+                name={
+                  d.state === "succeeded"
+                    ? "resolved"
+                    : d.state === "failed"
+                      ? "critical"
+                      : "time"
+                }
+              />
+            }
             variant={
               d.state === "succeeded"
                 ? "success"

--- a/apps/towbar-web-app/src/components/server-capacity.tsx
+++ b/apps/towbar-web-app/src/components/server-capacity.tsx
@@ -14,7 +14,6 @@ import type {
   RuntimeCapacity,
   SystemHealthStatus,
 } from "@workspace/towbar-web-client";
-import { Chip } from "@workspace/web-design-system/data-display/chip";
 import { EmptyState } from "@workspace/web-design-system/data-display/empty-state";
 import { Table } from "@workspace/web-design-system/data-display/table";
 import { Widget } from "@workspace/web-design-system/data-display/widget";
@@ -439,7 +438,7 @@ function MeterBar({
 
 function CapacityStatusBadge({ status }: { status: SystemHealthStatus }) {
   const presentation = capacityStatusPresentation[status];
-  return <Chip variant={presentation.variant}>{presentation.label}</Chip>;
+  return <StatusBadge status={status} label={presentation.label} />;
 }
 
 function meterStatus(

--- a/apps/towbar-web-app/src/components/source-detail.tsx
+++ b/apps/towbar-web-app/src/components/source-detail.tsx
@@ -22,7 +22,6 @@ import type {
   Source,
   SourceSync,
 } from "@workspace/towbar-web-client";
-import { Chip } from "@workspace/web-design-system/data-display/chip";
 import { EmptyState } from "@workspace/web-design-system/data-display/empty-state";
 import { useTablePagination } from "@workspace/web-design-system/hooks/use-table-pagination";
 import { Pagination } from "@workspace/web-design-system/navigation/pagination";
@@ -494,15 +493,12 @@ function SourceSubtabs({
 }
 
 function SyncStatusChip({ sync }: { sync?: SourceSync }) {
-  const variant = !sync
-    ? "secondary"
-    : sync.status === "succeeded"
-      ? "success"
-      : sync.status === "failed"
-        ? "destructive"
-        : "warning";
-
-  return <Chip variant={variant}>{getSyncStatusLabel(sync)}</Chip>;
+  return (
+    <StatusBadge
+      status={sync?.status ?? "unknown"}
+      label={getSyncStatusLabel(sync)}
+    />
+  );
 }
 
 function getSyncStatusLabel(sync?: SourceSync) {

--- a/apps/towbar-web-app/src/components/system-health.tsx
+++ b/apps/towbar-web-app/src/components/system-health.tsx
@@ -178,7 +178,14 @@ function HealthChecks({
 
 function HealthStatusChip({ status }: { status: SystemHealthStatus }) {
   const presentation = statusPresentation[status];
-  return <Chip variant={presentation.variant}>{presentation.label}</Chip>;
+  return (
+    <Chip
+      variant={presentation.variant}
+      icon={<HugeiconsIcon icon={presentation.icon} />}
+    >
+      {presentation.label}
+    </Chip>
+  );
 }
 
 function shortVersion(version: string) {

--- a/apps/towbar-web-app/src/components/workspace-monitoring-alerts.tsx
+++ b/apps/towbar-web-app/src/components/workspace-monitoring-alerts.tsx
@@ -65,11 +65,19 @@ export function WorkspaceAlerts() {
           <Chip
             size="small"
             variant={
-              rule.enabled && !muted && rule.evaluationState === "firing"
-                ? "destructive"
-                : rule.enabled && !muted && rule.evaluationState === "healthy"
-                  ? "success"
-                  : "secondary"
+              !rule.enabled || muted
+                ? "secondary"
+                : rule.evaluationState === "firing"
+                  ? rule.severity === "critical"
+                    ? "destructive"
+                    : "warning"
+                  : rule.evaluationState === "healthy"
+                    ? "success"
+                    : rule.evaluationState === "error"
+                      ? "destructive"
+                      : rule.evaluationState === "pending"
+                        ? "warning"
+                        : "secondary"
             }
           >
             {!rule.enabled

--- a/apps/towbar-web-app/src/components/workspace-monitoring-alerts.tsx
+++ b/apps/towbar-web-app/src/components/workspace-monitoring-alerts.tsx
@@ -64,6 +64,23 @@ export function WorkspaceAlerts() {
         return (
           <Chip
             size="small"
+            icon={
+              <ScoutIcon
+                name={
+                  !rule.enabled || muted
+                    ? "mute"
+                    : rule.evaluationState === "healthy"
+                      ? "resolved"
+                      : rule.evaluationState === "firing"
+                        ? rule.severity === "critical"
+                          ? "critical"
+                          : "warning"
+                        : rule.evaluationState === "error"
+                          ? "critical"
+                          : "time"
+                }
+              />
+            }
             variant={
               !rule.enabled || muted
                 ? "secondary"
@@ -102,6 +119,11 @@ export function WorkspaceAlerts() {
       cell: ({ rule }) => (
         <Chip
           size="small"
+          icon={
+            <ScoutIcon
+              name={rule.severity === "critical" ? "critical" : "warning"}
+            />
+          }
           variant={rule.severity === "critical" ? "destructive" : "warning"}
         >
           {rule.severity === "critical" ? "Critical" : "Warning"}

--- a/apps/towbar-web-app/src/components/workspace-monitoring-incidents.tsx
+++ b/apps/towbar-web-app/src/components/workspace-monitoring-incidents.tsx
@@ -68,6 +68,19 @@ export function WorkspaceIncidents() {
       cell: ({ incident }) => (
         <Chip
           size="small"
+          icon={
+            <ScoutIcon
+              name={
+                incident.resolvedAt
+                  ? incident.resolutionReason === "recovered"
+                    ? "resolved"
+                    : "close"
+                  : incident.severity === "critical"
+                    ? "critical"
+                    : "warning"
+              }
+            />
+          }
           variant={
             incident.resolvedAt
               ? incident.resolutionReason === "recovered"

--- a/apps/towbar-web-app/src/components/workspace-monitoring-incidents.tsx
+++ b/apps/towbar-web-app/src/components/workspace-monitoring-incidents.tsx
@@ -70,7 +70,9 @@ export function WorkspaceIncidents() {
           size="small"
           variant={
             incident.resolvedAt
-              ? "secondary"
+              ? incident.resolutionReason === "recovered"
+                ? "success"
+                : "secondary"
               : incident.severity === "critical"
                 ? "destructive"
                 : "warning"

--- a/packages/towbar-web-ui/package.json
+++ b/packages/towbar-web-ui/package.json
@@ -13,7 +13,9 @@
     "@workspace/web-design-system": "workspace:*",
     "next": "catalog:",
     "react": "catalog:",
-    "react-dom": "catalog:"
+    "react-dom": "catalog:",
+    "@hugeicons/core-free-icons": "catalog:",
+    "@hugeicons/react": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/towbar-web-ui/src/code-panel.tsx
+++ b/packages/towbar-web-ui/src/code-panel.tsx
@@ -10,15 +10,18 @@ export function CodePanel({
   language?: string;
 }) {
   return (
-    <CodeBlock
-      aria-label={ariaLabel}
-      className="max-h-[34rem] w-full min-w-0 overflow-auto"
-    >
+    <CodeBlock aria-label={ariaLabel} className="w-full min-w-0">
       <CodeBlock.Header>
         <CodeBlock.Filename>{ariaLabel}</CodeBlock.Filename>
         <CodeBlock.CopyButton code={children} />
       </CodeBlock.Header>
-      <CodeBlock.Code code={children} language={language} />
+      <CodeBlock.Code
+        aria-label={`${ariaLabel} code`}
+        className="max-h-[30rem] overflow-auto"
+        tabIndex={0}
+        code={children}
+        language={language}
+      />
     </CodeBlock>
   );
 }

--- a/packages/towbar-web-ui/src/status-badge.tsx
+++ b/packages/towbar-web-ui/src/status-badge.tsx
@@ -5,6 +5,8 @@ import {
   Clock01Icon,
   InformationCircleIcon,
   PlayIcon,
+  Rocket01Icon,
+  ServerStack01Icon,
   StopIcon,
   RefreshIcon,
 } from "@hugeicons/core-free-icons";
@@ -129,25 +131,29 @@ export function StatusBadge({
           ? "destructive"
           : "secondary";
   const icon =
-    status === "restarted"
-      ? RefreshIcon
-      : status === "running" && context === "runtime"
-        ? PlayIcon
-        : status === "stopped" || status === "cancelled"
-          ? StopIcon
-          : variant === "success"
-            ? CheckmarkCircle01Icon
-            : variant === "destructive"
-              ? AlertCircleIcon
-              : status === "queued" ||
-                  status === "pending" ||
-                  status.startsWith("waiting")
-                ? Clock01Icon
-                : variant === "warning"
-                  ? progress.has(status)
-                    ? RefreshIcon
-                    : Alert02Icon
-                  : InformationCircleIcon;
+    status === "preview"
+      ? Rocket01Icon
+      : status === "production"
+        ? ServerStack01Icon
+        : status === "restarted"
+          ? RefreshIcon
+          : status === "running" && context === "runtime"
+            ? PlayIcon
+            : status === "stopped" || status === "cancelled"
+              ? StopIcon
+              : variant === "success"
+                ? CheckmarkCircle01Icon
+                : variant === "destructive"
+                  ? AlertCircleIcon
+                  : status === "queued" ||
+                      status === "pending" ||
+                      status.startsWith("waiting")
+                    ? Clock01Icon
+                    : variant === "warning"
+                      ? progress.has(status)
+                        ? RefreshIcon
+                        : Alert02Icon
+                      : InformationCircleIcon;
   return (
     <Chip variant={variant} icon={<HugeiconsIcon icon={icon} />}>
       {label ?? formatStatus(status)}

--- a/packages/towbar-web-ui/src/status-badge.tsx
+++ b/packages/towbar-web-ui/src/status-badge.tsx
@@ -8,6 +8,9 @@ const success = new Set([
   "current",
   "success",
   "healthy",
+  "in_sync",
+  "online",
+  "recovered",
   "live",
   "passed",
   "published",
@@ -55,6 +58,8 @@ const warning = new Set([
   "stale",
   "delivering",
   "findings",
+  "warning",
+  "offline",
   "retrying",
 ]);
 const destructive = new Set([
@@ -68,14 +73,21 @@ const destructive = new Set([
   "not_restore_ready",
 ]);
 
-export function StatusBadge({ status }: { status: string }) {
-  const variant = success.has(status)
-    ? "success"
-    : warning.has(status)
-      ? "warning"
-      : destructive.has(status)
-        ? "destructive"
-        : "secondary";
+export function StatusBadge({
+  status,
+  context,
+}: {
+  status: string;
+  context?: "runtime";
+}) {
+  const variant =
+    success.has(status) || (context === "runtime" && status === "running")
+      ? "success"
+      : warning.has(status)
+        ? "warning"
+        : destructive.has(status)
+          ? "destructive"
+          : "secondary";
   return <Chip variant={variant}>{formatStatus(status)}</Chip>;
 }
 

--- a/packages/towbar-web-ui/src/status-badge.tsx
+++ b/packages/towbar-web-ui/src/status-badge.tsx
@@ -1,3 +1,14 @@
+import {
+  Alert02Icon,
+  AlertCircleIcon,
+  CheckmarkCircle01Icon,
+  Clock01Icon,
+  InformationCircleIcon,
+  PlayIcon,
+  StopIcon,
+  RefreshIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Chip } from "@workspace/web-design-system/data-display/chip";
 
 const success = new Set([
@@ -73,6 +84,31 @@ const destructive = new Set([
   "not_restore_ready",
 ]);
 
+const progress = new Set([
+  "building",
+  "deleting",
+  "checking_health",
+  "checking_public_endpoint",
+  "checking_server",
+  "cleaning_up",
+  "configuring_routing",
+  "fetching_source",
+  "preparing",
+  "provisioning_tls",
+  "resolving_secrets",
+  "running",
+  "running_post_deploy",
+  "running_pre_deploy",
+  "starting_candidate",
+  "switching_traffic",
+  "transferring",
+  "validating_credentials",
+  "connecting",
+  "reconnecting",
+  "delivering",
+  "retrying",
+]);
+
 export function StatusBadge({
   status,
   context,
@@ -88,7 +124,29 @@ export function StatusBadge({
         : destructive.has(status)
           ? "destructive"
           : "secondary";
-  return <Chip variant={variant}>{formatStatus(status)}</Chip>;
+  const icon =
+    status === "running" && context === "runtime"
+      ? PlayIcon
+      : status === "stopped" || status === "cancelled"
+        ? StopIcon
+        : variant === "success"
+          ? CheckmarkCircle01Icon
+          : variant === "destructive"
+            ? AlertCircleIcon
+            : status === "queued" ||
+                status === "pending" ||
+                status.startsWith("waiting")
+              ? Clock01Icon
+              : variant === "warning"
+                ? progress.has(status)
+                  ? RefreshIcon
+                  : Alert02Icon
+                : InformationCircleIcon;
+  return (
+    <Chip variant={variant} icon={<HugeiconsIcon icon={icon} />}>
+      {formatStatus(status)}
+    </Chip>
+  );
 }
 
 export function formatStatus(status: string) {

--- a/packages/towbar-web-ui/src/status-badge.tsx
+++ b/packages/towbar-web-ui/src/status-badge.tsx
@@ -70,11 +70,13 @@ const warning = new Set([
   "delivering",
   "findings",
   "warning",
+  "attention",
   "offline",
   "retrying",
 ]);
 const destructive = new Set([
   "blocked",
+  "critical",
   "decommissioned",
   "error",
   "failed",
@@ -112,9 +114,11 @@ const progress = new Set([
 export function StatusBadge({
   status,
   context,
+  label,
 }: {
   status: string;
   context?: "runtime";
+  label?: string;
 }) {
   const variant =
     success.has(status) || (context === "runtime" && status === "running")
@@ -125,26 +129,28 @@ export function StatusBadge({
           ? "destructive"
           : "secondary";
   const icon =
-    status === "running" && context === "runtime"
-      ? PlayIcon
-      : status === "stopped" || status === "cancelled"
-        ? StopIcon
-        : variant === "success"
-          ? CheckmarkCircle01Icon
-          : variant === "destructive"
-            ? AlertCircleIcon
-            : status === "queued" ||
-                status === "pending" ||
-                status.startsWith("waiting")
-              ? Clock01Icon
-              : variant === "warning"
-                ? progress.has(status)
-                  ? RefreshIcon
-                  : Alert02Icon
-                : InformationCircleIcon;
+    status === "restarted"
+      ? RefreshIcon
+      : status === "running" && context === "runtime"
+        ? PlayIcon
+        : status === "stopped" || status === "cancelled"
+          ? StopIcon
+          : variant === "success"
+            ? CheckmarkCircle01Icon
+            : variant === "destructive"
+              ? AlertCircleIcon
+              : status === "queued" ||
+                  status === "pending" ||
+                  status.startsWith("waiting")
+                ? Clock01Icon
+                : variant === "warning"
+                  ? progress.has(status)
+                    ? RefreshIcon
+                    : Alert02Icon
+                  : InformationCircleIcon;
   return (
     <Chip variant={variant} icon={<HugeiconsIcon icon={icon} />}>
-      {formatStatus(status)}
+      {label ?? formatStatus(status)}
     </Chip>
   );
 }

--- a/packages/web-design-system/src/data-display/chip.tsx
+++ b/packages/web-design-system/src/data-display/chip.tsx
@@ -18,6 +18,7 @@ export type ChipProps = Omit<
 > & {
   children?: ReactNode;
   loading?: boolean;
+  icon?: ReactNode;
   size?: ChipSize;
   variant?: ChipVariant;
 };
@@ -36,6 +37,7 @@ const sizes = { small: "sm", default: "md", large: "lg" } as const;
 export function Chip({
   children,
   loading,
+  icon,
   size,
   variant,
   ...props
@@ -49,7 +51,17 @@ export function Chip({
       {...props}
     >
       {loading ? <Spinner color="current" size="sm" /> : null}
-      <HeroChip.Label className="whitespace-nowrap">{children}</HeroChip.Label>
+      <HeroChip.Label className="inline-flex items-center gap-1.5 whitespace-nowrap">
+        {!loading && icon ? (
+          <span
+            aria-hidden="true"
+            className="inline-flex shrink-0 [&_svg]:size-3.5"
+          >
+            {icon}
+          </span>
+        ) : null}
+        {children}
+      </HeroChip.Label>
     </HeroChip>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -533,6 +533,12 @@ importers:
 
   packages/towbar-web-ui:
     dependencies:
+      "@hugeicons/core-free-icons":
+        specifier: "catalog:"
+        version: 4.3.0
+      "@hugeicons/react":
+        specifier: "catalog:"
+        version: 1.1.10(react@19.2.8)
       "@workspace/web-design-system":
         specifier: workspace:*
         version: link:../web-design-system


### PR DESCRIPTION
Container runtime “Running” and configuration “In Sync” now use green chips on app and resource pages. Running jobs remain amber because they have not completed.

The status-color audit also aligns recovered incidents with green, warning-level firing alerts with amber, and critical alerts, evaluation errors, and failed Scout Agent states with red. Muted, paused, closed, and unknown states stay neutral. Shared badges recognize online, recovered, offline, and warning states consistently.

Status badges and Scout alert, incident, notification-delivery, and agent chips include semantic icons with consistent spacing. Running containers use play, healthy states use checks, queued work uses clocks, and problems use warning/error symbols.

The YAML/log code panel now scrolls on the code element itself, with a bounded height and keyboard focus, keeping the filename and copy control visible. The previous outer-card scrolling was clipped by the inner widget surface.

Validation: web app and shared UI typechecks, lint, and tests pass. In Chrome, verified green Running/In Sync alongside an amber Building state. With a temporary long YAML fixture, verified vertical and horizontal scroll offsets change inside the bounded code area. Temporary fixture data is not part of this change.
