### PR TITLE
Add action icons and reuse the editor for manifests

### DIFF
--- a/apps/towbar-web-app/package.json
+++ b/apps/towbar-web-app/package.json
@@ -21,10 +21,13 @@
   },
   "dependencies": {
     "@codemirror/commands": "^6.11.0",
+    "@codemirror/lang-yaml": "^6.1.3",
+    "@codemirror/language": "^6.12.4",
     "@codemirror/state": "^6.7.4",
     "@codemirror/view": "^6.43.11",
     "@hugeicons/core-free-icons": "catalog:",
     "@hugeicons/react": "catalog:",
+    "@lezer/highlight": "^1.2.3",
     "@workspace/identity-web-ui": "workspace:*",
     "@workspace/towbar-web-client": "workspace:*",
     "@workspace/towbar-web-ui": "workspace:*",

--- a/apps/towbar-web-app/src/components/api-mcp-settings.tsx
+++ b/apps/towbar-web-app/src/components/api-mcp-settings.tsx
@@ -1,4 +1,12 @@
 "use client";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  BookOpen01Icon,
+  Key01Icon,
+  Tick02Icon,
+  Add01Icon,
+  Cancel01Icon,
+} from "@hugeicons/core-free-icons";
 import { useId, useState, type FormEvent, type ReactNode } from "react";
 import {
   Button,
@@ -180,6 +188,11 @@ export function ApiMcpSettings() {
             variant="danger"
             success="Key revoked"
           >
+            <HugeiconsIcon
+              aria-hidden="true"
+              icon={Cancel01Icon}
+              className="size-4 shrink-0"
+            />
             Revoke
           </ActionButton>
         ) : null,
@@ -206,6 +219,11 @@ export function ApiMcpSettings() {
                   emptyDescription="Create a key for your scripts or MCP client. The secret is only shown once."
                 />
                 <Button className="w-fit" onPress={() => setCreating(true)}>
+                  <HugeiconsIcon
+                    aria-hidden="true"
+                    icon={Add01Icon}
+                    className="size-4 shrink-0"
+                  />
                   Create API key
                 </Button>
               </div>
@@ -230,7 +248,12 @@ export function ApiMcpSettings() {
                   variant="secondary"
                   className="w-fit"
                 >
-                  API documentation and route reference →
+                  <HugeiconsIcon
+                    aria-hidden="true"
+                    icon={BookOpen01Icon}
+                    className="size-4 shrink-0"
+                  />
+                  API documentation and route reference
                 </ButtonLink>
               </div>
             ),
@@ -279,7 +302,14 @@ export function ApiMcpSettings() {
                 {revealed ? (
                   <SetupCode title="Your new key" code={revealed} />
                 ) : null}
-                <Button onPress={() => setRevealed(null)}>Done</Button>
+                <Button onPress={() => setRevealed(null)}>
+                  <HugeiconsIcon
+                    aria-hidden="true"
+                    icon={Tick02Icon}
+                    className="size-4 shrink-0"
+                  />
+                  Done
+                </Button>
               </Modal.Body>
             </Modal.Dialog>
           </Modal.Container>
@@ -364,6 +394,11 @@ function CreateKey({ onCreated }: { onCreated: (token: string) => void }) {
         ]}
       />
       <Button type="submit" isDisabled={busy}>
+        <HugeiconsIcon
+          aria-hidden="true"
+          icon={Key01Icon}
+          className="size-4 shrink-0"
+        />
         {busy ? "Creating…" : "Create key"}
       </Button>
     </form>
@@ -470,7 +505,12 @@ function McpSetup({ url }: { url: string }) {
           variant="secondary"
           className="w-fit"
         >
-          MCP setup and troubleshooting →
+          <HugeiconsIcon
+            aria-hidden="true"
+            icon={BookOpen01Icon}
+            className="size-4 shrink-0"
+          />
+          MCP setup and troubleshooting
         </ButtonLink>
       </div>
     </FormCard>

--- a/apps/towbar-web-app/src/components/app-detail.tsx
+++ b/apps/towbar-web-app/src/components/app-detail.tsx
@@ -136,6 +136,11 @@ export function AppDetail() {
               success="Deployment queued"
               variant="primary"
             >
+              <HugeiconsIcon
+                aria-hidden="true"
+                icon={Rocket01Icon}
+                className="size-4 shrink-0"
+              />
               Deploy
             </ActionButton>
           </div>

--- a/apps/towbar-web-app/src/components/app-secrets.tsx
+++ b/apps/towbar-web-app/src/components/app-secrets.tsx
@@ -1,26 +1,30 @@
 "use client";
+import {
+  Add01Icon,
+  ArrowLeft01Icon,
+  ArrowRight01Icon,
+  Delete02Icon,
+  FloppyDiskIcon,
+  Key01Icon,
+  LockIcon,
+  Menu01Icon,
+  PackageIcon,
+  PlayIcon,
+  ReloadIcon,
+  RestoreBinIcon,
+  Rocket01Icon,
+  ServerStack01Icon,
+  SourceCodeIcon,
+  ViewIcon,
+  ViewOffSlashIcon,
+} from "@hugeicons/core-free-icons";
 
 import dynamic from "next/dynamic";
 import { Tabs } from "@workspace/web-design-system/navigation/tabs";
 import { parseSecretEnv, serializeSecretEnv } from "@/lib/secret-env";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState, type FormEvent } from "react";
-import {
-  Delete02Icon,
-  SourceCodeIcon,
-  Menu01Icon,
-  ViewIcon,
-  ViewOffSlashIcon,
-  Key01Icon,
-  LockIcon,
-  RestoreBinIcon,
-  ServerStack01Icon,
-  Rocket01Icon,
-  PackageIcon,
-  PlayIcon,
-  ArrowLeft01Icon,
-  ArrowRight01Icon,
-} from "@hugeicons/core-free-icons";
+
 import { HugeiconsIcon } from "@hugeicons/react";
 import type {
   AppSecretBinding,
@@ -536,6 +540,11 @@ function SecretVariablesEditor({
                           ])
                         }
                       >
+                        <HugeiconsIcon
+                          aria-hidden="true"
+                          icon={Add01Icon}
+                          className="size-4 shrink-0"
+                        />
                         Add variable
                       </Button>
                     </EmptyState.Content>
@@ -687,6 +696,11 @@ function SecretVariablesEditor({
                 <FieldError>
                   {error}{" "}
                   <Button variant="ghost" onPress={onUpdated}>
+                    <HugeiconsIcon
+                      aria-hidden="true"
+                      icon={ReloadIcon}
+                      className="size-4 shrink-0"
+                    />
                     Refresh secrets
                   </Button>
                 </FieldError>
@@ -705,10 +719,20 @@ function SecretVariablesEditor({
                         ])
                       }
                     >
+                      <HugeiconsIcon
+                        aria-hidden="true"
+                        icon={Add01Icon}
+                        className="size-4 shrink-0"
+                      />
                       Add variable
                     </Button>
                   ) : null}
                   <Button type="submit" isDisabled={busy || !hasChanges}>
+                    <HugeiconsIcon
+                      aria-hidden="true"
+                      icon={FloppyDiskIcon}
+                      className="size-4 shrink-0"
+                    />
                     {busy ? "Saving…" : "Save"}
                   </Button>
                 </div>

--- a/apps/towbar-web-app/src/components/app-secrets.tsx
+++ b/apps/towbar-web-app/src/components/app-secrets.tsx
@@ -44,7 +44,7 @@ import { api } from "@/lib/api";
 import { Select, ListBox } from "@workspace/web-design-system/forms/select";
 import { Label } from "@workspace/web-design-system/forms/label";
 
-const SecretFileEditor = dynamic(() => import("./secret-file-editor"), {
+const CodeEditor = dynamic(() => import("./code-editor"), {
   ssr: false,
 });
 
@@ -514,7 +514,7 @@ function SecretVariablesEditor({
             >
               {fileMode ? (
                 <div className="grid min-w-0 gap-3">
-                  <SecretFileEditor
+                  <CodeEditor
                     value={fileText}
                     onChange={setFileText}
                     disabled={busy}

--- a/apps/towbar-web-app/src/components/auto-deploy-control.tsx
+++ b/apps/towbar-web-app/src/components/auto-deploy-control.tsx
@@ -1,8 +1,7 @@
 "use client";
+import { FloppyDiskIcon, Rocket01Icon } from "@hugeicons/core-free-icons";
 
 import { HugeiconsIcon } from "@hugeicons/react";
-
-import { Rocket01Icon } from "@hugeicons/core-free-icons";
 
 import { useEffect, useState } from "react";
 import type { FormEvent } from "react";
@@ -107,6 +106,11 @@ export function AutoDeployControlEditor({
             }
             type="submit"
           >
+            <HugeiconsIcon
+              aria-hidden="true"
+              icon={FloppyDiskIcon}
+              className="size-4 shrink-0"
+            />
             {saving ? "Saving…" : "Save"}
           </Button>
         </Widget.Content>

--- a/apps/towbar-web-app/src/components/aws-integration.tsx
+++ b/apps/towbar-web-app/src/components/aws-integration.tsx
@@ -1,8 +1,12 @@
 "use client";
+import {
+  Add01Icon,
+  Delete02Icon,
+  Edit02Icon,
+  Key01Icon,
+} from "@hugeicons/core-free-icons";
 
 import { HugeiconsIcon } from "@hugeicons/react";
-
-import { Key01Icon } from "@hugeicons/core-free-icons";
 
 import { useState } from "react";
 import type { AwsCredentialMetadata } from "@workspace/towbar-web-client";
@@ -61,6 +65,11 @@ export function AwsIntegration() {
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex flex-wrap gap-3">
                 <Button onPress={() => setEditorOpen(true)}>
+                  <HugeiconsIcon
+                    aria-hidden="true"
+                    icon={Edit02Icon}
+                    className="size-4 shrink-0"
+                  />
                   Update credentials
                 </Button>
               </div>
@@ -77,6 +86,11 @@ export function AwsIntegration() {
                   success="S3 backup credentials deleted"
                   variant="danger"
                 >
+                  <HugeiconsIcon
+                    aria-hidden="true"
+                    icon={Delete02Icon}
+                    className="size-4 shrink-0"
+                  />
                   Delete credentials
                 </ActionButton>
               </div>
@@ -97,6 +111,11 @@ export function AwsIntegration() {
           {canManage ? (
             <EmptyState.Content>
               <Button onPress={() => setEditorOpen(true)}>
+                <HugeiconsIcon
+                  aria-hidden="true"
+                  icon={Add01Icon}
+                  className="size-4 shrink-0"
+                />
                 Add credentials
               </Button>
             </EmptyState.Content>

--- a/apps/towbar-web-app/src/components/code-editor.tsx
+++ b/apps/towbar-web-app/src/components/code-editor.tsx
@@ -107,7 +107,7 @@ export default function CodeEditor({
               overflow: "hidden",
             },
             "&.cm-focused": {
-              outline: "2px solid var(--focus)",
+              outline: embedded ? "none" : "2px solid var(--focus)",
               outlineOffset: "2px",
             },
             ".cm-scroller": {
@@ -119,7 +119,7 @@ export default function CodeEditor({
               maxHeight: "480px",
             },
             ".cm-content": {
-              padding: "12px 0",
+              padding: embedded ? "0" : "12px 0",
               caretColor: "var(--foreground)",
             },
             ".cm-line": { padding: "0 12px" },

--- a/apps/towbar-web-app/src/components/code-editor.tsx
+++ b/apps/towbar-web-app/src/components/code-editor.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { yaml } from "@codemirror/lang-yaml";
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { tags } from "@lezer/highlight";
 import { Compartment, EditorState } from "@codemirror/state";
 import {
   Decoration,
@@ -37,14 +40,32 @@ const highlighting = ViewPlugin.fromClass(
   { decorations: (plugin) => plugin.decorations },
 );
 
-export default function SecretFileEditor({
+const yamlHighlighting = syntaxHighlighting(
+  HighlightStyle.define([
+    {
+      tag: [tags.propertyName, tags.definition(tags.propertyName)],
+      color: "var(--accent)",
+    },
+    { tag: tags.string, color: "var(--success)" },
+    { tag: [tags.number, tags.bool, tags.null], color: "var(--warning)" },
+    { tag: tags.comment, color: "var(--muted)" },
+  ]),
+);
+
+export default function CodeEditor({
   value,
-  disabled,
+  disabled = false,
+  embedded = false,
+  language = "env",
+  ariaLabel = "Secrets .env file",
   onChange,
 }: {
   value: string;
-  disabled: boolean;
-  onChange: (value: string) => void;
+  disabled?: boolean;
+  embedded?: boolean;
+  language?: "env" | "yaml";
+  ariaLabel?: string;
+  onChange?: (value: string) => void;
 }) {
   const host = useRef<HTMLDivElement>(null);
   const editor = useRef<EditorView>(null);
@@ -58,26 +79,30 @@ export default function SecretFileEditor({
         doc: value,
         extensions: [
           lineNumbers(),
-          highlighting,
+          language === "yaml" ? [yaml(), yamlHighlighting] : highlighting,
           drawSelection(),
-          highlightActiveLine(),
+          disabled ? [] : highlightActiveLine(),
           history(),
           keymap.of([...defaultKeymap, ...historyKeymap]),
           editable.current.of(EditorState.readOnly.of(disabled)),
-          EditorView.contentAttributes.of({
-            "aria-label": "Secrets .env file",
+          EditorView.contentAttributes.of((view) => ({
+            "aria-label": ariaLabel,
+            "aria-readonly": String(view.state.readOnly),
             autocapitalize: "off",
             spellcheck: "false",
             "data-lpignore": "true",
             "data-1p-ignore": "true",
-          }),
+          })),
           EditorView.updateListener.of((update) => {
-            if (update.docChanged) change.current(update.state.doc.toString());
+            if (update.docChanged)
+              change.current?.(update.state.doc.toString());
           }),
           EditorView.theme({
             "&": {
               color: "var(--foreground)",
-              backgroundColor: "var(--surface-secondary)",
+              backgroundColor: embedded
+                ? "transparent"
+                : "var(--surface-secondary)",
               borderRadius: "var(--radius-lg)",
               overflow: "hidden",
             },
@@ -99,7 +124,9 @@ export default function SecretFileEditor({
             },
             ".cm-line": { padding: "0 12px" },
             ".cm-gutters": {
-              backgroundColor: "var(--surface-secondary)",
+              backgroundColor: embedded
+                ? "transparent"
+                : "var(--surface-secondary)",
               color: "var(--muted)",
               border: "none",
             },
@@ -117,7 +144,7 @@ export default function SecretFileEditor({
       view.destroy();
       editor.current = null;
     };
-    // The document is owned by this editor until file mode is closed.
+    // Language and label are fixed for the lifetime of an editor instance.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   useEffect(() => {
@@ -125,5 +152,13 @@ export default function SecretFileEditor({
       effects: editable.current.reconfigure(EditorState.readOnly.of(disabled)),
     });
   }, [disabled]);
+  useEffect(() => {
+    const view = editor.current;
+    if (view && value !== view.state.doc.toString()) {
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: value },
+      });
+    }
+  }, [value]);
   return <div ref={host} className="min-w-0" />;
 }

--- a/apps/towbar-web-app/src/components/credential-editor.tsx
+++ b/apps/towbar-web-app/src/components/credential-editor.tsx
@@ -1,13 +1,15 @@
 "use client";
+import {
+  CheckmarkCircle01Icon,
+  Delete02Icon,
+  FloppyDiskIcon,
+  InformationCircleIcon,
+  Key01Icon,
+  ReloadIcon,
+  Undo02Icon,
+} from "@hugeicons/core-free-icons";
 
 import { HugeiconsIcon } from "@hugeicons/react";
-
-import {
-  Key01Icon,
-  CheckmarkCircle01Icon,
-  InformationCircleIcon,
-  Delete02Icon,
-} from "@hugeicons/core-free-icons";
 
 import { useState, type FormEvent } from "react";
 import type { SecretMetadata, Server } from "@workspace/towbar-web-client";
@@ -249,12 +251,22 @@ function ServerCredentialForm({
           <FieldError>
             {error}{" "}
             <Button variant="ghost" onPress={refresh}>
+              <HugeiconsIcon
+                aria-hidden="true"
+                icon={ReloadIcon}
+                className="size-4 shrink-0"
+              />
               Refresh settings
             </Button>
           </FieldError>
         ) : null}
         {canManage ? (
           <Button type="submit" className="w-fit" isDisabled={busy}>
+            <HugeiconsIcon
+              aria-hidden="true"
+              icon={FloppyDiskIcon}
+              className="size-4 shrink-0"
+            />
             {busy ? "Saving…" : "Save"}
           </Button>
         ) : null}
@@ -356,6 +368,11 @@ function CredentialField({
           isDisabled={busy}
           onPress={() => onRemoveChange(!deleted)}
         >
+          <HugeiconsIcon
+            aria-hidden="true"
+            icon={deleted ? Undo02Icon : Delete02Icon}
+            className="size-4 shrink-0"
+          />
           {deleted ? "Keep" : "Remove"}
         </Button>
       ) : null}

--- a/apps/towbar-web-app/src/components/dashboard-overview.tsx
+++ b/apps/towbar-web-app/src/components/dashboard-overview.tsx
@@ -250,6 +250,11 @@ function OverviewActivity() {
             </EmptyState.Header>
             <EmptyState.Content>
               <ButtonLink href="/sources" variant="secondary">
+                <HugeiconsIcon
+                  aria-hidden="true"
+                  icon={GitBranchIcon}
+                  className="size-4 shrink-0"
+                />
                 Open Sources
               </ButtonLink>
             </EmptyState.Content>

--- a/apps/towbar-web-app/src/components/deployment-detail.tsx
+++ b/apps/towbar-web-app/src/components/deployment-detail.tsx
@@ -1,4 +1,15 @@
 "use client";
+import {
+  Activity01Icon,
+  Cancel01Icon,
+  DashboardCircleIcon,
+  DatabaseIcon,
+  FileViewIcon,
+  InformationSquareIcon,
+  ReloadIcon,
+  Rocket01Icon,
+  ServerStack01Icon,
+} from "@hugeicons/core-free-icons";
 
 import { TooltipText } from "@workspace/web-design-system/overlays/tooltip";
 
@@ -7,15 +18,6 @@ import { isEventRunning } from "@/lib/elapsed-time";
 
 import { ConfigurationLinks } from "./configuration-links";
 
-import {
-  Activity01Icon,
-  DashboardCircleIcon,
-  DatabaseIcon,
-  FileViewIcon,
-  InformationSquareIcon,
-  Rocket01Icon,
-  ServerStack01Icon,
-} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useParams, useRouter } from "next/navigation";
 import type { Deployment, Source } from "@workspace/towbar-web-client";
@@ -159,6 +161,11 @@ export function DeploymentDetail() {
       success="Cancellation requested"
       variant="danger"
     >
+      <HugeiconsIcon
+        aria-hidden="true"
+        icon={Cancel01Icon}
+        className="size-4 shrink-0"
+      />
       Cancel
     </ActionButton>
   ) : item.environment === "production" &&
@@ -180,6 +187,11 @@ export function DeploymentDetail() {
       success="Retry queued"
       variant="primary"
     >
+      <HugeiconsIcon
+        aria-hidden="true"
+        icon={ReloadIcon}
+        className="size-4 shrink-0"
+      />
       Retry
     </ActionButton>
   ) : undefined;

--- a/apps/towbar-web-app/src/components/deployment-vulnerability-scan.tsx
+++ b/apps/towbar-web-app/src/components/deployment-vulnerability-scan.tsx
@@ -1,10 +1,10 @@
 "use client";
+import { SecurityCheckIcon, Shield01Icon } from "@hugeicons/core-free-icons";
 
 import { TooltipText } from "@workspace/web-design-system/overlays/tooltip";
 
 import { useEffect, useState } from "react";
 
-import { SecurityCheckIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import type {
@@ -186,6 +186,11 @@ export function DeploymentVulnerabilityScanPanel({
                 success="Image scan queued"
                 variant="secondary"
               >
+                <HugeiconsIcon
+                  aria-hidden="true"
+                  icon={Shield01Icon}
+                  className="size-4 shrink-0"
+                />
                 {scan ? "Scan again" : "Scan image"}
               </ActionButton>
             </div>

--- a/apps/towbar-web-app/src/components/github-settings.tsx
+++ b/apps/towbar-web-app/src/components/github-settings.tsx
@@ -1,8 +1,13 @@
 "use client";
+import {
+  Add01Icon,
+  Cancel01Icon,
+  GithubIcon,
+  ReloadIcon,
+  Shield01Icon,
+} from "@hugeicons/core-free-icons";
 
 import { HugeiconsIcon } from "@hugeicons/react";
-
-import { GithubIcon } from "@hugeicons/core-free-icons";
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
@@ -69,6 +74,11 @@ export function GitHubSettings() {
         success="Opening GitHub"
         variant="primary"
       >
+        <HugeiconsIcon
+          aria-hidden="true"
+          icon={ReloadIcon}
+          className="size-4 shrink-0"
+        />
         Reconnect GitHub
       </ActionButton>
     ) : (
@@ -83,6 +93,11 @@ export function GitHubSettings() {
         success="GitHub disconnected"
         variant="danger"
       >
+        <HugeiconsIcon
+          aria-hidden="true"
+          icon={Cancel01Icon}
+          className="size-4 shrink-0"
+        />
         Disconnect GitHub
       </ActionButton>
     )
@@ -92,6 +107,11 @@ export function GitHubSettings() {
       success="Opening GitHub"
       variant="primary"
     >
+      <HugeiconsIcon
+        aria-hidden="true"
+        icon={Add01Icon}
+        className="size-4 shrink-0"
+      />
       Install GitHub App
     </ActionButton>
   );
@@ -127,6 +147,11 @@ export function GitHubSettings() {
                 pendingLabel="Retrying…"
                 success="Preview reporting retried"
               >
+                <HugeiconsIcon
+                  aria-hidden="true"
+                  icon={ReloadIcon}
+                  className="size-4 shrink-0"
+                />
                 Retry reporting
               </ActionButton>
             </div>
@@ -182,6 +207,11 @@ export function GitHubSettings() {
             action={openGitHubInstallation}
             success="Opening GitHub"
           >
+            <HugeiconsIcon
+              aria-hidden="true"
+              icon={Shield01Icon}
+              className="size-4 shrink-0"
+            />
             Review permissions
           </ActionButton>
         ) : null}

--- a/apps/towbar-web-app/src/components/login-form.tsx
+++ b/apps/towbar-web-app/src/components/login-form.tsx
@@ -1,4 +1,6 @@
 "use client";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Login01Icon, UserAdd01Icon } from "@hugeicons/core-free-icons";
 
 import { useSearchParams } from "next/navigation";
 import { useEffect, useId, useState, type FormEvent } from "react";
@@ -72,6 +74,13 @@ export function LoginForm() {
   return (
     <AuthFrame description="Use your Towbar owner account." title="Sign in">
       <IdentityCredentialsForm
+        submitIcon={
+          <HugeiconsIcon
+            aria-hidden="true"
+            icon={Login01Icon}
+            className="size-4 shrink-0"
+          />
+        }
         identifierLabel="Email"
         identifierType="email"
         onSubmit={async ({ identifier, password }) => {
@@ -200,6 +209,11 @@ function InitialOwnerSetup() {
           </Alert>
         ) : null}
         <Button className="w-full" isDisabled={isSubmitting} type="submit">
+          <HugeiconsIcon
+            aria-hidden="true"
+            icon={UserAdd01Icon}
+            className="size-4 shrink-0"
+          />
           {isSubmitting ? "Creating owner…" : "Create owner"}
         </Button>
       </form>

--- a/apps/towbar-web-app/src/components/monitoring-entity-picker.tsx
+++ b/apps/towbar-web-app/src/components/monitoring-entity-picker.tsx
@@ -1,4 +1,6 @@
 "use client";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
 import { useEffect, useState } from "react";
 import {
   Autocomplete,
@@ -168,6 +170,11 @@ export function MonitoringEntityPicker({
                     variant="secondary"
                     onPress={() => setAfter("")}
                   >
+                    <HugeiconsIcon
+                      aria-hidden="true"
+                      icon={ArrowLeft01Icon}
+                      className="size-4 shrink-0"
+                    />
                     First results
                   </Button>
                 ) : null}

--- a/apps/towbar-web-app/src/components/monitoring-history.tsx
+++ b/apps/towbar-web-app/src/components/monitoring-history.tsx
@@ -1,4 +1,6 @@
 "use client";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Settings01Icon } from "@hugeicons/core-free-icons";
 import { ScoutOptionIcon } from "./scout-icons";
 
 import { useCallback, useDeferredValue, useId, useMemo, useState } from "react";
@@ -265,6 +267,11 @@ function MonitoringEmptyState({
             href={`/servers/${serverId}?section=settings&settings=monitoring`}
             variant="secondary"
           >
+            <HugeiconsIcon
+              aria-hidden="true"
+              icon={Settings01Icon}
+              className="size-4 shrink-0"
+            />
             Scout Agent settings
           </ButtonLink>
           <MonitoringDocumentation />

--- a/apps/towbar-web-app/src/components/monitoring-range-picker.tsx
+++ b/apps/towbar-web-app/src/components/monitoring-range-picker.tsx
@@ -1,4 +1,6 @@
 "use client";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Cancel01Icon } from "@hugeicons/core-free-icons";
 import { useId, useState } from "react";
 import { Button } from "@workspace/web-design-system/buttons/button";
 import { Input } from "@workspace/web-design-system/forms/input";
@@ -119,6 +121,11 @@ export function MonitoringRangePicker({
                 ) : null}
                 <div className="flex justify-end gap-2">
                   <Button type="button" variant="secondary" onPress={onClose}>
+                    <HugeiconsIcon
+                      aria-hidden="true"
+                      icon={Cancel01Icon}
+                      className="size-4 shrink-0"
+                    />
                     Cancel
                   </Button>
                   <Button type="submit">

--- a/apps/towbar-web-app/src/components/notification-integration.tsx
+++ b/apps/towbar-web-app/src/components/notification-integration.tsx
@@ -1,11 +1,12 @@
 "use client";
-
 import {
   Alert02Icon,
+  BookOpen01Icon,
   CheckmarkCircle01Icon,
   Mail01Icon,
   SlackIcon,
 } from "@hugeicons/core-free-icons";
+
 import { HugeiconsIcon } from "@hugeicons/react";
 import { QueryError, QueryLoading } from "@workspace/towbar-web-ui/query-state";
 import { ButtonLink } from "@workspace/web-design-system/buttons/button";
@@ -88,6 +89,11 @@ export function NotificationIntegration({
           target="_blank"
           rel="noopener noreferrer"
         >
+          <HugeiconsIcon
+            aria-hidden="true"
+            icon={BookOpen01Icon}
+            className="size-4 shrink-0"
+          />
           {name} setup documentation
         </ButtonLink>
       </Widget.Content>

--- a/apps/towbar-web-app/src/components/page-parts.tsx
+++ b/apps/towbar-web-app/src/components/page-parts.tsx
@@ -1,4 +1,10 @@
 "use client";
+import {
+  FloppyDiskIcon,
+  Cancel01Icon,
+  Delete02Icon,
+  Tick02Icon,
+} from "@hugeicons/core-free-icons";
 
 import { TooltipText } from "@workspace/web-design-system/overlays/tooltip";
 
@@ -276,7 +282,10 @@ export function ActionButton<T>({
     busy && isIconOnly ? (
       <Spinner aria-label={pendingLabel} size="sm" />
     ) : busy ? (
-      pendingLabel
+      <>
+        <Spinner aria-label={pendingLabel} size="sm" />
+        {pendingLabel}
+      </>
     ) : (
       children
     );
@@ -314,6 +323,11 @@ export function ActionButton<T>({
                 variant="secondary"
                 onPress={() => setIsConfirming(false)}
               >
+                <HugeiconsIcon
+                  aria-hidden="true"
+                  icon={Cancel01Icon}
+                  className="size-4 shrink-0"
+                />
                 Cancel
               </Button>
               <Button
@@ -324,7 +338,23 @@ export function ActionButton<T>({
                   void runAction();
                 }}
               >
-                {busy ? pendingLabel : (confirm.actionLabel ?? children)}
+                {busy ? (
+                  <>
+                    <Spinner aria-label={pendingLabel} size="sm" />
+                    {pendingLabel}
+                  </>
+                ) : confirm.actionLabel ? (
+                  <>
+                    <HugeiconsIcon
+                      aria-hidden="true"
+                      icon={variant === "danger" ? Delete02Icon : Tick02Icon}
+                      className="size-4 shrink-0"
+                    />
+                    {confirm.actionLabel}
+                  </>
+                ) : (
+                  children
+                )}
               </Button>
             </AlertDialog.Footer>
           </AlertDialog.Dialog>
@@ -441,6 +471,11 @@ export function SimpleForm({
         </Field>
       ))}
       <Button className="w-fit" isDisabled={busy} type="submit">
+        <HugeiconsIcon
+          aria-hidden="true"
+          icon={FloppyDiskIcon}
+          className="size-4 shrink-0"
+        />
         {busy ? "Saving…" : submitLabel}
       </Button>
     </form>

--- a/apps/towbar-web-app/src/components/preview-environments.tsx
+++ b/apps/towbar-web-app/src/components/preview-environments.tsx
@@ -1,4 +1,6 @@
 "use client";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Delete02Icon, ReloadIcon } from "@hugeicons/core-free-icons";
 
 import { TooltipText } from "@workspace/web-design-system/overlays/tooltip";
 
@@ -146,6 +148,11 @@ export function PreviewEnvironments({
               pendingLabel="Queueing…"
               success="Preview cleanup retry queued"
             >
+              <HugeiconsIcon
+                aria-hidden="true"
+                icon={ReloadIcon}
+                className="size-4 shrink-0"
+              />
               Retry cleanup
             </ActionButton>
           ) : (
@@ -164,6 +171,11 @@ export function PreviewEnvironments({
               success="Preview cleanup queued"
               variant="danger"
             >
+              <HugeiconsIcon
+                aria-hidden="true"
+                icon={Delete02Icon}
+                className="size-4 shrink-0"
+              />
               Delete
             </ActionButton>
           )}

--- a/apps/towbar-web-app/src/components/resource-backup-configuration.tsx
+++ b/apps/towbar-web-app/src/components/resource-backup-configuration.tsx
@@ -1,14 +1,19 @@
 "use client";
+import {
+  Archive01Icon,
+  Cancel01Icon,
+  Copy01Icon,
+  DatabaseIcon,
+  Delete02Icon,
+  RefreshIcon,
+  Settings01Icon,
+  Shield01Icon,
+  Undo02Icon,
+} from "@hugeicons/core-free-icons";
 
 import { ElapsedTime } from "./elapsed-time";
 
 import { HugeiconsIcon } from "@hugeicons/react";
-
-import {
-  Archive01Icon,
-  RefreshIcon,
-  Settings01Icon,
-} from "@hugeicons/core-free-icons";
 
 import { useState } from "react";
 import type { FormEvent } from "react";
@@ -187,6 +192,11 @@ export function ResourceBackupConfiguration({
             variant="secondary"
             onPress={() => setSelectedBackup(item)}
           >
+            <HugeiconsIcon
+              aria-hidden="true"
+              icon={Undo02Icon}
+              className="size-4 shrink-0"
+            />
             Restore
           </Button>
         );
@@ -253,6 +263,11 @@ export function ResourceBackupConfiguration({
                     success="Backup queued"
                     variant="primary"
                   >
+                    <HugeiconsIcon
+                      aria-hidden="true"
+                      icon={DatabaseIcon}
+                      className="size-4 shrink-0"
+                    />
                     Back up now
                   </ActionButton>
                 ) : null}
@@ -489,6 +504,11 @@ function RestoreConfirmation({
                     variant="secondary"
                     onPress={close}
                   >
+                    <HugeiconsIcon
+                      aria-hidden="true"
+                      icon={Cancel01Icon}
+                      className="size-4 shrink-0"
+                    />
                     Cancel
                   </Button>
                   <Button
@@ -500,6 +520,11 @@ function RestoreConfirmation({
                     type="submit"
                     variant="danger"
                   >
+                    <HugeiconsIcon
+                      aria-hidden="true"
+                      icon={Undo02Icon}
+                      className="size-4 shrink-0"
+                    />
                     {submitting ? "Queueing restore…" : "Restore database"}
                   </Button>
                 </div>
@@ -727,10 +752,20 @@ function RestoreOperationAction({
       success="Restore cancellation requested"
       variant="danger"
     >
+      <HugeiconsIcon
+        aria-hidden="true"
+        icon={Cancel01Icon}
+        className="size-4 shrink-0"
+      />
       Cancel
     </ActionButton>
   ) : (
     <Button size="sm" variant="secondary" onPress={onCleanup}>
+      <HugeiconsIcon
+        aria-hidden="true"
+        icon={Delete02Icon}
+        className="size-4 shrink-0"
+      />
       Clean up volume
     </Button>
   );
@@ -821,6 +856,11 @@ function RestoreCleanupConfirmation({
                   variant="secondary"
                   onPress={close}
                 >
+                  <HugeiconsIcon
+                    aria-hidden="true"
+                    icon={Shield01Icon}
+                    className="size-4 shrink-0"
+                  />
                   Keep rollback volume
                 </Button>
                 <Button
@@ -828,6 +868,11 @@ function RestoreCleanupConfirmation({
                   variant="danger"
                   onPress={cleanUp}
                 >
+                  <HugeiconsIcon
+                    aria-hidden="true"
+                    icon={Delete02Icon}
+                    className="size-4 shrink-0"
+                  />
                   {submitting ? "Queueing cleanup…" : "Clean up volume"}
                 </Button>
               </div>
@@ -852,10 +897,15 @@ function CopyBackupKey({ backup }: { backup: SourceBackup }) {
     <span className="flex min-h-7 flex-wrap items-center gap-x-3 gap-y-1">
       <span>{formatDate(backup.finishedAt ?? backup.createdAt)}</span>
       <button
-        className="focus-visible:ring-focus relative inline-flex min-h-7 items-center rounded-md font-medium underline-offset-4 outline-none after:absolute after:-inset-x-1 after:-inset-y-2 after:content-[''] pointer-fine:hover:underline focus-visible:ring-2"
+        className="focus-visible:ring-focus relative inline-flex min-h-7 items-center gap-2 rounded-md font-medium underline-offset-4 outline-none after:absolute after:-inset-x-1 after:-inset-y-2 after:content-[''] pointer-fine:hover:underline focus-visible:ring-2"
         type="button"
         onClick={copyObjectKey}
       >
+        <HugeiconsIcon
+          aria-hidden="true"
+          icon={Copy01Icon}
+          className="size-4 shrink-0"
+        />
         Copy S3 key
       </button>
     </span>

--- a/apps/towbar-web-app/src/components/resource-detail.tsx
+++ b/apps/towbar-web-app/src/components/resource-detail.tsx
@@ -285,6 +285,11 @@ export function ResourceDetail() {
               success="Resource deployment queued"
               variant="primary"
             >
+              <HugeiconsIcon
+                aria-hidden="true"
+                icon={Rocket01Icon}
+                className="size-4 shrink-0"
+              />
               Deploy
             </ActionButton>
           </div>

--- a/apps/towbar-web-app/src/components/resource-index.tsx
+++ b/apps/towbar-web-app/src/components/resource-index.tsx
@@ -1,14 +1,15 @@
 "use client";
+import {
+  Add01Icon,
+  DashboardCircleIcon,
+  DatabaseIcon,
+  GitBranchIcon,
+  GithubIcon,
+  ServerStack01Icon,
+} from "@hugeicons/core-free-icons";
 
 import { TooltipText } from "@workspace/web-design-system/overlays/tooltip";
 
-import {
-  GithubIcon,
-  GitBranchIcon,
-  DashboardCircleIcon,
-  DatabaseIcon,
-  ServerStack01Icon,
-} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useRouter } from "next/navigation";
 import type { App, Resource, Source } from "@workspace/towbar-web-client";
@@ -144,7 +145,16 @@ export function SourceIndex() {
   return (
     <DashboardPage
       icon={GitBranchIcon}
-      actions={<ButtonLink href="/sources/new">Add source</ButtonLink>}
+      actions={
+        <ButtonLink href="/sources/new">
+          <HugeiconsIcon
+            aria-hidden="true"
+            icon={Add01Icon}
+            className="size-4 shrink-0"
+          />
+          Add source
+        </ButtonLink>
+      }
       title="Sources"
     >
       {error ? (
@@ -155,7 +165,16 @@ export function SourceIndex() {
         <ResourceTable
           ariaLabel="Sources"
           columns={columns}
-          emptyAction={<ButtonLink href="/sources/new">Add source</ButtonLink>}
+          emptyAction={
+            <ButtonLink href="/sources/new">
+              <HugeiconsIcon
+                aria-hidden="true"
+                icon={Add01Icon}
+                className="size-4 shrink-0"
+              />
+              Add source
+            </ButtonLink>
+          }
           emptyDescription="Connect a GitHub repository to import its Towbar manifest."
           emptyTitle="No sources yet"
           getRowHref={(source) => `/sources/${source.id}`}

--- a/apps/towbar-web-app/src/components/runtime-operations.tsx
+++ b/apps/towbar-web-app/src/components/runtime-operations.tsx
@@ -1,10 +1,6 @@
 "use client";
-
-import { ElapsedTime } from "./elapsed-time";
-
-import { ConfigurationLinks } from "./configuration-links";
-
 import {
+  Cancel01Icon,
   MoreHorizontalIcon,
   PlayIcon,
   ReloadIcon,
@@ -12,6 +8,11 @@ import {
   StopIcon,
   Undo02Icon,
 } from "@hugeicons/core-free-icons";
+
+import { ElapsedTime } from "./elapsed-time";
+
+import { ConfigurationLinks } from "./configuration-links";
+
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -163,6 +164,11 @@ export function DeployableActionsMenu({
                 variant="secondary"
                 onPress={() => setSelectedAction(null)}
               >
+                <HugeiconsIcon
+                  aria-hidden="true"
+                  icon={Cancel01Icon}
+                  className="size-4 shrink-0"
+                />
                 Cancel
               </Button>
               <Button
@@ -170,6 +176,11 @@ export function DeployableActionsMenu({
                 variant={selection?.danger ? "danger" : "primary"}
                 onPress={runAction}
               >
+                <HugeiconsIcon
+                  aria-hidden="true"
+                  icon={selectedAction ? actionIcon(selectedAction) : PlayIcon}
+                  className="size-4 shrink-0"
+                />
                 {busy ? selection?.pendingLabel : selection?.label}
               </Button>
             </AlertDialog.Footer>
@@ -277,6 +288,11 @@ export function RuntimeLogs({
       success="Log capture queued"
       variant="primary"
     >
+      <HugeiconsIcon
+        aria-hidden="true"
+        icon={SourceCodeIcon}
+        className="size-4 shrink-0"
+      />
       Capture logs
     </ActionButton>
   ) : null;

--- a/apps/towbar-web-app/src/components/server-detail.tsx
+++ b/apps/towbar-web-app/src/components/server-detail.tsx
@@ -1,4 +1,16 @@
 "use client";
+import {
+  Activity01Icon,
+  Cancel01Icon,
+  DashboardCircleIcon,
+  DatabaseIcon,
+  Delete02Icon,
+  Link01Icon,
+  ServerStack01Icon,
+  Settings01Icon,
+  Shield01Icon,
+  Tick02Icon,
+} from "@hugeicons/core-free-icons";
 
 import { MonitoringAgentSettings } from "./monitoring-agent-settings";
 import { ScoutPanel } from "./scout-panel";
@@ -9,14 +21,6 @@ import { ConfigurationLinks } from "./configuration-links";
 import { ServerEditor } from "./server-editor";
 import { ServerHardwareDescription } from "./server-hardware";
 
-import {
-  Activity01Icon,
-  DashboardCircleIcon,
-  DatabaseIcon,
-  Link01Icon,
-  ServerStack01Icon,
-  Settings01Icon,
-} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useParams, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
@@ -314,6 +318,11 @@ export function ServerDetail() {
             success="Host key untrusted"
             variant="danger"
           >
+            <HugeiconsIcon
+              aria-hidden="true"
+              icon={Cancel01Icon}
+              className="size-4 shrink-0"
+            />
             Untrust key
           </ActionButton>
         ) : key.status === "untrusted" && key.publicKey ? (
@@ -341,6 +350,11 @@ export function ServerDetail() {
             }}
             success="Host key trusted"
           >
+            <HugeiconsIcon
+              aria-hidden="true"
+              icon={Shield01Icon}
+              className="size-4 shrink-0"
+            />
             Trust key
           </ActionButton>
         ) : (
@@ -360,6 +374,11 @@ export function ServerDetail() {
           success="Server check queued"
           variant="primary"
         >
+          <HugeiconsIcon
+            aria-hidden="true"
+            icon={Tick02Icon}
+            className="size-4 shrink-0"
+          />
           Check server
         </ActionButton>
       }
@@ -779,6 +798,11 @@ function ServerPreparationPanel({
               success="Server preparation queued"
               variant="primary"
             >
+              <HugeiconsIcon
+                aria-hidden="true"
+                icon={Settings01Icon}
+                className="size-4 shrink-0"
+              />
               Prepare Server
             </ActionButton>
           </div>
@@ -871,6 +895,11 @@ function CleanupButton({
       success="Orphan cleanup queued"
       variant="danger"
     >
+      <HugeiconsIcon
+        aria-hidden="true"
+        icon={Delete02Icon}
+        className="size-4 shrink-0"
+      />
       {label}
     </ActionButton>
   );

--- a/apps/towbar-web-app/src/components/server-editor.tsx
+++ b/apps/towbar-web-app/src/components/server-editor.tsx
@@ -1,8 +1,11 @@
 "use client";
+import {
+  Delete02Icon,
+  FloppyDiskIcon,
+  Settings01Icon,
+} from "@hugeicons/core-free-icons";
 
 import { HugeiconsIcon } from "@hugeicons/react";
-
-import { Delete02Icon, Settings01Icon } from "@hugeicons/core-free-icons";
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -177,6 +180,11 @@ export function ServerEditor({
             isDisabled={busy || !canManage}
             type="submit"
           >
+            <HugeiconsIcon
+              aria-hidden="true"
+              icon={FloppyDiskIcon}
+              className="size-4 shrink-0"
+            />
             {busy ? "Saving…" : editing ? "Save" : "Add server"}
           </Button>
         </form>
@@ -209,6 +217,11 @@ export function ServerEditor({
               success="Server removal requested"
               variant="danger"
             >
+              <HugeiconsIcon
+                aria-hidden="true"
+                icon={Delete02Icon}
+                className="size-4 shrink-0"
+              />
               Remove server
             </ActionButton>
           </div>

--- a/apps/towbar-web-app/src/components/settings-pages.tsx
+++ b/apps/towbar-web-app/src/components/settings-pages.tsx
@@ -1,8 +1,11 @@
 "use client";
+import {
+  Cancel01Icon,
+  Key01Icon,
+  UserAccountIcon,
+} from "@hugeicons/core-free-icons";
 
 import { HugeiconsIcon } from "@hugeicons/react";
-
-import { Key01Icon, UserAccountIcon } from "@hugeicons/core-free-icons";
 
 import type { TowbarUser, UserSession } from "@workspace/towbar-web-client";
 import { Button } from "@workspace/web-design-system/buttons/button";
@@ -170,6 +173,11 @@ export function SessionSettings() {
       cell: (session) =>
         session.id === currentSessionId ? (
           <Button isDisabled variant="danger">
+            <HugeiconsIcon
+              aria-hidden="true"
+              icon={Cancel01Icon}
+              className="size-4 shrink-0"
+            />
             Revoke
           </Button>
         ) : (
@@ -184,6 +192,11 @@ export function SessionSettings() {
             success="Session revoked"
             variant="danger"
           >
+            <HugeiconsIcon
+              aria-hidden="true"
+              icon={Cancel01Icon}
+              className="size-4 shrink-0"
+            />
             Revoke
           </ActionButton>
         ),

--- a/apps/towbar-web-app/src/components/source-create.tsx
+++ b/apps/towbar-web-app/src/components/source-create.tsx
@@ -1,8 +1,12 @@
 "use client";
+import {
+  Add01Icon,
+  GitBranchIcon,
+  GithubIcon,
+} from "@hugeicons/core-free-icons";
 
 import { HugeiconsIcon } from "@hugeicons/react";
 
-import { GitBranchIcon } from "@hugeicons/core-free-icons";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import type {
@@ -78,6 +82,11 @@ export function SourceCreate() {
           </EmptyState.Header>
           <EmptyState.Content>
             <ButtonLink href="/manage/integrations?integration=github">
+              <HugeiconsIcon
+                aria-hidden="true"
+                icon={GithubIcon}
+                className="size-4 shrink-0"
+              />
               Open GitHub integration
             </ButtonLink>
           </EmptyState.Content>
@@ -247,6 +256,11 @@ export function SourceCreate() {
               isDisabled={!selected || busy}
               type="submit"
             >
+              <HugeiconsIcon
+                aria-hidden="true"
+                icon={Add01Icon}
+                className="size-4 shrink-0"
+              />
               {busy ? "Adding…" : "Add and sync source"}
             </Button>
           </form>

--- a/apps/towbar-web-app/src/components/source-detail.tsx
+++ b/apps/towbar-web-app/src/components/source-detail.tsx
@@ -301,7 +301,7 @@ export function SourceDetail() {
                             code={manifest.data.manifest.rawManifest}
                           />
                         </CodeBlock.Header>
-                        <Widget.Content className="py-0">
+                        <Widget.Content>
                           <CodeEditor
                             ariaLabel="Deployment manifest code"
                             language="yaml"

--- a/apps/towbar-web-app/src/components/source-detail.tsx
+++ b/apps/towbar-web-app/src/components/source-detail.tsx
@@ -27,7 +27,9 @@ import { EmptyState } from "@workspace/web-design-system/data-display/empty-stat
 import { useTablePagination } from "@workspace/web-design-system/hooks/use-table-pagination";
 import { Pagination } from "@workspace/web-design-system/navigation/pagination";
 import { TypographyCode } from "@workspace/web-design-system/typography/typography";
-import { CodePanel } from "@workspace/towbar-web-ui/code-panel";
+import dynamic from "next/dynamic";
+import { Widget } from "@workspace/web-design-system/data-display/widget";
+import { CodeBlock } from "@workspace/web-design-system/typography/code-block";
 import { QueryError, QueryLoading } from "@workspace/towbar-web-ui/query-state";
 import {
   ResourceTable,
@@ -54,6 +56,8 @@ import {
 import { SourceApps, SourceResources } from "./source-inventory";
 import { ResponsiveSubtabs } from "./responsive-subtabs";
 import { AutoDeployControlEditor } from "./auto-deploy-control";
+
+const CodeEditor = dynamic(() => import("./code-editor"), { ssr: false });
 
 type ManifestResponse = {
   manifest: {
@@ -285,12 +289,28 @@ export function SourceDetail() {
                     value: "manifest",
                     label: "Manifest",
                     content: manifest.data.manifest ? (
-                      <CodePanel
-                        ariaLabel="Deployment manifest"
-                        language="yaml"
+                      <CodeBlock
+                        aria-label="Deployment manifest"
+                        className="w-full min-w-0"
                       >
-                        {manifest.data.manifest.rawManifest}
-                      </CodePanel>
+                        <CodeBlock.Header>
+                          <CodeBlock.Filename>
+                            Deployment manifest
+                          </CodeBlock.Filename>
+                          <CodeBlock.CopyButton
+                            code={manifest.data.manifest.rawManifest}
+                          />
+                        </CodeBlock.Header>
+                        <Widget.Content>
+                          <CodeEditor
+                            ariaLabel="Deployment manifest code"
+                            language="yaml"
+                            value={manifest.data.manifest.rawManifest}
+                            disabled
+                            embedded
+                          />
+                        </Widget.Content>
+                      </CodeBlock>
                     ) : (
                       <EmptyState>
                         <EmptyState.Header>

--- a/apps/towbar-web-app/src/components/source-detail.tsx
+++ b/apps/towbar-web-app/src/components/source-detail.tsx
@@ -301,7 +301,7 @@ export function SourceDetail() {
                             code={manifest.data.manifest.rawManifest}
                           />
                         </CodeBlock.Header>
-                        <Widget.Content>
+                        <Widget.Content className="py-0">
                           <CodeEditor
                             ariaLabel="Deployment manifest code"
                             language="yaml"

--- a/apps/towbar-web-app/src/components/source-detail.tsx
+++ b/apps/towbar-web-app/src/components/source-detail.tsx
@@ -1,15 +1,16 @@
 "use client";
-
-import { ElapsedTime } from "./elapsed-time";
-
 import {
   DashboardCircleIcon,
   DatabaseIcon,
   Delete02Icon,
   GithubIcon,
   InformationSquareIcon,
+  ReloadIcon,
   Settings01Icon,
 } from "@hugeicons/core-free-icons";
+
+import { ElapsedTime } from "./elapsed-time";
+
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { type Key, type ReactNode } from "react";
@@ -182,6 +183,11 @@ export function SourceDetail() {
               success="Source sync queued"
               variant="primary"
             >
+              <HugeiconsIcon
+                aria-hidden="true"
+                icon={ReloadIcon}
+                className="size-4 shrink-0"
+              />
               Sync now
             </ActionButton>
           ) : null}
@@ -413,6 +419,11 @@ function SourceSettings({
                         success="Source deleted"
                         variant="danger"
                       >
+                        <HugeiconsIcon
+                          aria-hidden="true"
+                          icon={Delete02Icon}
+                          className="size-4 shrink-0"
+                        />
                         Delete Source
                       </ActionButton>
                     </div>

--- a/apps/towbar-web-app/src/components/system-health.tsx
+++ b/apps/towbar-web-app/src/components/system-health.tsx
@@ -1,15 +1,17 @@
 "use client";
-
-import { TooltipText } from "@workspace/web-design-system/overlays/tooltip";
-
 import {
   Activity01Icon,
   AlertCircleIcon,
+  ArrowRight01Icon,
   CheckmarkCircle02Icon,
   HealthIcon,
   InformationCircleIcon,
   PlugSocketIcon,
+  Tick02Icon,
 } from "@hugeicons/core-free-icons";
+
+import { TooltipText } from "@workspace/web-design-system/overlays/tooltip";
+
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import type {
@@ -83,6 +85,11 @@ export function SystemHealthPage() {
           success="System checks completed"
           variant="primary"
         >
+          <HugeiconsIcon
+            aria-hidden="true"
+            icon={Tick02Icon}
+            className="size-4 shrink-0"
+          />
           Run checks
         </ActionButton>
       }
@@ -155,6 +162,11 @@ function HealthChecks({
               </div>
               {check.remediationHref && check.remediationLabel ? (
                 <ButtonLink href={check.remediationHref} variant="secondary">
+                  <HugeiconsIcon
+                    aria-hidden="true"
+                    icon={ArrowRight01Icon}
+                    className="size-4 shrink-0"
+                  />
                   {check.remediationLabel}
                 </ButtonLink>
               ) : null}

--- a/apps/towbar-web-app/src/components/workspace-inventory.tsx
+++ b/apps/towbar-web-app/src/components/workspace-inventory.tsx
@@ -1,13 +1,14 @@
 "use client";
-
-import { TooltipText } from "@workspace/web-design-system/overlays/tooltip";
-
 import {
+  Add01Icon,
   DashboardCircleIcon,
   DatabaseIcon,
   GithubIcon,
   ServerStack01Icon,
 } from "@hugeicons/core-free-icons";
+
+import { TooltipText } from "@workspace/web-design-system/overlays/tooltip";
+
 import { HugeiconsIcon } from "@hugeicons/react";
 import type {
   App,
@@ -122,7 +123,16 @@ export function ServersIndex() {
   return (
     <DashboardPage
       icon={ServerStack01Icon}
-      actions={<ButtonLink href="/servers/new">Add server</ButtonLink>}
+      actions={
+        <ButtonLink href="/servers/new">
+          <HugeiconsIcon
+            aria-hidden="true"
+            icon={Add01Icon}
+            className="size-4 shrink-0"
+          />
+          Add server
+        </ButtonLink>
+      }
       title="Servers"
     >
       {error ? (

--- a/packages/identity-web-ui/src/identity-credentials-form.tsx
+++ b/packages/identity-web-ui/src/identity-credentials-form.tsx
@@ -40,6 +40,7 @@ type IdentityCredentialsFormOwnProps = {
   onSubmit: (credentials: IdentityCredentials) => Promise<void>;
   passwordAction?: ReactNode;
   submitLabel?: string;
+  submitIcon?: ReactNode;
   submittingLabel?: string;
 };
 
@@ -61,6 +62,7 @@ export function IdentityCredentialsForm({
   onSubmit,
   passwordAction,
   submitLabel = "Sign in",
+  submitIcon,
   submittingLabel = "Signing in…",
   ...props
 }: IdentityCredentialsFormProps) {
@@ -163,6 +165,7 @@ export function IdentityCredentialsForm({
         isDisabled={disabled || isSubmitting}
         className="w-full"
       >
+        {submitIcon}
         {isSubmitting ? submittingLabel : submitLabel}
       </Button>
     </form>

--- a/packages/towbar-web-ui/src/query-state.tsx
+++ b/packages/towbar-web-ui/src/query-state.tsx
@@ -1,4 +1,6 @@
 "use client";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ReloadIcon } from "@hugeicons/core-free-icons";
 
 import { useEffect, useState } from "react";
 
@@ -100,6 +102,11 @@ export function QueryError({
               variant="secondary"
               onPress={() => window.dispatchEvent(new Event("towbar:refresh"))}
             >
+              <HugeiconsIcon
+                aria-hidden="true"
+                icon={ReloadIcon}
+                className="size-4 shrink-0"
+              />
               Retry
             </Button>
           </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,12 @@ importers:
       "@codemirror/commands":
         specifier: ^6.11.0
         version: 6.11.0
+      "@codemirror/lang-yaml":
+        specifier: ^6.1.3
+        version: 6.1.3
+      "@codemirror/language":
+        specifier: ^6.12.4
+        version: 6.12.4
       "@codemirror/state":
         specifier: ^6.7.4
         version: 6.7.4
@@ -235,6 +241,9 @@ importers:
       "@hugeicons/react":
         specifier: "catalog:"
         version: 1.1.10(react@19.2.8)
+      "@lezer/highlight":
+        specifier: ^1.2.3
+        version: 1.2.3
       "@workspace/identity-web-ui":
         specifier: workspace:*
         version: link:../../packages/identity-web-ui
@@ -973,10 +982,22 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@codemirror/autocomplete@6.20.3":
+    resolution:
+      {
+        integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==,
+      }
+
   "@codemirror/commands@6.11.0":
     resolution:
       {
         integrity: sha512-/K4Rl5BN0OtTiPWmJCdqODu38XnDMsDxKY5rgrPnCkutPTJf2wVbkoixLfealF5Kwse/s8P8M5jAiURiwSwnFA==,
+      }
+
+  "@codemirror/lang-yaml@6.1.3":
+    resolution:
+      {
+        integrity: sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==,
       }
 
   "@codemirror/language@6.12.4":
@@ -2296,6 +2317,12 @@ packages:
     resolution:
       {
         integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==,
+      }
+
+  "@lezer/yaml@1.0.4":
+    resolution:
+      {
+        integrity: sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==,
       }
 
   "@marijn/find-cluster-break@1.0.4":
@@ -7872,12 +7899,29 @@ snapshots:
       "@babel/helper-string-parser": 7.29.7
       "@babel/helper-validator-identifier": 7.29.7
 
+  "@codemirror/autocomplete@6.20.3":
+    dependencies:
+      "@codemirror/language": 6.12.4
+      "@codemirror/state": 6.7.4
+      "@codemirror/view": 6.43.11
+      "@lezer/common": 1.5.2
+
   "@codemirror/commands@6.11.0":
     dependencies:
       "@codemirror/language": 6.12.4
       "@codemirror/state": 6.7.4
       "@codemirror/view": 6.43.11
       "@lezer/common": 1.5.2
+
+  "@codemirror/lang-yaml@6.1.3":
+    dependencies:
+      "@codemirror/autocomplete": 6.20.3
+      "@codemirror/language": 6.12.4
+      "@codemirror/state": 6.7.4
+      "@lezer/common": 1.5.2
+      "@lezer/highlight": 1.2.3
+      "@lezer/lr": 1.4.10
+      "@lezer/yaml": 1.0.4
 
   "@codemirror/language@6.12.4":
     dependencies:
@@ -8538,6 +8582,12 @@ snapshots:
     dependencies:
       "@lezer/common": 1.5.2
 
+  "@lezer/yaml@1.0.4":
+    dependencies:
+      "@lezer/common": 1.5.2
+      "@lezer/highlight": 1.2.3
+      "@lezer/lr": 1.4.10
+
   "@marijn/find-cluster-break@1.0.4": {}
 
   "@modelcontextprotocol/sdk@1.30.0(zod@4.5.4)":
@@ -8742,28 +8792,28 @@ snapshots:
 
   "@react-aria/i18n@3.13.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:
-      "@internationalized/date": 3.12.3
+      "@internationalized/date": 3.12.4
       "@internationalized/message": 3.1.10
       "@internationalized/string": 3.2.10
       "@swc/helpers": 0.5.23
       react: 19.2.8
-      react-aria: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-aria: 3.52.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom: 19.2.8(react@19.2.8)
 
   "@react-aria/ssr@3.10.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:
       "@swc/helpers": 0.5.23
       react: 19.2.8
-      react-aria: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-aria: 3.52.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom: 19.2.8(react@19.2.8)
 
   "@react-aria/utils@3.34.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:
       "@swc/helpers": 0.5.23
       react: 19.2.8
-      react-aria: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-aria: 3.52.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom: 19.2.8(react@19.2.8)
-      react-stately: 3.49.0(react@19.2.8)
+      react-stately: 3.50.0(react@19.2.8)
 
   "@react-spectrum/color@3.2.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:


### PR DESCRIPTION
Add missing action icons across secrets, credentials, sources, apps, resources, servers, backups, integrations, API keys, monitoring, system health, and authentication. Use consistent 16px decorative icons while keeping action labels and existing button styles.

Shared confirmations now include icons when they supply a separate action label, and pending ActionButton states show a spinner. The shared identity form accepts a submit icon supplied by Towbar. Existing icon-only controls and deployment queue status/progress indicators remain intact.

Validation: audited button call sites across the web app and its shared UI packages; typecheck and lint pass for the web app, identity UI, and Towbar UI. Visually checked the local secrets form's Add, Save, and Deploy buttons. Diff checks pass.

Deployment manifests now reuse the secrets CodeMirror editor in read-only YAML mode, with line numbers, syntax highlighting, scrolling, and the existing copy action. The editor sits on a single standard widget inset surface.

Manifest validation: web app typecheck and lint, frozen-lockfile install, and local fixture visual checks.
