### PR TITLE
Open Source repository titles in a new tab

### DIFF
--- a/apps/towbar-web-app/src/components/source-detail.tsx
+++ b/apps/towbar-web-app/src/components/source-detail.tsx
@@ -201,6 +201,18 @@ export function SourceDetail() {
         )
       }
       title={item.repositoryName}
+      titleContent={
+        <a
+          href={`https://github.com/${encodeURIComponent(item.repositoryOwner)}/${encodeURIComponent(item.repositoryName)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="truncate rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-accent"
+          aria-label={`${item.repositoryOwner}/${item.repositoryName} on GitHub (opens in a new tab)`}
+          title={`${item.repositoryOwner}/${item.repositoryName}`}
+        >
+          {item.repositoryName}
+        </a>
+      }
     >
       <PageTabs
         defaultValue="apps"


### PR DESCRIPTION
Clicking the repository title on a Source page opens its GitHub repository in a new tab. The link preserves the heading styling, adds hover and keyboard-focus feedback, and announces the new-tab behavior to assistive technology.

The URL uses the Source repository owner and name with encoded path segments and noopener/noreferrer. Sync behavior is unchanged.

Validation: web typecheck, focused ESLint, formatting, and diff checks passed.
