### PR TITLE
Add env file editing and improve secret input layout

### DIFF
--- a/apps/towbar-web-app/package.json
+++ b/apps/towbar-web-app/package.json
@@ -20,6 +20,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.11.0",
+    "@codemirror/state": "^6.7.4",
+    "@codemirror/view": "^6.43.11",
     "@hugeicons/core-free-icons": "catalog:",
     "@hugeicons/react": "catalog:",
     "@workspace/identity-web-ui": "workspace:*",
@@ -37,10 +40,10 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@workspace/eslint-config": "workspace:^",
+    "@workspace/towbar-core": "workspace:*",
     "@workspace/typescript-config": "workspace:*",
     "eslint": "catalog:",
     "tsx": "^4.23.13",
-    "typescript": "catalog:",
-    "@workspace/towbar-core": "workspace:*"
+    "typescript": "catalog:"
   }
 }

--- a/apps/towbar-web-app/src/components/app-detail.tsx
+++ b/apps/towbar-web-app/src/components/app-detail.tsx
@@ -10,6 +10,7 @@ import {
   Rocket01Icon,
   ServerStack01Icon,
   Settings01Icon,
+  Key01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
@@ -310,10 +311,16 @@ export function AppDetail() {
 
 function AppSettings({ appId, item }: { appId: string; item: AppRecord }) {
   const requestedSettings = useSearchParams().get("settings");
-  const tabs: Array<{ content: ReactNode; label: string; value: string }> = [
+  const tabs: Array<{
+    content: ReactNode;
+    icon: ReactNode;
+    label: string;
+    value: string;
+  }> = [
     {
       value: "configuration",
       label: "Configuration",
+      icon: <HugeiconsIcon icon={Settings01Icon} />,
       content: <AppConfiguration item={item} />,
     },
     ...(item.config.preview?.enabled
@@ -321,6 +328,7 @@ function AppSettings({ appId, item }: { appId: string; item: AppRecord }) {
           {
             value: "preview",
             label: "Preview",
+            icon: <HugeiconsIcon icon={Rocket01Icon} />,
             content: (
               <Attributes
                 icon={<HugeiconsIcon icon={Settings01Icon} />}
@@ -342,11 +350,13 @@ function AppSettings({ appId, item }: { appId: string; item: AppRecord }) {
     {
       value: "auto-deploy",
       label: "Auto-deploy",
+      icon: <HugeiconsIcon icon={GitBranchIcon} />,
       content: <AutoDeployControlEditor id={appId} type="app" />,
     },
     {
       value: "secrets",
       label: "Secrets",
+      icon: <HugeiconsIcon icon={Key01Icon} />,
       content: <AppSecrets appId={appId} />,
     },
   ];

--- a/apps/towbar-web-app/src/components/app-secrets.tsx
+++ b/apps/towbar-web-app/src/components/app-secrets.tsx
@@ -155,50 +155,76 @@ function SecretSelector({
 }) {
   const selected = options.find((option) => option.value === value);
   return (
-    <Select
-      fullWidth
-      variant="secondary"
-      selectedKey={value}
-      onSelectionChange={(key) => {
-        if (key !== null) onChange(String(key));
-      }}
-    >
-      <Label className="sr-only">{label}</Label>
-      <Select.Trigger>
-        <Select.Value>
-          <span className="inline-flex min-w-0 items-center gap-2">
-            <HugeiconsIcon
-              aria-hidden="true"
-              icon={selected?.icon ?? PackageIcon}
-              className="size-4 shrink-0"
-            />
-            <span className="truncate">{selected?.label}</span>
-          </span>
-        </Select.Value>
-        <Select.Indicator />
-      </Select.Trigger>
-      <Select.Popover>
-        <ListBox>
-          {options.map((option) => (
-            <ListBox.Item
-              key={option.value}
-              id={option.value}
-              textValue={option.label}
-            >
-              <span className="inline-flex items-center gap-2">
+    <>
+      <Select
+        className="md:hidden"
+        fullWidth
+        variant="secondary"
+        selectedKey={value}
+        onSelectionChange={(key) => {
+          if (key !== null) onChange(String(key));
+        }}
+      >
+        <Label className="sr-only">{label}</Label>
+        <Select.Trigger>
+          <Select.Value>
+            <span className="inline-flex min-w-0 items-center gap-2">
+              <HugeiconsIcon
+                aria-hidden="true"
+                icon={selected?.icon ?? PackageIcon}
+                className="size-4 shrink-0"
+              />
+              <span className="truncate">{selected?.label}</span>
+            </span>
+          </Select.Value>
+          <Select.Indicator />
+        </Select.Trigger>
+        <Select.Popover>
+          <ListBox>
+            {options.map((option) => (
+              <ListBox.Item
+                key={option.value}
+                id={option.value}
+                textValue={option.label}
+              >
+                <span className="inline-flex items-center gap-2">
+                  <HugeiconsIcon
+                    aria-hidden="true"
+                    icon={option.icon}
+                    className="size-4 shrink-0"
+                  />
+                  {option.label}
+                </span>
+                <ListBox.ItemIndicator />
+              </ListBox.Item>
+            ))}
+          </ListBox>
+        </Select.Popover>
+      </Select>
+      <Tabs
+        className="hidden min-w-0 md:block"
+        selectedKey={value}
+        onSelectionChange={(key) => {
+          if (key !== null) onChange(String(key));
+        }}
+      >
+        <Tabs.ListContainer className="w-fit max-w-full overflow-x-auto">
+          <Tabs.List aria-label={label} className="min-w-max">
+            {options.map((option) => (
+              <Tabs.Tab key={option.value} id={option.value} className="gap-2">
                 <HugeiconsIcon
                   aria-hidden="true"
                   icon={option.icon}
                   className="size-4 shrink-0"
                 />
                 {option.label}
-              </span>
-              <ListBox.ItemIndicator />
-            </ListBox.Item>
-          ))}
-        </ListBox>
-      </Select.Popover>
-    </Select>
+                <Tabs.Indicator />
+              </Tabs.Tab>
+            ))}
+          </Tabs.List>
+        </Tabs.ListContainer>
+      </Tabs>
+    </>
   );
 }
 
@@ -221,7 +247,9 @@ function EnvironmentEditors({
     <div className="grid min-w-0 gap-4">
       <div
         className={
-          environment ? "grid min-w-0 grid-cols-2 gap-3" : "grid min-w-0"
+          environment
+            ? "grid min-w-0 grid-cols-2 gap-3 md:grid-cols-1"
+            : "grid min-w-0"
         }
       >
         {environment && onEnvironmentChange ? (

--- a/apps/towbar-web-app/src/components/app-secrets.tsx
+++ b/apps/towbar-web-app/src/components/app-secrets.tsx
@@ -1,9 +1,14 @@
 "use client";
 
+import dynamic from "next/dynamic";
+import { Tabs } from "@workspace/web-design-system/navigation/tabs";
+import { parseSecretEnv, serializeSecretEnv } from "@/lib/secret-env";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState, type FormEvent } from "react";
 import {
   Delete02Icon,
+  SourceCodeIcon,
+  Menu01Icon,
   ViewIcon,
   ViewOffSlashIcon,
   Key01Icon,
@@ -27,6 +32,10 @@ import { QueryError, QueryLoading } from "@workspace/towbar-web-ui/query-state";
 import { useApiQuery } from "@/hooks/use-api-query";
 import { api } from "@/lib/api";
 import { ResponsiveSubtabs } from "./responsive-subtabs";
+
+const SecretFileEditor = dynamic(() => import("./secret-file-editor"), {
+  ssr: false,
+});
 
 export const stageLabels: Record<AppSecretStage, string> = {
   build: "Build",
@@ -205,19 +214,118 @@ function SecretVariablesEditor({
     Array<{ id: string; key: string; value: string }>
   >([]);
   const [error, setError] = useState<string>();
+  const [fileMode, setFileMode] = useState(false);
+  const [fileText, setFileText] = useState("");
+  const [initialFile, setInitialFile] = useState("");
+  const originalValues = useRef(new Map<string, string>());
+  const modeRequest = useRef(0);
+  useEffect(
+    () => () => {
+      modeRequest.current++;
+    },
+    [],
+  );
   const keys = [...binding.keys].sort();
   const hasChanges =
+    (fileMode && fileText !== initialFile) ||
     Object.keys(replacements).length > 0 ||
     deleted.length > 0 ||
     newKeys.length > 0;
+  function fileChanges() {
+    const values = parseSecretEnv(fileText);
+    const replacement: Record<string, string> = Object.create(null);
+    const added: Array<{ id: string; key: string; value: string }> = [];
+    for (const [key, value] of values) {
+      if (keys.includes(key)) {
+        if (value !== originalValues.current.get(key)) replacement[key] = value;
+      } else added.push({ id: crypto.randomUUID(), key, value });
+    }
+    return {
+      replacement,
+      added,
+      removed: keys.filter((key) => !values.has(key)),
+    };
+  }
+  async function toggleMode() {
+    if (busy) return;
+    const request = ++modeRequest.current;
+    setBusy(true);
+    try {
+      if (fileMode) {
+        const changes = fileChanges();
+        setReplacements(changes.replacement);
+        setNewKeys(changes.added);
+        setDeleted(changes.removed);
+        setFileText("");
+        originalValues.current.clear();
+      } else {
+        const entries: Array<[string, string]> = [];
+        const stored = new Map<string, string>();
+        const retained = keys.filter((key) => !deleted.includes(key));
+        for (let index = 0; index < retained.length; index += 8) {
+          const batch = await Promise.all(
+            retained.slice(index, index + 8).map(async (key) => {
+              if (Object.hasOwn(replacements, key))
+                return [key, replacements[key]!] as [string, string];
+              const result = await api.post<{
+                value: string;
+                revision: string | null;
+              }>(`${endpoint}/${binding.environment}/${binding.stage}/reveal`, {
+                key,
+              });
+              if (result.revision !== binding.revision)
+                throw new Error(
+                  "Secrets changed. Refresh before opening file mode.",
+                );
+              stored.set(key, result.value);
+              return [key, result.value] as [string, string];
+            }),
+          );
+          if (request !== modeRequest.current) return;
+          entries.push(...batch);
+        }
+        for (const row of newKeys) {
+          if (!row.key.trim() && !row.value) continue;
+          entries.push([row.key.trim(), row.value]);
+        }
+        const text = serializeSecretEnv(entries);
+        parseSecretEnv(text);
+        originalValues.current = stored;
+        setFileText(text);
+        setInitialFile(text);
+      }
+      setError(undefined);
+      setFileMode(!fileMode);
+    } catch (failure) {
+      if (request === modeRequest.current)
+        setError(
+          failure instanceof Error
+            ? failure.message
+            : "Could not open file mode.",
+        );
+    } finally {
+      if (request === modeRequest.current) setBusy(false);
+    }
+  }
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    let draft;
+    try {
+      draft = fileMode
+        ? fileChanges()
+        : { replacement: replacements, added: newKeys, removed: deleted };
+    } catch (failure) {
+      setError(
+        failure instanceof Error ? failure.message : "Check the .env file.",
+      );
+      return;
+    }
     const set: Record<string, string> = Object.assign(
       Object.create(null),
-      replacements,
+      draft.replacement,
     );
     const seen = new Set(keys);
-    for (const row of newKeys) {
+    for (const row of draft.added) {
       const key = row.key.trim();
       if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(key) || seen.has(key)) {
         setError(
@@ -228,7 +336,7 @@ function SecretVariablesEditor({
       seen.add(key);
       set[key] = row.value;
     }
-    if (!Object.keys(set).length && !deleted.length) {
+    if (!Object.keys(set).length && !draft.removed.length) {
       setError("Add, replace, or remove at least one variable.");
       return;
     }
@@ -238,11 +346,13 @@ function SecretVariablesEditor({
       await api.patch(`${endpoint}/${binding.environment}/${binding.stage}`, {
         expectedRevision: binding.revision,
         set,
-        delete: deleted,
+        delete: draft.removed,
       });
       setReplacements({});
       setDeleted([]);
       setNewKeys([]);
+      setFileMode(false);
+      setFileText("");
       toast.success("Secrets saved. Changes apply on the next deployment.");
       onUpdated();
     } catch (failure) {
@@ -265,195 +375,246 @@ function SecretVariablesEditor({
           </Widget.Title>
         </Widget.Header>
         <Widget.Content className="content-grid min-w-0">
-          {!keys.length && !newKeys.length ? (
-            <EmptyState>
-              <EmptyState.Header>
-                <EmptyState.Title>
-                  No {stageLabel.toLowerCase()} secrets
-                </EmptyState.Title>
-                <EmptyState.Description className="max-w-sm text-pretty">
-                  Add a variable to make it available at this stage.
-                </EmptyState.Description>
-              </EmptyState.Header>
-              {canManage ? (
-                <EmptyState.Content>
-                  <Button
-                    onPress={() =>
-                      setNewKeys([
-                        { id: crypto.randomUUID(), key: "", value: "" },
-                      ])
-                    }
-                  >
-                    Add variable
-                  </Button>
-                </EmptyState.Content>
+          <Tabs
+            selectedKey={fileMode ? "file" : "form"}
+            onSelectionChange={(key) => {
+              if ((key === "file") !== fileMode) void toggleMode();
+            }}
+          >
+            <Tabs.ListContainer className="mb-4 w-fit">
+              <Tabs.List aria-label="Secret editing mode">
+                <Tabs.Tab id="form" isDisabled={busy}>
+                  <HugeiconsIcon
+                    aria-hidden="true"
+                    icon={Menu01Icon}
+                    size={16}
+                  />
+                  Form
+                  <Tabs.Indicator />
+                </Tabs.Tab>
+                <Tabs.Tab id="file" isDisabled={busy || !canManage}>
+                  <HugeiconsIcon
+                    aria-hidden="true"
+                    icon={SourceCodeIcon}
+                    size={16}
+                  />
+                  {busy && !fileMode ? "Loading…" : "File"}
+                  <Tabs.Indicator />
+                </Tabs.Tab>
+              </Tabs.List>
+            </Tabs.ListContainer>
+            <Tabs.Panel
+              id={fileMode ? "file" : "form"}
+              key={fileMode ? "file" : "form"}
+              className="content-grid m-0 min-w-0 p-0"
+            >
+              {fileMode ? (
+                <div className="grid min-w-0 gap-3">
+                  <SecretFileEditor
+                    value={fileText}
+                    onChange={setFileText}
+                    disabled={busy}
+                  />
+                </div>
               ) : null}
-            </EmptyState>
-          ) : null}
-          {keys.length > 0 || newKeys.length > 0 ? (
-            <div className="grid gap-3">
-              {keys.map((key) => {
-                const removed = deleted.includes(key);
-                return (
-                  <div
-                    key={key}
-                    className="grid grid-cols-[repeat(8,minmax(0,1fr))_2.5rem] sm:grid-cols-[repeat(8,minmax(0,1fr))_2.25rem] items-center gap-2 md:gap-3"
-                  >
-                    <div className="col-span-4 flex min-h-10 min-w-0 items-center gap-2">
-                      <span
-                        className={`break-all font-mono text-sm ${
-                          removed ? "text-muted line-through" : ""
-                        }`}
-                      >
-                        {key}
-                      </span>
-                    </div>
-                    <div className="col-span-4 min-w-0">
-                      <SecretValueInput
-                        label={`Value for ${key}`}
-                        value={replacements[key] ?? ""}
-                        configured={!Object.hasOwn(replacements, key)}
-                        disabled={!canManage || busy || removed}
-                        reveal={async () => {
-                          const result = await api.post<{
-                            value: string;
-                            revision: string | null;
-                          }>(
-                            `${endpoint}/${binding.environment}/${binding.stage}/reveal`,
-                            { key },
-                          );
-                          if (result.revision !== binding.revision)
-                            throw new Error(
-                              "This secret changed. Refresh before viewing it.",
-                            );
-                          return result.value;
-                        }}
-                        onChange={(value) =>
-                          setReplacements((current) => ({
-                            ...current,
-                            [key]: value,
-                          }))
-                        }
-                      />
-                    </div>
-                    {canManage ? (
+              {!fileMode && !keys.length && !newKeys.length ? (
+                <EmptyState>
+                  <EmptyState.Header>
+                    <EmptyState.Title>
+                      No {stageLabel.toLowerCase()} secrets
+                    </EmptyState.Title>
+                    <EmptyState.Description className="max-w-sm text-pretty">
+                      Add a variable to make it available at this stage.
+                    </EmptyState.Description>
+                  </EmptyState.Header>
+                  {canManage ? (
+                    <EmptyState.Content>
                       <Button
-                        aria-label={removed ? `Keep ${key}` : `Remove ${key}`}
+                        onPress={() =>
+                          setNewKeys([
+                            { id: crypto.randomUUID(), key: "", value: "" },
+                          ])
+                        }
+                      >
+                        Add variable
+                      </Button>
+                    </EmptyState.Content>
+                  ) : null}
+                </EmptyState>
+              ) : null}
+              {!fileMode && (keys.length > 0 || newKeys.length > 0) ? (
+                <div className="grid gap-3">
+                  {keys.map((key) => {
+                    const removed = deleted.includes(key);
+                    return (
+                      <div
+                        key={key}
+                        className="grid grid-cols-[repeat(8,minmax(0,1fr))_2.5rem] sm:grid-cols-[repeat(8,minmax(0,1fr))_2.25rem] items-center gap-2 md:gap-3"
+                      >
+                        <div className="col-span-4 flex min-h-10 min-w-0 items-center gap-2">
+                          <span
+                            className={`break-all font-mono text-sm ${
+                              removed ? "text-muted line-through" : ""
+                            }`}
+                          >
+                            {key}
+                          </span>
+                        </div>
+                        <div className="col-span-4 min-w-0">
+                          <SecretValueInput
+                            label={`Value for ${key}`}
+                            value={replacements[key] ?? ""}
+                            configured={!Object.hasOwn(replacements, key)}
+                            disabled={!canManage || busy || removed}
+                            reveal={async () => {
+                              const result = await api.post<{
+                                value: string;
+                                revision: string | null;
+                              }>(
+                                `${endpoint}/${binding.environment}/${binding.stage}/reveal`,
+                                { key },
+                              );
+                              if (result.revision !== binding.revision)
+                                throw new Error(
+                                  "This secret changed. Refresh before viewing it.",
+                                );
+                              return result.value;
+                            }}
+                            onChange={(value) =>
+                              setReplacements((current) => ({
+                                ...current,
+                                [key]: value,
+                              }))
+                            }
+                          />
+                        </div>
+                        {canManage ? (
+                          <Button
+                            aria-label={
+                              removed ? `Keep ${key}` : `Remove ${key}`
+                            }
+                            className="col-span-1 size-10 min-w-0 justify-self-end sm:size-9"
+                            isIconOnly
+                            variant="secondary"
+                            isDisabled={busy}
+                            onPress={() => {
+                              setDeleted((current) =>
+                                removed
+                                  ? current.filter((item) => item !== key)
+                                  : [...current, key],
+                              );
+                              setReplacements((current) => {
+                                const next = { ...current };
+                                delete next[key];
+                                return next;
+                              });
+                            }}
+                          >
+                            <HugeiconsIcon
+                              aria-hidden="true"
+                              icon={removed ? RestoreBinIcon : Delete02Icon}
+                              size={18}
+                            />
+                          </Button>
+                        ) : null}
+                      </div>
+                    );
+                  })}
+                  {newKeys.map((row, index) => (
+                    <div
+                      key={row.id}
+                      className="grid grid-cols-[repeat(8,minmax(0,1fr))_2.5rem] sm:grid-cols-[repeat(8,minmax(0,1fr))_2.25rem] items-center gap-2 md:gap-3"
+                    >
+                      <div className="col-span-4 min-w-0">
+                        <Input
+                          aria-label={`New variable ${index + 1} name`}
+                          autoComplete="off"
+                          fullWidth
+                          placeholder="VARIABLE_NAME"
+                          spellCheck={false}
+                          variant="secondary"
+                          disabled={busy}
+                          value={row.key}
+                          onChange={(event) => {
+                            const value = event.currentTarget.value;
+                            setNewKeys((current) =>
+                              current.map((item) =>
+                                item.id === row.id
+                                  ? { ...item, key: value }
+                                  : item,
+                              ),
+                            );
+                          }}
+                        />
+                      </div>
+                      <div className="col-span-4 min-w-0">
+                        <SecretValueInput
+                          label={`New variable ${index + 1} value`}
+                          value={row.value}
+                          disabled={busy}
+                          onChange={(value) =>
+                            setNewKeys((current) =>
+                              current.map((item) =>
+                                item.id === row.id ? { ...item, value } : item,
+                              ),
+                            )
+                          }
+                        />
+                      </div>
+                      <Button
+                        aria-label={`Remove new variable ${index + 1}`}
                         className="col-span-1 size-10 min-w-0 justify-self-end sm:size-9"
                         isIconOnly
                         variant="secondary"
                         isDisabled={busy}
-                        onPress={() => {
-                          setDeleted((current) =>
-                            removed
-                              ? current.filter((item) => item !== key)
-                              : [...current, key],
-                          );
-                          setReplacements((current) => {
-                            const next = { ...current };
-                            delete next[key];
-                            return next;
-                          });
-                        }}
+                        onPress={() =>
+                          setNewKeys((current) =>
+                            current.filter((item) => item.id !== row.id),
+                          )
+                        }
                       >
                         <HugeiconsIcon
                           aria-hidden="true"
-                          icon={removed ? RestoreBinIcon : Delete02Icon}
+                          icon={Delete02Icon}
                           size={18}
                         />
                       </Button>
-                    ) : null}
-                  </div>
-                );
-              })}
-              {newKeys.map((row, index) => (
-                <div
-                  key={row.id}
-                  className="grid grid-cols-[repeat(8,minmax(0,1fr))_2.5rem] sm:grid-cols-[repeat(8,minmax(0,1fr))_2.25rem] items-center gap-2 md:gap-3"
-                >
-                  <div className="col-span-4 min-w-0">
-                    <Input
-                      aria-label={`New variable ${index + 1} name`}
-                      autoComplete="off"
-                      fullWidth
-                      placeholder="VARIABLE_NAME"
-                      spellCheck={false}
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+              {error ? (
+                <FieldError>
+                  {error}{" "}
+                  <Button variant="ghost" onPress={onUpdated}>
+                    Refresh secrets
+                  </Button>
+                </FieldError>
+              ) : null}
+              {canManage &&
+              (fileMode || keys.length > 0 || newKeys.length > 0) ? (
+                <div className="flex flex-wrap gap-2">
+                  {!fileMode ? (
+                    <Button
                       variant="secondary"
-                      disabled={busy}
-                      value={row.key}
-                      onChange={(event) => {
-                        const value = event.currentTarget.value;
-                        setNewKeys((current) =>
-                          current.map((item) =>
-                            item.id === row.id ? { ...item, key: value } : item,
-                          ),
-                        );
-                      }}
-                    />
-                  </div>
-                  <div className="col-span-4 min-w-0">
-                    <SecretValueInput
-                      label={`New variable ${index + 1} value`}
-                      value={row.value}
-                      disabled={busy}
-                      onChange={(value) =>
-                        setNewKeys((current) =>
-                          current.map((item) =>
-                            item.id === row.id ? { ...item, value } : item,
-                          ),
-                        )
+                      isDisabled={busy || newKeys.length >= 200}
+                      onPress={() =>
+                        setNewKeys((current) => [
+                          ...current,
+                          { id: crypto.randomUUID(), key: "", value: "" },
+                        ])
                       }
-                    />
-                  </div>
-                  <Button
-                    aria-label={`Remove new variable ${index + 1}`}
-                    className="col-span-1 size-10 min-w-0 justify-self-end sm:size-9"
-                    isIconOnly
-                    variant="secondary"
-                    isDisabled={busy}
-                    onPress={() =>
-                      setNewKeys((current) =>
-                        current.filter((item) => item.id !== row.id),
-                      )
-                    }
-                  >
-                    <HugeiconsIcon
-                      aria-hidden="true"
-                      icon={Delete02Icon}
-                      size={18}
-                    />
+                    >
+                      Add variable
+                    </Button>
+                  ) : null}
+                  <Button type="submit" isDisabled={busy || !hasChanges}>
+                    {busy ? "Saving…" : "Save"}
                   </Button>
                 </div>
-              ))}
-            </div>
-          ) : null}
-          {error ? (
-            <FieldError>
-              {error}{" "}
-              <Button variant="ghost" onPress={onUpdated}>
-                Refresh secrets
-              </Button>
-            </FieldError>
-          ) : null}
-          {canManage && (keys.length > 0 || newKeys.length > 0) ? (
-            <div className="flex flex-wrap gap-2">
-              <Button
-                variant="secondary"
-                isDisabled={busy || newKeys.length >= 200}
-                onPress={() =>
-                  setNewKeys((current) => [
-                    ...current,
-                    { id: crypto.randomUUID(), key: "", value: "" },
-                  ])
-                }
-              >
-                Add variable
-              </Button>
-              <Button type="submit" isDisabled={busy || !hasChanges}>
-                {busy ? "Saving…" : "Save"}
-              </Button>
-            </div>
-          ) : null}
+              ) : null}
+            </Tabs.Panel>
+          </Tabs>
         </Widget.Content>
       </Widget>
     </form>

--- a/apps/towbar-web-app/src/components/app-secrets.tsx
+++ b/apps/towbar-web-app/src/components/app-secrets.tsx
@@ -375,6 +375,7 @@ function SecretVariablesEditor({
                     <Input
                       aria-label={`New variable ${index + 1} name`}
                       autoComplete="off"
+                      fullWidth
                       placeholder="VARIABLE_NAME"
                       spellCheck={false}
                       variant="secondary"
@@ -542,7 +543,7 @@ function SecretValueInput({
         data-1p-ignore
         spellCheck={false}
         placeholder={
-          configured ? (visible ? "" : "********") : "Value or reference"
+          configured ? (visible ? "" : "∗∗∗∗∗∗∗∗") : "Value or reference"
         }
         value={displayedValue}
         disabled={disabled || loading}

--- a/apps/towbar-web-app/src/components/app-secrets.tsx
+++ b/apps/towbar-web-app/src/components/app-secrets.tsx
@@ -14,6 +14,12 @@ import {
   Key01Icon,
   LockIcon,
   RestoreBinIcon,
+  ServerStack01Icon,
+  Rocket01Icon,
+  PackageIcon,
+  PlayIcon,
+  ArrowLeft01Icon,
+  ArrowRight01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type {
@@ -31,7 +37,8 @@ import { toast } from "@workspace/web-design-system/overlays/toast";
 import { QueryError, QueryLoading } from "@workspace/towbar-web-ui/query-state";
 import { useApiQuery } from "@/hooks/use-api-query";
 import { api } from "@/lib/api";
-import { ResponsiveSubtabs } from "./responsive-subtabs";
+import { Select, ListBox } from "@workspace/web-design-system/forms/select";
+import { Label } from "@workspace/web-design-system/forms/label";
 
 const SecretFileEditor = dynamic(() => import("./secret-file-editor"), {
   ssr: false,
@@ -46,38 +53,12 @@ export const stageLabels: Record<AppSecretStage, string> = {
 
 export function AppSecrets({ appId }: { appId: string }) {
   const active = useSearchParams().get("section") === "settings";
-  const [environment, setEnvironment] = useState<"production" | "preview">(
-    "production",
-  );
-  const endpoint = `/v1/core/apps/${appId}/secrets`;
-  const query = useApiQuery<AppSecretsResponse>(
-    active ? `${endpoint}?environment=${environment}` : null,
-  );
-  if (!active) return null;
   return (
-    <div className="max-w-5xl">
-      <ResponsiveSubtabs
-        ariaLabel="Secret environments"
-        defaultSelectedKey="production"
-        layout="inline"
-        selectedKey={environment}
-        onSelectionChange={(key) =>
-          setEnvironment(String(key) as "production" | "preview")
-        }
-        tabs={(["production", "preview"] as const).map((value) => ({
-          label: value === "production" ? "Production" : "Preview",
-          value,
-          content:
-            value === environment ? (
-              <EnvironmentEditors
-                key={environment}
-                endpoint={endpoint}
-                query={query}
-              />
-            ) : null,
-        }))}
-      />
-    </div>
+    <EnvironmentSecretSettings
+      active={active}
+      endpoint={`/v1/core/apps/${appId}/secrets`}
+      scope="app"
+    />
   );
 }
 
@@ -128,7 +109,7 @@ function EnvironmentSecretSettings({
 }: {
   active: boolean;
   endpoint: string;
-  scope: "global" | "source";
+  scope: "global" | "source" | "app";
 }) {
   const [environment, setEnvironment] = useState<"production" | "preview">(
     "production",
@@ -139,60 +120,147 @@ function EnvironmentSecretSettings({
   if (!active) return null;
   return (
     <div className={scope === "global" ? "w-full" : "max-w-5xl"}>
-      <ResponsiveSubtabs
-        ariaLabel="Secret environments"
-        defaultSelectedKey="production"
-        layout="inline"
-        selectedKey={environment}
-        onSelectionChange={(key) =>
-          setEnvironment(String(key) as "production" | "preview")
-        }
-        tabs={(["production", "preview"] as const).map((value) => ({
-          label: value === "production" ? "Production" : "Preview",
-          value,
-          content:
-            value === environment ? (
-              <EnvironmentEditors
-                key={environment}
-                endpoint={endpoint}
-                query={query}
-              />
-            ) : null,
-        }))}
+      <EnvironmentEditors
+        key={environment}
+        endpoint={endpoint}
+        query={query}
+        environment={environment}
+        onEnvironmentChange={setEnvironment}
       />
     </div>
   );
 }
 
+const stageIcons = {
+  build: PackageIcon,
+  deployment: PlayIcon,
+  pre_deploy: ArrowLeft01Icon,
+  post_deploy: ArrowRight01Icon,
+};
+const environmentOptions = [
+  { value: "production", label: "Production", icon: ServerStack01Icon },
+  { value: "preview", label: "Preview", icon: Rocket01Icon },
+];
+
+function SecretSelector({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: Array<{ value: string; label: string; icon: typeof PackageIcon }>;
+  onChange: (value: string) => void;
+}) {
+  const selected = options.find((option) => option.value === value);
+  return (
+    <Select
+      fullWidth
+      variant="secondary"
+      selectedKey={value}
+      onSelectionChange={(key) => {
+        if (key !== null) onChange(String(key));
+      }}
+    >
+      <Label className="sr-only">{label}</Label>
+      <Select.Trigger>
+        <Select.Value>
+          <span className="inline-flex min-w-0 items-center gap-2">
+            <HugeiconsIcon
+              aria-hidden="true"
+              icon={selected?.icon ?? PackageIcon}
+              className="size-4 shrink-0"
+            />
+            <span className="truncate">{selected?.label}</span>
+          </span>
+        </Select.Value>
+        <Select.Indicator />
+      </Select.Trigger>
+      <Select.Popover>
+        <ListBox>
+          {options.map((option) => (
+            <ListBox.Item
+              key={option.value}
+              id={option.value}
+              textValue={option.label}
+            >
+              <span className="inline-flex items-center gap-2">
+                <HugeiconsIcon
+                  aria-hidden="true"
+                  icon={option.icon}
+                  className="size-4 shrink-0"
+                />
+                {option.label}
+              </span>
+              <ListBox.ItemIndicator />
+            </ListBox.Item>
+          ))}
+        </ListBox>
+      </Select.Popover>
+    </Select>
+  );
+}
+
 function EnvironmentEditors({
   query,
-  ...props
+  endpoint,
+  environment,
+  onEnvironmentChange,
 }: {
   query: Query;
   endpoint: string;
+  environment?: "production" | "preview";
+  onEnvironmentChange?: (value: "production" | "preview") => void;
 }) {
-  if (query.error) return <QueryError message={query.error} />;
-  if (!query.data) return <QueryLoading />;
+  const [stage, setStage] = useState<AppSecretStage>("build");
   const data = query.data;
+  const binding =
+    data?.bindings.find((item) => item.stage === stage) ?? data?.bindings[0];
   return (
-    <ResponsiveSubtabs
-      ariaLabel="Secret stages"
-      defaultSelectedKey={data.bindings[0]?.stage ?? "build"}
-      layout="inline"
-      tabs={data.bindings.map((binding) => ({
-        label: stageLabels[binding.stage],
-        value: binding.stage,
-        content: (
-          <SecretVariablesEditor
-            key={`${props.endpoint}:${binding.environment}:${binding.stage}:${binding.revision}:${binding.inheritedRevisions.global}:${binding.inheritedRevisions.source}`}
-            {...props}
-            binding={binding}
-            canManage={data.canManageSecrets}
-            onUpdated={query.refresh}
+    <div className="grid min-w-0 gap-4">
+      <div
+        className={
+          environment ? "grid min-w-0 grid-cols-2 gap-3" : "grid min-w-0"
+        }
+      >
+        {environment && onEnvironmentChange ? (
+          <SecretSelector
+            label="Secret environment"
+            value={environment}
+            options={environmentOptions}
+            onChange={(value) =>
+              onEnvironmentChange(value as "production" | "preview")
+            }
           />
-        ),
-      }))}
-    />
+        ) : null}
+        {binding && data ? (
+          <SecretSelector
+            label="Secret stage"
+            value={binding.stage}
+            options={data.bindings.map((item) => ({
+              value: item.stage,
+              label: stageLabels[item.stage],
+              icon: stageIcons[item.stage],
+            }))}
+            onChange={(value) => setStage(value as AppSecretStage)}
+          />
+        ) : null}
+      </div>
+      {query.error ? (
+        <QueryError message={query.error} />
+      ) : !data ? (
+        <QueryLoading />
+      ) : binding ? (
+        <SecretVariablesEditor
+          key={`${endpoint}:${binding.environment}:${binding.stage}:${binding.revision}:${binding.inheritedRevisions.global}:${binding.inheritedRevisions.source}`}
+          endpoint={endpoint}
+          binding={binding}
+          canManage={data.canManageSecrets}
+          onUpdated={query.refresh}
+        />
+      ) : null}
+    </div>
   );
 }
 
@@ -383,7 +451,7 @@ function SecretVariablesEditor({
           >
             <Tabs.ListContainer className="mb-4 w-fit">
               <Tabs.List aria-label="Secret editing mode">
-                <Tabs.Tab id="form" isDisabled={busy}>
+                <Tabs.Tab id="form" className="gap-2" isDisabled={busy}>
                   <HugeiconsIcon
                     aria-hidden="true"
                     icon={Menu01Icon}
@@ -392,7 +460,11 @@ function SecretVariablesEditor({
                   Form
                   <Tabs.Indicator />
                 </Tabs.Tab>
-                <Tabs.Tab id="file" isDisabled={busy || !canManage}>
+                <Tabs.Tab
+                  id="file"
+                  className="gap-2"
+                  isDisabled={busy || !canManage}
+                >
                   <HugeiconsIcon
                     aria-hidden="true"
                     icon={SourceCodeIcon}

--- a/apps/towbar-web-app/src/components/secret-file-editor.tsx
+++ b/apps/towbar-web-app/src/components/secret-file-editor.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Compartment, EditorState } from "@codemirror/state";
+import {
+  Decoration,
+  MatchDecorator,
+  ViewPlugin,
+  EditorView,
+  keymap,
+  lineNumbers,
+  drawSelection,
+  highlightActiveLine,
+} from "@codemirror/view";
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+
+const tokens = new MatchDecorator({
+  regexp:
+    /(?:^\s*(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*(?=\s*=))|(?:\{\{\s*(?:globals|source)\.[A-Za-z_][A-Za-z0-9_]*\s*\}\})/g,
+  decoration: (match) =>
+    Decoration.mark({
+      class: match[0].includes("{{")
+        ? "text-yellow-600 dark:text-yellow-400"
+        : "text-accent",
+    }),
+});
+const highlighting = ViewPlugin.fromClass(
+  class {
+    decorations;
+    constructor(view: EditorView) {
+      this.decorations = tokens.createDeco(view);
+    }
+    update(update: import("@codemirror/view").ViewUpdate) {
+      this.decorations = tokens.updateDeco(update, this.decorations);
+    }
+  },
+  { decorations: (plugin) => plugin.decorations },
+);
+
+export default function SecretFileEditor({
+  value,
+  disabled,
+  onChange,
+}: {
+  value: string;
+  disabled: boolean;
+  onChange: (value: string) => void;
+}) {
+  const host = useRef<HTMLDivElement>(null);
+  const editor = useRef<EditorView>(null);
+  const editable = useRef(new Compartment());
+  const change = useRef(onChange);
+  change.current = onChange;
+  useEffect(() => {
+    const view = new EditorView({
+      parent: host.current!,
+      state: EditorState.create({
+        doc: value,
+        extensions: [
+          lineNumbers(),
+          highlighting,
+          drawSelection(),
+          highlightActiveLine(),
+          history(),
+          keymap.of([...defaultKeymap, ...historyKeymap]),
+          editable.current.of(EditorState.readOnly.of(disabled)),
+          EditorView.contentAttributes.of({
+            "aria-label": "Secrets .env file",
+            autocapitalize: "off",
+            spellcheck: "false",
+            "data-lpignore": "true",
+            "data-1p-ignore": "true",
+          }),
+          EditorView.updateListener.of((update) => {
+            if (update.docChanged) change.current(update.state.doc.toString());
+          }),
+          EditorView.theme({
+            "&": {
+              color: "var(--foreground)",
+              backgroundColor: "var(--surface-secondary)",
+              borderRadius: "var(--radius-lg)",
+              overflow: "hidden",
+            },
+            "&.cm-focused": {
+              outline: "2px solid var(--focus)",
+              outlineOffset: "2px",
+            },
+            ".cm-scroller": {
+              fontFamily: "var(--font-mono, monospace)",
+              fontSize: "16px",
+              lineHeight: "1.6",
+              overflow: "auto",
+              minHeight: "240px",
+              maxHeight: "480px",
+            },
+            ".cm-content": {
+              padding: "12px 0",
+              caretColor: "var(--foreground)",
+            },
+            ".cm-line": { padding: "0 12px" },
+            ".cm-gutters": {
+              backgroundColor: "var(--surface-secondary)",
+              color: "var(--muted)",
+              border: "none",
+            },
+            ".cm-activeLine": { backgroundColor: "var(--surface-tertiary)" },
+            ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
+              backgroundColor: "var(--accent-soft)",
+            },
+            ".cm-cursor": { borderLeftColor: "var(--foreground)" },
+          }),
+        ],
+      }),
+    });
+    editor.current = view;
+    return () => {
+      view.destroy();
+      editor.current = null;
+    };
+    // The document is owned by this editor until file mode is closed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  useEffect(() => {
+    editor.current?.dispatch({
+      effects: editable.current.reconfigure(EditorState.readOnly.of(disabled)),
+    });
+  }, [disabled]);
+  return <div ref={host} className="min-w-0" />;
+}

--- a/apps/towbar-web-app/src/lib/secret-env.test.ts
+++ b/apps/towbar-web-app/src/lib/secret-env.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseSecretEnv, serializeSecretEnv } from "./secret-env";
+
+test("round trips values without interpolation or lost whitespace", () => {
+  const values: Array<[string, string]> = [
+    ["TOKEN", ' a#b=c\\d"e\nnext\t '],
+    ["REF", "{{source.TOKEN}}"],
+    ["EMPTY", ""],
+    ["STARS", "********"],
+  ];
+  assert.deepEqual([...parseSecretEnv(serializeSecretEnv(values))], values);
+});
+test("treats empty and starred values literally", () => {
+  const result = parseSecretEnv('CLEAR=""\nSTARS="********"');
+  assert.equal(result.get("CLEAR"), "");
+  assert.equal(result.get("STARS"), "********");
+});
+test("supports comments, export, CRLF, equals and multiline quotes", () => {
+  const result = parseSecretEnv(
+    "# comment\r\nexport URL=https://example.test/?a=b\r\nMULTI=\"first\nsecond\" # comment\nRAW=one # ignored\nSINGLE='a#b'",
+  );
+  assert.equal(result.get("URL"), "https://example.test/?a=b");
+  assert.equal(result.get("MULTI"), "first\nsecond");
+  assert.equal(result.get("RAW"), "one");
+  assert.equal(result.get("SINGLE"), "a#b");
+});
+test("rejects duplicates, malformed lines, unclosed quotes and excess variables", () => {
+  for (const text of [
+    "A=1\nA=2",
+    "BAD-KEY=1",
+    "oops",
+    'A="unclosed',
+    'A="x" trailing',
+    Array.from({ length: 201 }, (_, i) => `K${i}=x`).join("\n"),
+  ])
+    assert.throws(() => parseSecretEnv(text), /Line /);
+});
+test("does not expand references or treat prototype names specially", () => {
+  assert.equal(
+    parseSecretEnv("__proto__={{globals.TOKEN}}").get("__proto__"),
+    "{{globals.TOKEN}}",
+  );
+});

--- a/apps/towbar-web-app/src/lib/secret-env.ts
+++ b/apps/towbar-web-app/src/lib/secret-env.ts
@@ -1,0 +1,56 @@
+export function serializeSecretEnv(entries: Array<[string, string]>) {
+  return entries
+    .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
+    .join("\n");
+}
+
+export function parseSecretEnv(text: string) {
+  const values = new Map<string, string>();
+  const lines = text.replace(/\r\n?/g, "\n").split("\n");
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index]!.trim();
+    if (!line || line.startsWith("#")) continue;
+    const match = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/.exec(
+      line,
+    );
+    const fail = (message: string): never => {
+      throw new Error(`Line ${index + 1}: ${message}`);
+    };
+    if (!match) fail("Use KEY=value.");
+    const [, key, raw] = match!;
+    if (values.has(key!)) fail(`Duplicate variable ${key}.`);
+    if (values.size >= 200) fail("Use at most 200 variables.");
+    let value = raw!;
+    const quote = value[0];
+    if (quote === '"' || quote === "'" || quote === "`") {
+      let end = -1;
+      for (let cursor = 1; ; cursor++) {
+        if (cursor >= value.length) {
+          if (++index >= lines.length) fail("Close the quoted value.");
+          value += "\n" + lines[index];
+        }
+        if (value[cursor] === "\\" && quote === '"') {
+          cursor++;
+          continue;
+        }
+        if (value[cursor] === quote) {
+          end = cursor;
+          break;
+        }
+      }
+      const tail = value.slice(end + 1).trim();
+      if (tail && !tail.startsWith("#"))
+        fail("Unexpected text after quoted value.");
+      value = value.slice(1, end);
+      if (quote === '"')
+        value = value.replace(
+          /\\(u[0-9a-fA-F]{4}|[\\"nrtbf])/g,
+          (_, escaped: string) => JSON.parse('"\\' + escaped + '"') as string,
+        );
+    } else {
+      value = value.split("#")[0]!.trim();
+    }
+    values.set(key!, value);
+  }
+  return values;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,15 @@ importers:
 
   apps/towbar-web-app:
     dependencies:
+      "@codemirror/commands":
+        specifier: ^6.11.0
+        version: 6.11.0
+      "@codemirror/state":
+        specifier: ^6.7.4
+        version: 6.7.4
+      "@codemirror/view":
+        specifier: ^6.43.11
+        version: 6.43.11
       "@hugeicons/core-free-icons":
         specifier: "catalog:"
         version: 4.3.0
@@ -254,9 +263,6 @@ importers:
         specifier: "catalog:"
         version: 19.2.8(react@19.2.8)
     devDependencies:
-      "@workspace/towbar-core":
-        specifier: workspace:*
-        version: link:../../packages/towbar-core
       "@types/node":
         specifier: "catalog:"
         version: 26.4.1
@@ -269,6 +275,9 @@ importers:
       "@workspace/eslint-config":
         specifier: workspace:^
         version: link:../../packages/eslint-config
+      "@workspace/towbar-core":
+        specifier: workspace:*
+        version: link:../../packages/towbar-core
       "@workspace/typescript-config":
         specifier: workspace:*
         version: link:../../packages/typescript-config
@@ -963,6 +972,30 @@ packages:
         integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==,
       }
     engines: { node: ">=6.9.0" }
+
+  "@codemirror/commands@6.11.0":
+    resolution:
+      {
+        integrity: sha512-/K4Rl5BN0OtTiPWmJCdqODu38XnDMsDxKY5rgrPnCkutPTJf2wVbkoixLfealF5Kwse/s8P8M5jAiURiwSwnFA==,
+      }
+
+  "@codemirror/language@6.12.4":
+    resolution:
+      {
+        integrity: sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==,
+      }
+
+  "@codemirror/state@6.7.4":
+    resolution:
+      {
+        integrity: sha512-QhQIVRY+xHZDxwOSFrJ1eUMapJBUID3IdeAjf7dHO7zBUzSkyooHiodnalz5MG3iHzwixKMlAAyn7244y537EA==,
+      }
+
+  "@codemirror/view@6.43.11":
+    resolution:
+      {
+        integrity: sha512-2+esucbQX6wB2JYi1eDvdCPFTA31BN8oSy6xCmk3G6CloV11yOvEjYk+gH7kLrP0MuHG94E8WDhjs5oMiu3+Wg==,
+      }
 
   "@drizzle-team/brocli@0.10.2":
     resolution:
@@ -2246,6 +2279,30 @@ packages:
     engines: { node: ">=10.0" }
     peerDependencies:
       tslib: "2"
+
+  "@lezer/common@1.5.2":
+    resolution:
+      {
+        integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==,
+      }
+
+  "@lezer/highlight@1.2.3":
+    resolution:
+      {
+        integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==,
+      }
+
+  "@lezer/lr@1.4.10":
+    resolution:
+      {
+        integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==,
+      }
+
+  "@marijn/find-cluster-break@1.0.4":
+    resolution:
+      {
+        integrity: sha512-Wy0V7+SGUjnF9/TkiM1hKVDPj7jKXduPNboMVtHTA8dySMURWqfg/JZ9E2Sq8JgSJmkl7k7Qe9FLeMSrSraWmQ==,
+      }
 
   "@modelcontextprotocol/sdk@1.30.0":
     resolution:
@@ -4369,6 +4426,12 @@ packages:
         integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==,
       }
     engines: { node: ">= 0.10" }
+
+  crelt@1.0.7:
+    resolution:
+      {
+        integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==,
+      }
 
   croner@10.0.1:
     resolution:
@@ -7012,6 +7075,12 @@ packages:
       }
     engines: { node: ">=8" }
 
+  style-mod@4.1.3:
+    resolution:
+      {
+        integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==,
+      }
+
   styled-jsx@5.1.6:
     resolution:
       {
@@ -7335,6 +7404,12 @@ packages:
     resolution:
       {
         integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==,
+      }
+
+  w3c-keyname@2.2.8:
+    resolution:
+      {
+        integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==,
       }
 
   watchpack@2.5.2:
@@ -7796,6 +7871,33 @@ snapshots:
     dependencies:
       "@babel/helper-string-parser": 7.29.7
       "@babel/helper-validator-identifier": 7.29.7
+
+  "@codemirror/commands@6.11.0":
+    dependencies:
+      "@codemirror/language": 6.12.4
+      "@codemirror/state": 6.7.4
+      "@codemirror/view": 6.43.11
+      "@lezer/common": 1.5.2
+
+  "@codemirror/language@6.12.4":
+    dependencies:
+      "@codemirror/state": 6.7.4
+      "@codemirror/view": 6.43.11
+      "@lezer/common": 1.5.2
+      "@lezer/highlight": 1.2.3
+      "@lezer/lr": 1.4.10
+      style-mod: 4.1.3
+
+  "@codemirror/state@6.7.4":
+    dependencies:
+      "@marijn/find-cluster-break": 1.0.4
+
+  "@codemirror/view@6.43.11":
+    dependencies:
+      "@codemirror/state": 6.7.4
+      crelt: 1.0.7
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
 
   "@drizzle-team/brocli@0.10.2": {}
 
@@ -8426,6 +8528,18 @@ snapshots:
       "@jsonjoy.com/codegen": 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
+  "@lezer/common@1.5.2": {}
+
+  "@lezer/highlight@1.2.3":
+    dependencies:
+      "@lezer/common": 1.5.2
+
+  "@lezer/lr@1.4.10":
+    dependencies:
+      "@lezer/common": 1.5.2
+
+  "@marijn/find-cluster-break@1.0.4": {}
+
   "@modelcontextprotocol/sdk@1.30.0(zod@4.5.4)":
     dependencies:
       "@hono/node-server": 2.1.1(hono@4.13.3)
@@ -8625,6 +8739,11 @@ snapshots:
       react: 19.2.8
       react-aria: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom: 19.2.8(react@19.2.8)
+    dependencies:
+      "@swc/helpers": 0.5.23
+      react: 19.2.8
+      react-aria: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
 
   "@react-aria/i18n@3.13.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:
@@ -8635,12 +8754,25 @@ snapshots:
       react: 19.2.8
       react-aria: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom: 19.2.8(react@19.2.8)
+    dependencies:
+      "@internationalized/date": 3.12.4
+      "@internationalized/message": 3.1.10
+      "@internationalized/string": 3.2.10
+      "@swc/helpers": 0.5.23
+      react: 19.2.8
+      react-aria: 3.52.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
 
   "@react-aria/ssr@3.10.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:
       "@swc/helpers": 0.5.23
       react: 19.2.8
       react-aria: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
+    dependencies:
+      "@swc/helpers": 0.5.23
+      react: 19.2.8
+      react-aria: 3.52.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom: 19.2.8(react@19.2.8)
 
   "@react-aria/utils@3.34.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
@@ -8650,6 +8782,12 @@ snapshots:
       react-aria: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom: 19.2.8(react@19.2.8)
       react-stately: 3.49.0(react@19.2.8)
+    dependencies:
+      "@swc/helpers": 0.5.23
+      react: 19.2.8
+      react-aria: 3.52.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
+      react-stately: 3.50.0(react@19.2.8)
 
   "@react-spectrum/color@3.2.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:
@@ -9758,6 +9896,8 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  crelt@1.0.7: {}
 
   croner@10.0.1: {}
 
@@ -11538,6 +11678,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  style-mod@4.1.3: {}
+
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.8):
     dependencies:
       client-only: 0.0.1
@@ -11745,6 +11887,8 @@ snapshots:
       d3-shape: 3.2.0
       d3-time: 3.1.0
       d3-timer: 3.0.1
+
+  w3c-keyname@2.2.8: {}
 
   watchpack@2.5.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8739,11 +8739,6 @@ snapshots:
       react: 19.2.8
       react-aria: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom: 19.2.8(react@19.2.8)
-    dependencies:
-      "@swc/helpers": 0.5.23
-      react: 19.2.8
-      react-aria: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react-dom: 19.2.8(react@19.2.8)
 
   "@react-aria/i18n@3.13.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:
@@ -8754,25 +8749,12 @@ snapshots:
       react: 19.2.8
       react-aria: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom: 19.2.8(react@19.2.8)
-    dependencies:
-      "@internationalized/date": 3.12.4
-      "@internationalized/message": 3.1.10
-      "@internationalized/string": 3.2.10
-      "@swc/helpers": 0.5.23
-      react: 19.2.8
-      react-aria: 3.52.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react-dom: 19.2.8(react@19.2.8)
 
   "@react-aria/ssr@3.10.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:
       "@swc/helpers": 0.5.23
       react: 19.2.8
       react-aria: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react-dom: 19.2.8(react@19.2.8)
-    dependencies:
-      "@swc/helpers": 0.5.23
-      react: 19.2.8
-      react-aria: 3.52.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom: 19.2.8(react@19.2.8)
 
   "@react-aria/utils@3.34.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
@@ -8782,12 +8764,6 @@ snapshots:
       react-aria: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom: 19.2.8(react@19.2.8)
       react-stately: 3.49.0(react@19.2.8)
-    dependencies:
-      "@swc/helpers": 0.5.23
-      react: 19.2.8
-      react-aria: 3.52.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react-dom: 19.2.8(react@19.2.8)
-      react-stately: 3.50.0(react@19.2.8)
 
   "@react-spectrum/color@3.2.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:


### PR DESCRIPTION
Secrets now offer Form and File tabs inside each stage widget. File mode loads stored values through the existing reveal endpoint and opens an editable .env document. Form inputs fill their key columns and use centered asterisk placeholders.

The lazy-loaded CodeMirror editor uses Towbar surface and text tokens, line numbers, undo/redo, and highlighted keys and references. The parser supports comments, export, quoted and multiline values, and validates unique names and the 200-variable limit. Switching modes preserves edits; saving uses the existing revision-protected patch endpoint. Values fetched without edits are omitted from the patch, and removing a line deletes its key. Reveal failures or changed revisions keep the current form intact.

Environment and stage selectors use icon tabs on tablet and desktop, with equal-width dropdowns on mobile. App settings options also include icons.

Validation: web app typecheck, focused ESLint, five parser tests, and diff checks pass. Local browser checks covered file/form round trips, saving and deleting a fixture value, and fetching the saved value when File is selected. The temporary fixture value was removed afterward.
