### PR TITLE
Add secondary sidebar filters and permalink navigation

### DIFF
--- a/apps/towbar-api/src/areas/deployments/history-query.ts
+++ b/apps/towbar-api/src/areas/deployments/history-query.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { deploymentStateSchema } from "@workspace/towbar-core";
+
+export const historyQuerySchema = z
+  .object({
+    page: z.coerce.number().int().min(1).max(1_000_000).default(1),
+    limit: z.coerce.number().int().min(1).max(100).default(10),
+    environment: z.enum(["production", "preview"]).optional(),
+    type: z.enum(["app", "resource"]).optional(),
+    state: deploymentStateSchema.optional(),
+    trigger: z.enum(["auto_deploy", "manual", "rollback"]).optional(),
+    serverId: z.uuid().optional(),
+    sort: z
+      .enum(["newest", "oldest", "name_asc", "name_desc"])
+      .default("newest"),
+  })
+  .strict();

--- a/apps/towbar-api/src/areas/deployments/history-tests.ts
+++ b/apps/towbar-api/src/areas/deployments/history-tests.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { eq, inArray } from "drizzle-orm";
+import { apps, deployments } from "@workspace/towbar-database/schema";
+import type {
+  NormalizedApp,
+  NormalizedResource,
+  NormalizedServer,
+} from "@workspace/towbar-core";
+import type { TestContext } from "node:test";
+import type { getTowbarDatabase } from "../../infrastructure/database.js";
+import { listDeploymentHistory } from "./history.js";
+import { historyQuerySchema } from "./history-query.js";
+
+export async function testDeploymentHistory({
+  t,
+  db,
+  workspaceId,
+  otherWorkspaceId,
+  sourceId,
+  appId,
+  serverId,
+  actorUserId,
+  appConfig,
+  resourceConfig,
+  serverConfig,
+}: {
+  t: TestContext;
+  db: ReturnType<typeof getTowbarDatabase>;
+  workspaceId: string;
+  otherWorkspaceId: string;
+  sourceId: string;
+  appId: string;
+  serverId: string;
+  actorUserId: string;
+  appConfig: NormalizedApp;
+  resourceConfig: NormalizedResource;
+  serverConfig: NormalizedServer;
+}) {
+  await t.test(
+    "deployment history filters before pagination and sorts within its workspace",
+    async () => {
+      const resourceId = randomUUID();
+      const ids = [randomUUID(), randomUUID(), randomUUID()];
+      await db.insert(apps).values({
+        id: resourceId,
+        workspaceId,
+        sourceId,
+        serverId,
+        manifestId: "history-resource",
+        name: "Z Database",
+        kind: "postgres",
+        config: resourceConfig,
+        configDigest: "history",
+        sourceRevision: "1234567",
+      });
+      try {
+        await db.insert(deployments).values(
+          ids.map((id, index) => ({
+            id,
+            workspaceId,
+            sourceId,
+            serverId,
+            appId: index === 2 ? resourceId : appId,
+            idempotencyKey: id,
+            temporalWorkflowId: id,
+            commitSha: "1234567",
+            manifestDigest: "history",
+            appSnapshot: index === 2 ? resourceConfig : appConfig,
+            serverSnapshot: serverConfig,
+            createdAt: new Date(`2026-01-0${index + 1}T00:00:00Z`),
+            state: index === 0 ? ("succeeded" as const) : ("failed" as const),
+            deployableKind:
+              index === 2 ? ("postgres" as const) : ("app" as const),
+            requestedBy: index === 0 ? actorUserId : null,
+            kind: index === 2 ? ("rollback" as const) : ("deploy" as const),
+            rollbackReleaseSnapshot:
+              index === 2
+                ? {
+                    commitSha: "1234567",
+                    containerName: "history",
+                    imageTag: "example:test",
+                    releaseId: randomUUID(),
+                    sourceDeploymentId: ids[0]!,
+                  }
+                : null,
+          })),
+        );
+        const query = (input: Record<string, unknown> = {}) =>
+          listDeploymentHistory({
+            ...historyQuerySchema.parse(input),
+            workspaceId,
+          });
+        const all = await query({ limit: 1 });
+        assert.equal(all.pagination.total, 3);
+        assert.equal(all.pagination.totalPages, 3);
+        assert.equal(all.deployments[0]?.id, ids[2]);
+        const filtered = await query({
+          state: "failed",
+          type: "resource",
+          trigger: "rollback",
+          serverId,
+          environment: "production",
+          limit: 1,
+        });
+        assert.equal(filtered.pagination.total, 1);
+        assert.equal(filtered.deployments[0]?.id, ids[2]);
+        assert.equal(
+          (await query({ trigger: "manual" })).deployments[0]?.id,
+          ids[0],
+        );
+        assert.equal(
+          (await query({ trigger: "auto_deploy" })).deployments[0]?.id,
+          ids[1],
+        );
+        assert.equal(
+          (await query({ sort: "oldest", page: 2, limit: 1 })).deployments[0]
+            ?.id,
+          ids[1],
+        );
+        assert.equal(
+          (await query({ sort: "name_asc" })).deployments[0]?.appId,
+          appId,
+        );
+        assert.equal(
+          (await query({ sort: "name_desc" })).deployments[0]?.appId,
+          resourceId,
+        );
+        assert.equal(
+          (await query({ environment: "preview" })).pagination.total,
+          0,
+        );
+        assert.equal(
+          (await query({ serverId: randomUUID() })).pagination.total,
+          0,
+        );
+        assert.equal(
+          (
+            await listDeploymentHistory({
+              workspaceId: otherWorkspaceId,
+              page: 1,
+              limit: 10,
+            })
+          ).pagination.total,
+          0,
+        );
+        assert.equal(
+          historyQuerySchema.safeParse({ sort: "invalid" }).success,
+          false,
+        );
+        assert.equal(
+          historyQuerySchema.safeParse({ state: "invalid" }).success,
+          false,
+        );
+      } finally {
+        await db.delete(deployments).where(inArray(deployments.id, ids));
+        await db.delete(apps).where(eq(apps.id, resourceId));
+      }
+    },
+  );
+}

--- a/apps/towbar-api/src/areas/deployments/history.ts
+++ b/apps/towbar-api/src/areas/deployments/history.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq } from "drizzle-orm";
+import { and, asc, count, desc, eq, isNotNull, isNull, ne } from "drizzle-orm";
 
 import { apps, deployments } from "@workspace/towbar-database/schema";
 
@@ -6,17 +6,53 @@ import { getTowbarDatabase } from "../../infrastructure/database.js";
 import { publicDeploymentSelection } from "../deployment-selection.js";
 import { attachDeploymentQueueBlockers } from "./queue-blocker-query.js";
 
+import type { z } from "zod";
+import type { historyQuerySchema } from "./history-query.js";
+
 export async function listDeploymentHistory({
   limit,
   page,
   workspaceId,
-}: {
-  limit: number;
-  page: number;
+  environment,
+  type,
+  state,
+  trigger,
+  serverId,
+  sort = "newest",
+}: Omit<z.output<typeof historyQuerySchema>, "sort"> & {
+  sort?: z.output<typeof historyQuerySchema>["sort"];
   workspaceId: string;
 }) {
   const database = getTowbarDatabase();
-  const filter = eq(deployments.workspaceId, workspaceId);
+  const filter = and(
+    eq(deployments.workspaceId, workspaceId),
+    environment ? eq(deployments.environment, environment) : undefined,
+    type === "app"
+      ? eq(deployments.deployableKind, "app")
+      : type === "resource"
+        ? ne(deployments.deployableKind, "app")
+        : undefined,
+    state ? eq(deployments.state, state) : undefined,
+    serverId ? eq(deployments.serverId, serverId) : undefined,
+    trigger === "rollback"
+      ? eq(deployments.kind, "rollback")
+      : trigger === "auto_deploy"
+        ? and(ne(deployments.kind, "rollback"), isNull(deployments.requestedBy))
+        : trigger === "manual"
+          ? and(
+              ne(deployments.kind, "rollback"),
+              isNotNull(deployments.requestedBy),
+            )
+          : undefined,
+  );
+  const order =
+    sort === "oldest"
+      ? [asc(deployments.createdAt), asc(deployments.id)]
+      : sort === "name_asc"
+        ? [asc(apps.name), desc(deployments.createdAt), desc(deployments.id)]
+        : sort === "name_desc"
+          ? [desc(apps.name), desc(deployments.createdAt), desc(deployments.id)]
+          : [desc(deployments.createdAt), desc(deployments.id)];
   const [items, totalRows] = await Promise.all([
     database
       .select({ ...publicDeploymentSelection, deployableName: apps.name })
@@ -26,10 +62,17 @@ export async function listDeploymentHistory({
         and(eq(apps.id, deployments.appId), eq(apps.workspaceId, workspaceId)),
       )
       .where(filter)
-      .orderBy(desc(deployments.createdAt), desc(deployments.id))
+      .orderBy(...order)
       .limit(limit)
       .offset((page - 1) * limit),
-    database.select({ total: count() }).from(deployments).where(filter),
+    database
+      .select({ total: count() })
+      .from(deployments)
+      .innerJoin(
+        apps,
+        and(eq(apps.id, deployments.appId), eq(apps.workspaceId, workspaceId)),
+      )
+      .where(filter),
   ]);
   const total = Number(totalRows[0]?.total ?? 0);
   return {

--- a/apps/towbar-api/src/areas/external-api/browser-only-routes.test-helper.ts
+++ b/apps/towbar-api/src/areas/external-api/browser-only-routes.test-helper.ts
@@ -34,6 +34,6 @@ export function assertPublicOperationNames(
     new Set(operations.map((op) => op.name)).size,
     operations.length,
   );
-  assert.equal(operations.length, 124);
+  assert.equal(operations.length, 128);
   assert(operations.every((op) => op.name.length <= 64));
 }

--- a/apps/towbar-api/src/areas/external-api/response-schemas.json
+++ b/apps/towbar-api/src/areas/external-api/response-schemas.json
@@ -91,254 +91,254 @@
     },
     "account.ts:put:\"/profile/password\"": {},
     "apps.ts:get:\"/\"": { "$ref": "#/components/schemas/Response_89" },
-    "apps.ts:get:\"/:appId\"": { "$ref": "#/components/schemas/Response_116" },
+    "apps.ts:get:\"/:appId\"": { "$ref": "#/components/schemas/Response_117" },
     "apps.ts:get:\"/:appId/auto-deploy-control\"": {
-      "$ref": "#/components/schemas/Response_119"
+      "$ref": "#/components/schemas/Response_120"
     },
     "apps.ts:patch:\"/:appId/auto-deploy-control\"": {
-      "$ref": "#/components/schemas/Response_124"
+      "$ref": "#/components/schemas/Response_125"
     },
     "apps.ts:get:\"/:appId/deployments\"": {
-      "$ref": "#/components/schemas/Response_126"
+      "$ref": "#/components/schemas/Response_127"
     },
     "apps.ts:get:\"/:appId/releases\"": {
-      "$ref": "#/components/schemas/Response_128"
+      "$ref": "#/components/schemas/Response_129"
     },
     "apps.ts:get:\"/:appId/previews\"": {
-      "$ref": "#/components/schemas/Response_130"
+      "$ref": "#/components/schemas/Response_131"
     },
     "apps.ts:get:\"/:appId/operations\"": {
-      "$ref": "#/components/schemas/Response_132"
+      "$ref": "#/components/schemas/Response_133"
     },
     "apps.ts:post:\"/:appId/actions/deploy\"": {
-      "$ref": "#/components/schemas/Response_151"
-    },
-    "apps.ts:post:\"/:appId/actions/rollback\"": {
       "$ref": "#/components/schemas/Response_152"
     },
-    "apps.ts:post:`/:appId/actions/${action}`": {
+    "apps.ts:post:\"/:appId/actions/rollback\"": {
       "$ref": "#/components/schemas/Response_153"
+    },
+    "apps.ts:post:`/:appId/actions/${action}`": {
+      "$ref": "#/components/schemas/Response_154"
     },
     "apps.ts:post:\"/:appId/actions/logs\"": {
-      "$ref": "#/components/schemas/Response_153"
+      "$ref": "#/components/schemas/Response_154"
     },
-    "deployments.ts:get:\"/\"": { "$ref": "#/components/schemas/Response_154" },
+    "deployments.ts:get:\"/\"": { "$ref": "#/components/schemas/Response_155" },
     "deployments.ts:get:\"/history\"": {
-      "$ref": "#/components/schemas/Response_156"
+      "$ref": "#/components/schemas/Response_157"
     },
     "deployments.ts:get:\"/:deploymentId\"": {
-      "$ref": "#/components/schemas/Response_159"
+      "$ref": "#/components/schemas/Response_160"
     },
     "deployments.ts:get:\"/:deploymentId/steps\"": {
-      "$ref": "#/components/schemas/Response_163"
+      "$ref": "#/components/schemas/Response_164"
     },
     "deployments.ts:get:\"/:deploymentId/logs\"": {
-      "$ref": "#/components/schemas/Response_165"
+      "$ref": "#/components/schemas/Response_166"
     },
     "deployments.ts:get:\"/:deploymentId/vulnerability-scan/findings\"": {
-      "$ref": "#/components/schemas/Response_167"
+      "$ref": "#/components/schemas/Response_168"
     },
     "deployments.ts:get:\"/:deploymentId/events\"": {
-      "$ref": "#/components/schemas/Response_169"
-    },
-    "deployments.ts:post:\"/:deploymentId/actions/cancel\"": {
       "$ref": "#/components/schemas/Response_170"
     },
+    "deployments.ts:post:\"/:deploymentId/actions/cancel\"": {
+      "$ref": "#/components/schemas/Response_171"
+    },
     "deployments.ts:post:\"/:deploymentId/actions/retry\"": {
-      "$ref": "#/components/schemas/Response_151"
+      "$ref": "#/components/schemas/Response_152"
     },
     "deployments.ts:post:\"/:deploymentId/vulnerability-scan/actions/rescan\"": {
       "anyOf": [
         { "type": "null" },
-        { "$ref": "#/components/schemas/Response_171" }
+        { "$ref": "#/components/schemas/Response_172" }
       ]
     },
-    "aws.ts:get:\"/\"": { "$ref": "#/components/schemas/Response_172" },
-    "aws.ts:put:\"/\"": { "$ref": "#/components/schemas/Response_174" },
+    "aws.ts:get:\"/\"": { "$ref": "#/components/schemas/Response_173" },
+    "aws.ts:put:\"/\"": { "$ref": "#/components/schemas/Response_175" },
     "aws.ts:delete:\"/\"": {},
-    "github.ts:get:\"/\"": { "$ref": "#/components/schemas/Response_175" },
+    "github.ts:get:\"/\"": { "$ref": "#/components/schemas/Response_176" },
     "github.ts:post:\"/actions/retry-preview-reporting\"": {
-      "$ref": "#/components/schemas/Response_181"
-    },
-    "github.ts:post:\"/actions/installation-url\"": {
       "$ref": "#/components/schemas/Response_182"
     },
-    "github.ts:post:\"/actions/complete-installation\"": {
+    "github.ts:post:\"/actions/installation-url\"": {
       "$ref": "#/components/schemas/Response_183"
     },
+    "github.ts:post:\"/actions/complete-installation\"": {
+      "$ref": "#/components/schemas/Response_184"
+    },
     "github.ts:get:\"/repositories\"": {
-      "$ref": "#/components/schemas/Response_185"
+      "$ref": "#/components/schemas/Response_186"
     },
     "github.ts:delete:\"/\"": {},
-    "servers.ts:get:\"/\"": { "$ref": "#/components/schemas/Response_187" },
-    "servers.ts:post:\"/\"": { "$ref": "#/components/schemas/Response_193" },
+    "servers.ts:get:\"/\"": { "$ref": "#/components/schemas/Response_188" },
+    "servers.ts:post:\"/\"": { "$ref": "#/components/schemas/Response_195" },
     "servers.ts:get:\"/:serverId\"": {
-      "$ref": "#/components/schemas/Response_195"
-    },
-    "servers.ts:patch:\"/:serverId\"": {
       "$ref": "#/components/schemas/Response_197"
     },
+    "servers.ts:patch:\"/:serverId\"": {
+      "$ref": "#/components/schemas/Response_199"
+    },
     "servers.ts:get:\"/:serverId/apps\"": {
-      "$ref": "#/components/schemas/Response_198"
+      "$ref": "#/components/schemas/Response_200"
     },
     "servers.ts:get:\"/:serverId/resources\"": {
-      "$ref": "#/components/schemas/Response_201"
-    },
-    "servers.ts:get:\"/:serverId/deployments\"": {
-      "$ref": "#/components/schemas/Response_202"
-    },
-    "servers.ts:get:\"/:serverId/capacity\"": {
       "$ref": "#/components/schemas/Response_203"
     },
+    "servers.ts:get:\"/:serverId/deployments\"": {
+      "$ref": "#/components/schemas/Response_204"
+    },
+    "servers.ts:get:\"/:serverId/capacity\"": {
+      "$ref": "#/components/schemas/Response_205"
+    },
     "servers.ts:get:\"/:serverId/checks\"": {
-      "$ref": "#/components/schemas/Response_209"
+      "$ref": "#/components/schemas/Response_211"
     },
     "servers.ts:get:\"/:serverId/preparations\"": {
-      "$ref": "#/components/schemas/Response_213"
+      "$ref": "#/components/schemas/Response_215"
     },
     "servers.ts:get:\"/:serverId/orphans\"": {
-      "$ref": "#/components/schemas/Response_216"
+      "$ref": "#/components/schemas/Response_218"
     },
     "servers.ts:get:\"/:serverId/host-keys\"": {
-      "$ref": "#/components/schemas/Response_217"
-    },
-    "servers.ts:post:\"/:serverId/actions/check\"": {
       "$ref": "#/components/schemas/Response_219"
     },
-    "servers.ts:post:\"/:serverId/actions/prepare\"": {
+    "servers.ts:post:\"/:serverId/actions/check\"": {
       "$ref": "#/components/schemas/Response_221"
     },
+    "servers.ts:post:\"/:serverId/actions/prepare\"": {
+      "$ref": "#/components/schemas/Response_223"
+    },
     "servers.ts:post:\"/:serverId/actions/cleanup-orphans\"": {
-      "$ref": "#/components/schemas/Response_153"
+      "$ref": "#/components/schemas/Response_154"
     },
     "servers.ts:post:\"/:serverId/host-keys/actions/trust\"": {
-      "$ref": "#/components/schemas/Response_223"
+      "$ref": "#/components/schemas/Response_225"
     },
     "servers.ts:delete:\"/:serverId/host-keys/:hostKeyId\"": {},
     "servers.ts:delete:\"/:serverId\"": {
-      "$ref": "#/components/schemas/Response_225"
-    },
-    "resources.ts:get:\"/\"": { "$ref": "#/components/schemas/Response_226" },
-    "resources.ts:get:\"/:resourceId\"": {
       "$ref": "#/components/schemas/Response_227"
     },
-    "resources.ts:get:\"/:resourceId/auto-deploy-control\"": {
-      "$ref": "#/components/schemas/Response_228"
-    },
-    "resources.ts:patch:\"/:resourceId/auto-deploy-control\"": {
+    "resources.ts:get:\"/\"": { "$ref": "#/components/schemas/Response_228" },
+    "resources.ts:get:\"/:resourceId\"": {
       "$ref": "#/components/schemas/Response_229"
     },
-    "resources.ts:get:\"/:resourceId/deployments\"": {
+    "resources.ts:get:\"/:resourceId/auto-deploy-control\"": {
+      "$ref": "#/components/schemas/Response_230"
+    },
+    "resources.ts:patch:\"/:resourceId/auto-deploy-control\"": {
       "$ref": "#/components/schemas/Response_231"
     },
-    "resources.ts:get:\"/:resourceId/releases\"": {
-      "$ref": "#/components/schemas/Response_232"
-    },
-    "resources.ts:get:\"/:resourceId/operations\"": {
+    "resources.ts:get:\"/:resourceId/deployments\"": {
       "$ref": "#/components/schemas/Response_233"
     },
-    "resources.ts:get:\"/:resourceId/backup-assurance\"": {
+    "resources.ts:get:\"/:resourceId/releases\"": {
       "$ref": "#/components/schemas/Response_234"
     },
+    "resources.ts:get:\"/:resourceId/operations\"": {
+      "$ref": "#/components/schemas/Response_235"
+    },
+    "resources.ts:get:\"/:resourceId/backup-assurance\"": {
+      "$ref": "#/components/schemas/Response_236"
+    },
     "resources.ts:get:\"/:resourceId/operations/:operationId/events\"": {
-      "$ref": "#/components/schemas/Response_237"
+      "$ref": "#/components/schemas/Response_239"
     },
     "resources.ts:post:\"/:resourceId/actions/deploy\"": {
-      "$ref": "#/components/schemas/Response_151"
-    },
-    "resources.ts:post:\"/:resourceId/actions/rollback\"": {
       "$ref": "#/components/schemas/Response_152"
     },
-    "resources.ts:post:`/:resourceId/actions/${action}`": {
+    "resources.ts:post:\"/:resourceId/actions/rollback\"": {
       "$ref": "#/components/schemas/Response_153"
+    },
+    "resources.ts:post:`/:resourceId/actions/${action}`": {
+      "$ref": "#/components/schemas/Response_154"
     },
     "resources.ts:post:\"/:resourceId/actions/restore\"": {
-      "$ref": "#/components/schemas/Response_153"
+      "$ref": "#/components/schemas/Response_154"
     },
     "resources.ts:post:\"/:resourceId/actions/restore-cleanup\"": {
-      "$ref": "#/components/schemas/Response_153"
+      "$ref": "#/components/schemas/Response_154"
     },
     "resources.ts:post:\"/:resourceId/operations/:operationId/actions/cancel\"": {
-      "$ref": "#/components/schemas/Response_240"
-    },
-    "resources.ts:post:\"/:resourceId/actions/logs\"": {
-      "$ref": "#/components/schemas/Response_153"
-    },
-    "previews.ts:post:\"/:previewEnvironmentId/actions/delete\"": {
-      "$ref": "#/components/schemas/Response_241"
-    },
-    "previews.ts:post:\"/:previewEnvironmentId/actions/deploy\"": {
       "$ref": "#/components/schemas/Response_242"
     },
-    "sources.ts:get:\"/\"": { "$ref": "#/components/schemas/Response_243" },
-    "sources.ts:post:\"/\"": { "$ref": "#/components/schemas/Response_245" },
+    "resources.ts:post:\"/:resourceId/actions/logs\"": {
+      "$ref": "#/components/schemas/Response_154"
+    },
+    "previews.ts:post:\"/:previewEnvironmentId/actions/delete\"": {
+      "$ref": "#/components/schemas/Response_243"
+    },
+    "previews.ts:post:\"/:previewEnvironmentId/actions/deploy\"": {
+      "$ref": "#/components/schemas/Response_244"
+    },
+    "sources.ts:get:\"/\"": { "$ref": "#/components/schemas/Response_245" },
+    "sources.ts:post:\"/\"": { "$ref": "#/components/schemas/Response_248" },
     "sources.ts:get:\"/:sourceId\"": {
-      "$ref": "#/components/schemas/Response_247"
+      "$ref": "#/components/schemas/Response_250"
     },
     "sources.ts:get:\"/:sourceId/auto-deploy-control\"": {
-      "$ref": "#/components/schemas/Response_248"
-    },
-    "sources.ts:patch:\"/:sourceId/auto-deploy-control\"": {
       "$ref": "#/components/schemas/Response_252"
     },
-    "sources.ts:get:\"/:sourceId/apps\"": {
-      "$ref": "#/components/schemas/Response_254"
-    },
-    "sources.ts:get:\"/:sourceId/resources\"": {
-      "$ref": "#/components/schemas/Response_255"
-    },
-    "sources.ts:get:\"/:sourceId/capacity\"": {
+    "sources.ts:patch:\"/:sourceId/auto-deploy-control\"": {
       "$ref": "#/components/schemas/Response_256"
     },
-    "sources.ts:get:\"/:sourceId/deployments\"": {
-      "$ref": "#/components/schemas/Response_257"
-    },
-    "sources.ts:get:\"/:sourceId/backups\"": {
+    "sources.ts:get:\"/:sourceId/apps\"": {
       "$ref": "#/components/schemas/Response_258"
     },
-    "sources.ts:get:\"/:sourceId/previews\"": {
+    "sources.ts:get:\"/:sourceId/resources\"": {
+      "$ref": "#/components/schemas/Response_259"
+    },
+    "sources.ts:get:\"/:sourceId/capacity\"": {
       "$ref": "#/components/schemas/Response_260"
     },
-    "sources.ts:get:\"/:sourceId/manifest\"": {
+    "sources.ts:get:\"/:sourceId/deployments\"": {
       "$ref": "#/components/schemas/Response_261"
     },
-    "sources.ts:post:\"/:sourceId/actions/preview-sync\"": {
+    "sources.ts:get:\"/:sourceId/backups\"": {
+      "$ref": "#/components/schemas/Response_262"
+    },
+    "sources.ts:get:\"/:sourceId/previews\"": {
+      "$ref": "#/components/schemas/Response_264"
+    },
+    "sources.ts:get:\"/:sourceId/manifest\"": {
       "$ref": "#/components/schemas/Response_265"
     },
+    "sources.ts:post:\"/:sourceId/actions/preview-sync\"": {
+      "$ref": "#/components/schemas/Response_269"
+    },
     "sources.ts:post:\"/:sourceId/actions/sync\"": {
-      "$ref": "#/components/schemas/Response_272"
+      "$ref": "#/components/schemas/Response_276"
     },
     "sources.ts:delete:\"/:sourceId\"": {},
     "sources.ts:get:\"/:sourceId/syncs\"": {
-      "$ref": "#/components/schemas/Response_274"
+      "$ref": "#/components/schemas/Response_278"
     },
     "sources.ts:get:\"/:sourceId/syncs/:syncId\"": {
-      "$ref": "#/components/schemas/Response_277"
+      "$ref": "#/components/schemas/Response_281"
     },
     "system-health.ts:get:\"/\"": {
-      "$ref": "#/components/schemas/SystemHealth_278"
+      "$ref": "#/components/schemas/SystemHealth_282"
     },
     "system-health.ts:post:\"/actions/check\"": {
-      "$ref": "#/components/schemas/SystemHealth_278"
+      "$ref": "#/components/schemas/SystemHealth_282"
     },
     "notifications.ts:get:\"/destinations\"": {
-      "$ref": "#/components/schemas/Response_280"
+      "$ref": "#/components/schemas/Response_284"
     },
     "notifications.ts:post:\"/destinations\"": {
-      "$ref": "#/components/schemas/Response_282"
+      "$ref": "#/components/schemas/Response_286"
     },
     "notifications.ts:put:\"/destinations/:destinationId\"": {
-      "$ref": "#/components/schemas/Response_284"
+      "$ref": "#/components/schemas/Response_288"
     },
     "notifications.ts:delete:\"/destinations/:destinationId\"": {},
     "notifications.ts:post:\"/destinations/:destinationId/actions/test\"": {
-      "$ref": "#/components/schemas/Response_285"
+      "$ref": "#/components/schemas/Response_289"
     },
     "notification-center.ts:get:\"/providers\"": {
-      "$ref": "#/components/schemas/Response_287"
+      "$ref": "#/components/schemas/Response_291"
     },
     "notification-center.ts:get:\"/\"": {
-      "$ref": "#/components/schemas/Response_288"
+      "$ref": "#/components/schemas/Response_292"
     }
   },
   "definitions": {
@@ -2404,17 +2404,26 @@
         "updatedAt"
       ]
     },
+    "Response_116": {
+      "type": "object",
+      "properties": {
+        "all": { "type": "number" },
+        "attention": { "type": "number" }
+      },
+      "required": ["all", "attention"]
+    },
     "Response_89": {
       "type": "object",
       "properties": {
         "apps": {
           "type": "array",
           "items": { "$ref": "#/components/schemas/Response_90" }
-        }
+        },
+        "counts": { "$ref": "#/components/schemas/Response_116" }
       },
-      "required": ["apps"]
+      "required": ["apps", "counts"]
     },
-    "Response_118": {
+    "Response_119": {
       "type": "object",
       "properties": {
         "port": { "type": "number" },
@@ -2422,10 +2431,10 @@
       },
       "required": ["port", "username"]
     },
-    "Response_117": {
+    "Response_118": {
       "type": "object",
       "properties": {
-        "serverSsh": { "$ref": "#/components/schemas/Response_118" },
+        "serverSsh": { "$ref": "#/components/schemas/Response_119" },
         "runtimeState": { "$ref": "#/components/schemas/Response_91" },
         "serverReady": { "type": "boolean" },
         "archivedAt": {
@@ -2477,12 +2486,12 @@
         "updatedAt"
       ]
     },
-    "Response_116": {
+    "Response_117": {
       "type": "object",
-      "properties": { "app": { "$ref": "#/components/schemas/Response_117" } },
+      "properties": { "app": { "$ref": "#/components/schemas/Response_118" } },
       "required": ["app"]
     },
-    "DeferredAutomaticDeployment_122": {
+    "DeferredAutomaticDeployment_123": {
       "type": "object",
       "properties": {
         "commitSha": { "type": "string" },
@@ -2506,13 +2515,13 @@
         "scope"
       ]
     },
-    "Response_121": {
+    "Response_122": {
       "type": "object",
       "properties": {
         "pending": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/DeferredAutomaticDeployment_122" }
+            { "$ref": "#/components/schemas/DeferredAutomaticDeployment_123" }
           ]
         },
         "paused": { "type": "boolean" },
@@ -2520,13 +2529,13 @@
       },
       "required": ["pending", "paused", "scope"]
     },
-    "Response_123": {
+    "Response_124": {
       "type": "object",
       "properties": {
         "pending": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/DeferredAutomaticDeployment_122" }
+            { "$ref": "#/components/schemas/DeferredAutomaticDeployment_123" }
           ]
         },
         "paused": { "type": "boolean" },
@@ -2539,13 +2548,35 @@
       },
       "required": ["pending", "paused", "scope"]
     },
+    "Response_121": {
+      "type": "object",
+      "properties": {
+        "effective": {
+          "anyOf": [
+            { "$ref": "#/components/schemas/Response_122" },
+            { "$ref": "#/components/schemas/Response_124" }
+          ]
+        },
+        "manifestAutoDeployEnabled": { "type": "boolean" },
+        "paused": { "type": "boolean" }
+      },
+      "required": ["effective", "manifestAutoDeployEnabled", "paused"]
+    },
     "Response_120": {
       "type": "object",
       "properties": {
+        "autoDeploy": { "$ref": "#/components/schemas/Response_121" },
+        "canManageAutoDeploy": { "type": "boolean" }
+      },
+      "required": ["autoDeploy", "canManageAutoDeploy"]
+    },
+    "autoDeploy_126": {
+      "type": "object",
+      "properties": {
         "effective": {
           "anyOf": [
-            { "$ref": "#/components/schemas/Response_121" },
-            { "$ref": "#/components/schemas/Response_123" }
+            { "$ref": "#/components/schemas/Response_122" },
+            { "$ref": "#/components/schemas/Response_124" }
           ]
         },
         "manifestAutoDeployEnabled": { "type": "boolean" },
@@ -2553,37 +2584,15 @@
       },
       "required": ["effective", "manifestAutoDeployEnabled", "paused"]
     },
-    "Response_119": {
+    "Response_125": {
       "type": "object",
       "properties": {
-        "autoDeploy": { "$ref": "#/components/schemas/Response_120" },
+        "autoDeploy": { "$ref": "#/components/schemas/autoDeploy_126" },
         "canManageAutoDeploy": { "type": "boolean" }
       },
       "required": ["autoDeploy", "canManageAutoDeploy"]
     },
-    "autoDeploy_125": {
-      "type": "object",
-      "properties": {
-        "effective": {
-          "anyOf": [
-            { "$ref": "#/components/schemas/Response_121" },
-            { "$ref": "#/components/schemas/Response_123" }
-          ]
-        },
-        "manifestAutoDeployEnabled": { "type": "boolean" },
-        "paused": { "type": "boolean" }
-      },
-      "required": ["effective", "manifestAutoDeployEnabled", "paused"]
-    },
-    "Response_124": {
-      "type": "object",
-      "properties": {
-        "autoDeploy": { "$ref": "#/components/schemas/autoDeploy_125" },
-        "canManageAutoDeploy": { "type": "boolean" }
-      },
-      "required": ["autoDeploy", "canManageAutoDeploy"]
-    },
-    "Response_127": {
+    "Response_128": {
       "type": "object",
       "properties": {
         "appId": { "type": "string" },
@@ -2701,17 +2710,17 @@
         "updatedAt"
       ]
     },
-    "Response_126": {
+    "Response_127": {
       "type": "object",
       "properties": {
         "deployments": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_127" }
+          "items": { "$ref": "#/components/schemas/Response_128" }
         }
       },
       "required": ["deployments"]
     },
-    "Response_129": {
+    "Response_130": {
       "type": "object",
       "properties": {
         "id": { "type": "string" },
@@ -2776,17 +2785,17 @@
         "supersededAt"
       ]
     },
-    "Response_128": {
+    "Response_129": {
       "type": "object",
       "properties": {
         "releases": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_129" }
+          "items": { "$ref": "#/components/schemas/Response_130" }
         }
       },
       "required": ["releases"]
     },
-    "Response_131": {
+    "Response_132": {
       "type": "object",
       "properties": {
         "pullRequestUrl": { "type": "string" },
@@ -2845,17 +2854,17 @@
         "updatedAt"
       ]
     },
-    "Response_130": {
+    "Response_131": {
       "type": "object",
       "properties": {
         "previews": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_131" }
+          "items": { "$ref": "#/components/schemas/Response_132" }
         }
       },
       "required": ["previews"]
     },
-    "ResourceReleaseSnapshot_135": {
+    "ResourceReleaseSnapshot_136": {
       "type": "object",
       "properties": {
         "containerName": { "type": "string" },
@@ -2864,28 +2873,28 @@
       },
       "required": ["containerName", "imageTag", "releaseId"]
     },
-    "Response_134": {
+    "Response_135": {
       "type": "object",
       "properties": {
         "release": {
-          "$ref": "#/components/schemas/ResourceReleaseSnapshot_135"
+          "$ref": "#/components/schemas/ResourceReleaseSnapshot_136"
         },
         "type": { "type": "string", "const": "backup" }
       },
       "required": ["release", "type"]
     },
-    "Response_136": {
+    "Response_137": {
       "type": "object",
       "properties": {
         "release": {
-          "$ref": "#/components/schemas/ResourceReleaseSnapshot_135"
+          "$ref": "#/components/schemas/ResourceReleaseSnapshot_136"
         },
         "tail": { "type": "number" },
         "type": { "type": "string", "const": "capture_logs" }
       },
       "required": ["release", "tail", "type"]
     },
-    "Response_138": {
+    "Response_139": {
       "type": "object",
       "properties": {
         "kind": {
@@ -2900,46 +2909,46 @@
       },
       "required": ["kind", "name", "reason"]
     },
-    "Response_137": {
+    "Response_138": {
       "type": "object",
       "properties": {
         "items": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_138" }
+          "items": { "$ref": "#/components/schemas/Response_139" }
         },
         "type": { "type": "string", "const": "cleanup_orphans" }
       },
       "required": ["items", "type"]
     },
-    "Response_139": {
+    "Response_140": {
       "type": "object",
       "properties": {
         "backupId": { "type": "string" },
         "reason": { "type": "string" },
         "release": {
-          "$ref": "#/components/schemas/ResourceReleaseSnapshot_135"
+          "$ref": "#/components/schemas/ResourceReleaseSnapshot_136"
         },
         "type": { "type": "string", "const": "restore" }
       },
       "required": ["backupId", "reason", "release", "type"]
     },
-    "Response_140": {
+    "Response_141": {
       "type": "object",
       "properties": {
         "restoreId": { "type": "string" },
         "release": {
-          "$ref": "#/components/schemas/ResourceReleaseSnapshot_135"
+          "$ref": "#/components/schemas/ResourceReleaseSnapshot_136"
         },
         "type": { "type": "string", "const": "restore_cleanup" },
         "volumes": { "type": "array", "items": { "type": "string" } }
       },
       "required": ["restoreId", "release", "type", "volumes"]
     },
-    "Response_141": {
+    "Response_142": {
       "type": "object",
       "properties": {
         "release": {
-          "$ref": "#/components/schemas/ResourceReleaseSnapshot_135"
+          "$ref": "#/components/schemas/ResourceReleaseSnapshot_136"
         },
         "type": {
           "anyOf": [
@@ -2951,7 +2960,7 @@
       },
       "required": ["release", "type"]
     },
-    "BackupOperationResult_142": {
+    "BackupOperationResult_143": {
       "type": "object",
       "properties": {
         "backupId": { "type": "string" },
@@ -2998,35 +3007,27 @@
         "warnings"
       ]
     },
-    "Response_143": {
+    "Response_144": {
       "type": "object",
       "properties": {
         "cleaned": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_138" }
+          "items": { "$ref": "#/components/schemas/Response_139" }
         },
         "skipped": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_138" }
+          "items": { "$ref": "#/components/schemas/Response_139" }
         }
       },
       "required": ["cleaned", "skipped"]
     },
-    "Response_144": {
+    "Response_145": {
       "type": "object",
       "properties": {
         "logs": { "type": "string" },
         "truncated": { "type": "boolean" }
       },
       "required": ["logs", "truncated"]
-    },
-    "Response_146": {
-      "type": "object",
-      "properties": {
-        "logicalName": { "type": "string" },
-        "volumeName": { "type": "string" }
-      },
-      "required": ["logicalName", "volumeName"]
     },
     "Response_147": {
       "type": "object",
@@ -3037,6 +3038,14 @@
       "required": ["logicalName", "volumeName"]
     },
     "Response_148": {
+      "type": "object",
+      "properties": {
+        "logicalName": { "type": "string" },
+        "volumeName": { "type": "string" }
+      },
+      "required": ["logicalName", "volumeName"]
+    },
+    "Response_149": {
       "type": "object",
       "properties": {
         "databaseName": { "anyOf": [{ "type": "null" }, { "type": "string" }] },
@@ -3058,12 +3067,12 @@
         "readable"
       ]
     },
-    "Response_145": {
+    "Response_146": {
       "type": "object",
       "properties": {
         "activeVolumes": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_146" }
+          "items": { "$ref": "#/components/schemas/Response_147" }
         },
         "candidateCleaned": { "type": "boolean" },
         "outcome": {
@@ -3076,7 +3085,7 @@
         },
         "previousVolumes": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_147" }
+          "items": { "$ref": "#/components/schemas/Response_148" }
         },
         "restoredBackupId": { "type": "string" },
         "rollbackAvailableUntil": {
@@ -3085,7 +3094,7 @@
         "validation": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/Response_148" }
+            { "$ref": "#/components/schemas/Response_149" }
           ]
         },
         "verifiedAt": { "anyOf": [{ "type": "null" }, { "type": "string" }] }
@@ -3101,7 +3110,7 @@
         "verifiedAt"
       ]
     },
-    "Response_149": {
+    "Response_150": {
       "type": "object",
       "properties": {
         "cleanedVolumes": { "type": "array", "items": { "type": "string" } },
@@ -3110,7 +3119,7 @@
       },
       "required": ["cleanedVolumes", "restoreId", "skippedVolumes"]
     },
-    "Response_150": {
+    "Response_151": {
       "type": "object",
       "properties": {
         "state": {
@@ -3122,7 +3131,7 @@
       },
       "required": ["state"]
     },
-    "Response_133": {
+    "Response_134": {
       "type": "object",
       "properties": {
         "createdAt": { "type": "string", "format": "date-time" },
@@ -3170,24 +3179,24 @@
         },
         "request": {
           "anyOf": [
-            { "$ref": "#/components/schemas/Response_134" },
-            { "$ref": "#/components/schemas/Response_136" },
+            { "$ref": "#/components/schemas/Response_135" },
             { "$ref": "#/components/schemas/Response_137" },
-            { "$ref": "#/components/schemas/Response_139" },
+            { "$ref": "#/components/schemas/Response_138" },
             { "$ref": "#/components/schemas/Response_140" },
-            { "$ref": "#/components/schemas/Response_141" }
+            { "$ref": "#/components/schemas/Response_141" },
+            { "$ref": "#/components/schemas/Response_142" }
           ]
         },
         "resourceId": { "anyOf": [{ "type": "null" }, { "type": "string" }] },
         "result": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/BackupOperationResult_142" },
-            { "$ref": "#/components/schemas/Response_143" },
+            { "$ref": "#/components/schemas/BackupOperationResult_143" },
             { "$ref": "#/components/schemas/Response_144" },
             { "$ref": "#/components/schemas/Response_145" },
-            { "$ref": "#/components/schemas/Response_149" },
-            { "$ref": "#/components/schemas/Response_150" }
+            { "$ref": "#/components/schemas/Response_146" },
+            { "$ref": "#/components/schemas/Response_150" },
+            { "$ref": "#/components/schemas/Response_151" }
           ]
         },
         "serverId": { "type": "string" },
@@ -3242,28 +3251,20 @@
         "updatedAt"
       ]
     },
-    "Response_132": {
+    "Response_133": {
       "type": "object",
       "properties": {
         "operations": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_133" }
+          "items": { "$ref": "#/components/schemas/Response_134" }
         }
       },
       "required": ["operations"]
     },
-    "Response_151": {
-      "type": "object",
-      "properties": {
-        "deployment": { "$ref": "#/components/schemas/Response_127" },
-        "replayed": { "type": "boolean" }
-      },
-      "required": ["deployment", "replayed"]
-    },
     "Response_152": {
       "type": "object",
       "properties": {
-        "deployment": { "$ref": "#/components/schemas/Response_127" },
+        "deployment": { "$ref": "#/components/schemas/Response_128" },
         "replayed": { "type": "boolean" }
       },
       "required": ["deployment", "replayed"]
@@ -3271,12 +3272,20 @@
     "Response_153": {
       "type": "object",
       "properties": {
-        "operation": { "$ref": "#/components/schemas/Response_133" },
+        "deployment": { "$ref": "#/components/schemas/Response_128" },
+        "replayed": { "type": "boolean" }
+      },
+      "required": ["deployment", "replayed"]
+    },
+    "Response_154": {
+      "type": "object",
+      "properties": {
+        "operation": { "$ref": "#/components/schemas/Response_134" },
         "replayed": { "type": "boolean" }
       },
       "required": ["operation", "replayed"]
     },
-    "Response_155": {
+    "Response_156": {
       "type": "object",
       "properties": {
         "appId": { "type": "string" },
@@ -3404,17 +3413,17 @@
         "queueBlocker"
       ]
     },
-    "Response_154": {
+    "Response_155": {
       "type": "object",
       "properties": {
         "deployments": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_155" }
+          "items": { "$ref": "#/components/schemas/Response_156" }
         }
       },
       "required": ["deployments"]
     },
-    "Response_157": {
+    "Response_158": {
       "type": "object",
       "properties": {
         "deployableName": { "type": "string" },
@@ -3544,7 +3553,7 @@
         "queueBlocker"
       ]
     },
-    "Response_158": {
+    "Response_159": {
       "type": "object",
       "properties": {
         "limit": { "type": "number" },
@@ -3554,18 +3563,18 @@
       },
       "required": ["limit", "page", "total", "totalPages"]
     },
-    "Response_156": {
+    "Response_157": {
       "type": "object",
       "properties": {
         "deployments": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_157" }
+          "items": { "$ref": "#/components/schemas/Response_158" }
         },
-        "pagination": { "$ref": "#/components/schemas/Response_158" }
+        "pagination": { "$ref": "#/components/schemas/Response_159" }
       },
       "required": ["deployments", "pagination"]
     },
-    "Response_162": {
+    "Response_163": {
       "type": "object",
       "properties": {
         "critical": { "type": "number" },
@@ -3576,7 +3585,7 @@
       },
       "required": ["critical", "high", "low", "medium", "unknown"]
     },
-    "Response_161": {
+    "Response_162": {
       "type": "object",
       "properties": {
         "completedAt": {
@@ -3595,7 +3604,7 @@
         "scannerVersion": {
           "anyOf": [{ "type": "null" }, { "type": "string" }]
         },
-        "severityTotals": { "$ref": "#/components/schemas/Response_162" },
+        "severityTotals": { "$ref": "#/components/schemas/Response_163" },
         "startedAt": {
           "anyOf": [
             { "type": "null" },
@@ -3635,13 +3644,13 @@
         "vulnerabilityDatabaseUpdatedAt"
       ]
     },
-    "Response_160": {
+    "Response_161": {
       "type": "object",
       "properties": {
         "vulnerabilityScan": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/Response_161" }
+            { "$ref": "#/components/schemas/Response_162" }
           ]
         },
         "vulnerabilityScanningEnabled": { "type": "boolean" },
@@ -3772,14 +3781,14 @@
         "queueBlocker"
       ]
     },
-    "Response_159": {
+    "Response_160": {
       "type": "object",
       "properties": {
-        "deployment": { "$ref": "#/components/schemas/Response_160" }
+        "deployment": { "$ref": "#/components/schemas/Response_161" }
       },
       "required": ["deployment"]
     },
-    "Response_164": {
+    "Response_165": {
       "type": "object",
       "properties": {
         "createdAt": { "type": "string", "format": "date-time" },
@@ -3846,17 +3855,17 @@
         "status"
       ]
     },
-    "Response_163": {
+    "Response_164": {
       "type": "object",
       "properties": {
         "steps": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_164" }
+          "items": { "$ref": "#/components/schemas/Response_165" }
         }
       },
       "required": ["steps"]
     },
-    "Response_166": {
+    "Response_167": {
       "type": "object",
       "properties": {
         "content": { "type": "string" },
@@ -3867,17 +3876,17 @@
       },
       "required": ["content", "createdAt", "id", "sequence", "stream"]
     },
-    "Response_165": {
+    "Response_166": {
       "type": "object",
       "properties": {
         "logs": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_166" }
+          "items": { "$ref": "#/components/schemas/Response_167" }
         }
       },
       "required": ["logs"]
     },
-    "Response_168": {
+    "Response_169": {
       "type": "object",
       "properties": {
         "advisoryId": { "type": "string" },
@@ -3906,47 +3915,47 @@
         "target"
       ]
     },
-    "Response_167": {
+    "Response_168": {
       "type": "object",
       "properties": {
         "findings": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_168" }
+          "items": { "$ref": "#/components/schemas/Response_169" }
         }
       },
       "required": ["findings"]
     },
-    "Response_169": {
+    "Response_170": {
       "type": "object",
       "properties": {
-        "deployment": { "$ref": "#/components/schemas/Response_160" },
+        "deployment": { "$ref": "#/components/schemas/Response_161" },
         "logs": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_166" }
+          "items": { "$ref": "#/components/schemas/Response_167" }
         },
         "steps": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_164" }
+          "items": { "$ref": "#/components/schemas/Response_165" }
         }
       },
       "required": ["deployment", "logs", "steps"]
     },
-    "Response_170": {
-      "type": "object",
-      "properties": {
-        "deployment": { "$ref": "#/components/schemas/Response_127" }
-      },
-      "required": ["deployment"]
-    },
     "Response_171": {
       "type": "object",
       "properties": {
+        "deployment": { "$ref": "#/components/schemas/Response_128" }
+      },
+      "required": ["deployment"]
+    },
+    "Response_172": {
+      "type": "object",
+      "properties": {
         "replayed": { "type": "boolean" },
-        "scan": { "$ref": "#/components/schemas/Response_161" }
+        "scan": { "$ref": "#/components/schemas/Response_162" }
       },
       "required": ["replayed", "scan"]
     },
-    "Response_173": {
+    "Response_174": {
       "type": "object",
       "properties": {
         "accessKeyIdSuffix": { "type": "string" },
@@ -3980,40 +3989,40 @@
         "verificationMessage"
       ]
     },
-    "Response_172": {
+    "Response_173": {
       "type": "object",
       "properties": {
         "canManage": { "type": "boolean" },
         "credential": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/Response_173" }
+            { "$ref": "#/components/schemas/Response_174" }
           ]
         }
       },
       "required": ["canManage", "credential"]
     },
-    "Response_174": {
+    "Response_175": {
       "type": "object",
       "properties": {
         "credential": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/Response_173" }
+            { "$ref": "#/components/schemas/Response_174" }
           ]
         }
       },
       "required": ["credential"]
     },
-    "Response_177": {
+    "Response_178": {
       "type": "object",
       "properties": { "status": { "type": "string", "const": "unavailable" } },
       "required": ["status"]
     },
-    "Response_176": {
+    "Response_177": {
       "type": "object",
       "properties": {
-        "permissionReadiness": { "$ref": "#/components/schemas/Response_177" },
+        "permissionReadiness": { "$ref": "#/components/schemas/Response_178" },
         "accountLogin": { "type": "string" },
         "accountType": { "type": "string" },
         "id": { "type": "string" },
@@ -4036,7 +4045,7 @@
         "updatedAt"
       ]
     },
-    "Response_179": {
+    "Response_180": {
       "type": "object",
       "properties": {
         "status": { "type": "string", "const": "available" },
@@ -4076,10 +4085,10 @@
         "pullRequests"
       ]
     },
-    "Response_178": {
+    "Response_179": {
       "type": "object",
       "properties": {
-        "permissionReadiness": { "$ref": "#/components/schemas/Response_179" },
+        "permissionReadiness": { "$ref": "#/components/schemas/Response_180" },
         "accountLogin": { "type": "string" },
         "accountType": { "type": "string" },
         "id": { "type": "string" },
@@ -4102,7 +4111,7 @@
         "updatedAt"
       ]
     },
-    "Response_180": {
+    "Response_181": {
       "type": "object",
       "properties": {
         "failedCount": { "type": "number" },
@@ -4116,21 +4125,21 @@
       },
       "required": ["failedCount", "lastError", "lastFailedAt"]
     },
-    "Response_175": {
+    "Response_176": {
       "type": "object",
       "properties": {
         "connection": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/Response_176" },
-            { "$ref": "#/components/schemas/Response_178" }
+            { "$ref": "#/components/schemas/Response_177" },
+            { "$ref": "#/components/schemas/Response_179" }
           ]
         },
-        "previewReporting": { "$ref": "#/components/schemas/Response_180" }
+        "previewReporting": { "$ref": "#/components/schemas/Response_181" }
       },
       "required": ["connection", "previewReporting"]
     },
-    "Response_181": {
+    "Response_182": {
       "type": "object",
       "properties": {
         "attempted": { "type": "number" },
@@ -4139,24 +4148,24 @@
       },
       "required": ["attempted", "failed", "succeeded"]
     },
-    "Response_182": {
+    "Response_183": {
       "type": "object",
       "properties": { "url": { "type": "string" } },
       "required": ["url"]
     },
-    "Response_184": {
+    "Response_185": {
       "type": "object",
       "properties": { "id": { "type": "string" } },
       "required": ["id"]
     },
-    "Response_183": {
+    "Response_184": {
       "type": "object",
       "properties": {
-        "installation": { "$ref": "#/components/schemas/Response_184" }
+        "installation": { "$ref": "#/components/schemas/Response_185" }
       },
       "required": ["installation"]
     },
-    "Response_186": {
+    "Response_187": {
       "type": "object",
       "properties": {
         "defaultBranch": { "type": "string" },
@@ -4175,17 +4184,17 @@
         "private"
       ]
     },
-    "Response_185": {
+    "Response_186": {
       "type": "object",
       "properties": {
         "repositories": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_186" }
+          "items": { "$ref": "#/components/schemas/Response_187" }
         }
       },
       "required": ["repositories"]
     },
-    "Response_190": {
+    "Response_191": {
       "type": "object",
       "properties": {
         "provider": {
@@ -4204,13 +4213,13 @@
       },
       "required": ["provider", "type"]
     },
-    "ServerHardware_189": {
+    "ServerHardware_190": {
       "type": "object",
       "properties": {
         "instance": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/Response_190" }
+            { "$ref": "#/components/schemas/Response_191" }
           ]
         },
         "cpuCount": { "anyOf": [{ "type": "null" }, { "type": "number" }] },
@@ -4218,7 +4227,7 @@
       },
       "required": ["instance", "cpuCount", "memoryBytes"]
     },
-    "Response_192": {
+    "Response_193": {
       "type": "object",
       "properties": {
         "at": { "type": "string" },
@@ -4227,7 +4236,7 @@
       },
       "required": ["at", "cpuPercent", "memoryPercent"]
     },
-    "ServerMonitoringSummary_191": {
+    "ServerMonitoringSummary_192": {
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean" },
@@ -4239,7 +4248,7 @@
         "end": { "type": "string" },
         "points": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_192" }
+          "items": { "$ref": "#/components/schemas/Response_193" }
         }
       },
       "required": [
@@ -4251,16 +4260,17 @@
         "points"
       ]
     },
-    "Response_188": {
+    "Response_189": {
       "type": "object",
       "properties": {
+        "healthStatus": { "type": "string" },
         "hardware": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/ServerHardware_189" }
+            { "$ref": "#/components/schemas/ServerHardware_190" }
           ]
         },
-        "scout": { "$ref": "#/components/schemas/ServerMonitoringSummary_191" },
+        "scout": { "$ref": "#/components/schemas/ServerMonitoringSummary_192" },
         "setupStatus": {
           "anyOf": [
             { "type": "string", "const": "preparing" },
@@ -4270,19 +4280,28 @@
           ]
         }
       },
-      "required": ["hardware", "scout", "setupStatus"]
+      "required": ["healthStatus", "hardware", "scout", "setupStatus"]
     },
-    "Response_187": {
+    "Response_194": {
+      "type": "object",
+      "properties": {
+        "all": { "type": "number" },
+        "attention": { "type": "number" }
+      },
+      "required": ["all", "attention"]
+    },
+    "Response_188": {
       "type": "object",
       "properties": {
         "servers": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_188" }
-        }
+          "items": { "$ref": "#/components/schemas/Response_189" }
+        },
+        "counts": { "$ref": "#/components/schemas/Response_194" }
       },
-      "required": ["servers"]
+      "required": ["servers", "counts"]
     },
-    "Response_194": {
+    "Response_196": {
       "type": "object",
       "properties": {
         "setupStatus": {
@@ -4296,20 +4315,20 @@
       },
       "required": ["setupStatus"]
     },
-    "Response_193": {
+    "Response_195": {
       "type": "object",
       "properties": {
-        "server": { "$ref": "#/components/schemas/Response_194" }
+        "server": { "$ref": "#/components/schemas/Response_196" }
       },
       "required": ["server"]
     },
-    "Response_196": {
+    "Response_198": {
       "type": "object",
       "properties": {
         "hardware": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/ServerHardware_189" }
+            { "$ref": "#/components/schemas/ServerHardware_190" }
           ]
         },
         "setupStatus": {
@@ -4323,13 +4342,13 @@
       },
       "required": ["hardware", "setupStatus"]
     },
-    "Response_195": {
+    "Response_197": {
       "type": "object",
       "properties": {
         "canCleanupOrphans": { "type": "boolean" },
         "canManageServer": { "type": "boolean" },
         "canRemoveServer": { "type": "boolean" },
-        "server": { "$ref": "#/components/schemas/Response_196" }
+        "server": { "$ref": "#/components/schemas/Response_198" }
       },
       "required": [
         "canCleanupOrphans",
@@ -4338,14 +4357,14 @@
         "server"
       ]
     },
-    "Response_197": {
+    "Response_199": {
       "type": "object",
       "properties": {
-        "server": { "$ref": "#/components/schemas/Response_194" }
+        "server": { "$ref": "#/components/schemas/Response_196" }
       },
       "required": ["server"]
     },
-    "Response_200": {
+    "Response_202": {
       "type": "object",
       "properties": {
         "desiredState": {
@@ -4401,11 +4420,11 @@
         "observedImage"
       ]
     },
-    "Response_199": {
+    "Response_201": {
       "type": "object",
       "properties": {
         "serverReady": { "type": "boolean" },
-        "runtimeState": { "$ref": "#/components/schemas/Response_200" },
+        "runtimeState": { "$ref": "#/components/schemas/Response_202" },
         "archivedAt": {
           "anyOf": [
             { "type": "null" },
@@ -4453,37 +4472,37 @@
         "updatedAt"
       ]
     },
-    "Response_198": {
+    "Response_200": {
       "type": "object",
       "properties": {
         "apps": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_199" }
+          "items": { "$ref": "#/components/schemas/Response_201" }
         }
       },
       "required": ["apps"]
     },
-    "Response_201": {
+    "Response_203": {
       "type": "object",
       "properties": {
         "resources": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_199" }
+          "items": { "$ref": "#/components/schemas/Response_201" }
         }
       },
       "required": ["resources"]
     },
-    "Response_202": {
+    "Response_204": {
       "type": "object",
       "properties": {
         "deployments": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_127" }
+          "items": { "$ref": "#/components/schemas/Response_128" }
         }
       },
       "required": ["deployments"]
     },
-    "Response_205": {
+    "Response_207": {
       "type": "object",
       "properties": {
         "logicalCount": { "type": "number" },
@@ -4492,25 +4511,25 @@
       },
       "required": ["logicalCount", "loadAverage1m", "usagePercent"]
     },
-    "Response_206": {
-      "type": "object",
-      "properties": {
-        "availableBytes": { "type": "number" },
-        "totalBytes": { "type": "number" },
-        "usedPercent": { "type": "number" }
-      },
-      "required": ["availableBytes", "totalBytes", "usedPercent"]
-    },
-    "Response_207": {
-      "type": "object",
-      "properties": {
-        "availableBytes": { "type": "number" },
-        "totalBytes": { "type": "number" },
-        "usedPercent": { "type": "number" }
-      },
-      "required": ["availableBytes", "totalBytes", "usedPercent"]
-    },
     "Response_208": {
+      "type": "object",
+      "properties": {
+        "availableBytes": { "type": "number" },
+        "totalBytes": { "type": "number" },
+        "usedPercent": { "type": "number" }
+      },
+      "required": ["availableBytes", "totalBytes", "usedPercent"]
+    },
+    "Response_209": {
+      "type": "object",
+      "properties": {
+        "availableBytes": { "type": "number" },
+        "totalBytes": { "type": "number" },
+        "usedPercent": { "type": "number" }
+      },
+      "required": ["availableBytes", "totalBytes", "usedPercent"]
+    },
+    "Response_210": {
       "type": "object",
       "properties": {
         "cpuPercent": { "anyOf": [{ "type": "null" }, { "type": "number" }] },
@@ -4565,20 +4584,20 @@
         "startedAt"
       ]
     },
-    "RuntimeCapacity_204": {
+    "RuntimeCapacity_206": {
       "type": "object",
       "properties": {
         "checkedAt": { "anyOf": [{ "type": "null" }, { "type": "string" }] },
         "cpu": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/Response_205" }
+            { "$ref": "#/components/schemas/Response_207" }
           ]
         },
         "disk": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/Response_206" }
+            { "$ref": "#/components/schemas/Response_208" }
           ]
         },
         "id": { "type": "string" },
@@ -4595,12 +4614,12 @@
         "memory": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/Response_207" }
+            { "$ref": "#/components/schemas/Response_209" }
           ]
         },
         "runtimes": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_208" }
+          "items": { "$ref": "#/components/schemas/Response_210" }
         },
         "status": {
           "anyOf": [
@@ -4625,15 +4644,15 @@
         "uptimeSeconds"
       ]
     },
-    "Response_203": {
+    "Response_205": {
       "type": "object",
       "properties": {
-        "capacity": { "$ref": "#/components/schemas/RuntimeCapacity_204" }
+        "capacity": { "$ref": "#/components/schemas/RuntimeCapacity_206" }
       },
       "required": ["capacity"]
     },
-    "Record_211": { "type": "object", "additionalProperties": {} },
-    "Response_210": {
+    "Record_213": { "type": "object", "additionalProperties": {} },
+    "Response_212": {
       "type": "object",
       "properties": {
         "createdAt": { "type": "string", "format": "date-time" },
@@ -4649,7 +4668,7 @@
         "result": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/Record_211" }
+            { "$ref": "#/components/schemas/Record_213" }
           ]
         },
         "startedAt": {
@@ -4678,7 +4697,7 @@
         "status"
       ]
     },
-    "Response_212": {
+    "Response_214": {
       "type": "object",
       "properties": {
         "limit": { "type": "number" },
@@ -4688,24 +4707,24 @@
       },
       "required": ["limit", "page", "total", "totalPages"]
     },
-    "Response_209": {
+    "Response_211": {
       "type": "object",
       "properties": {
         "checks": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_210" }
+          "items": { "$ref": "#/components/schemas/Response_212" }
         },
         "latestCheck": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/Response_210" }
+            { "$ref": "#/components/schemas/Response_212" }
           ]
         },
-        "pagination": { "$ref": "#/components/schemas/Response_212" }
+        "pagination": { "$ref": "#/components/schemas/Response_214" }
       },
       "required": ["checks", "latestCheck", "pagination"]
     },
-    "ServerPreparationStep_215": {
+    "ServerPreparationStep_217": {
       "type": "object",
       "properties": {
         "finishedAt": { "anyOf": [{ "type": "null" }, { "type": "string" }] },
@@ -4741,7 +4760,7 @@
         "title"
       ]
     },
-    "Response_214": {
+    "Response_216": {
       "type": "object",
       "properties": {
         "createdAt": { "type": "string", "format": "date-time" },
@@ -4757,7 +4776,7 @@
         "result": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/Record_211" }
+            { "$ref": "#/components/schemas/Record_213" }
           ]
         },
         "startedAt": {
@@ -4776,7 +4795,7 @@
         },
         "steps": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/ServerPreparationStep_215" }
+          "items": { "$ref": "#/components/schemas/ServerPreparationStep_217" }
         }
       },
       "required": [
@@ -4791,27 +4810,27 @@
         "steps"
       ]
     },
-    "Response_213": {
+    "Response_215": {
       "type": "object",
       "properties": {
         "preparations": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_214" }
+          "items": { "$ref": "#/components/schemas/Response_216" }
         }
       },
       "required": ["preparations"]
     },
-    "Response_216": {
+    "Response_218": {
       "type": "object",
       "properties": {
         "orphans": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_138" }
+          "items": { "$ref": "#/components/schemas/Response_139" }
         }
       },
       "required": ["orphans"]
     },
-    "Response_218": {
+    "Response_220": {
       "type": "object",
       "properties": {
         "algorithm": { "type": "string" },
@@ -4821,17 +4840,17 @@
       },
       "required": ["algorithm", "createdAt", "fingerprint", "id"]
     },
-    "Response_217": {
+    "Response_219": {
       "type": "object",
       "properties": {
         "hostKeys": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_218" }
+          "items": { "$ref": "#/components/schemas/Response_220" }
         }
       },
       "required": ["hostKeys"]
     },
-    "Response_220": {
+    "Response_222": {
       "type": "object",
       "properties": {
         "createdAt": { "type": "string", "format": "date-time" },
@@ -4847,7 +4866,7 @@
         "result": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/Record_211" }
+            { "$ref": "#/components/schemas/Record_213" }
           ]
         },
         "startedAt": {
@@ -4876,14 +4895,14 @@
         "status"
       ]
     },
-    "Response_219": {
+    "Response_221": {
       "type": "object",
       "properties": {
-        "check": { "$ref": "#/components/schemas/Response_220" }
+        "check": { "$ref": "#/components/schemas/Response_222" }
       },
       "required": ["check"]
     },
-    "Response_222": {
+    "Response_224": {
       "type": "object",
       "properties": {
         "createdAt": { "type": "string", "format": "date-time" },
@@ -4899,7 +4918,7 @@
         "result": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/Record_211" }
+            { "$ref": "#/components/schemas/Record_213" }
           ]
         },
         "startedAt": {
@@ -4918,7 +4937,7 @@
         },
         "steps": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/ServerPreparationStep_215" }
+          "items": { "$ref": "#/components/schemas/ServerPreparationStep_217" }
         }
       },
       "required": [
@@ -4933,14 +4952,14 @@
         "steps"
       ]
     },
-    "Response_221": {
+    "Response_223": {
       "type": "object",
       "properties": {
-        "preparation": { "$ref": "#/components/schemas/Response_222" }
+        "preparation": { "$ref": "#/components/schemas/Response_224" }
       },
       "required": ["preparation"]
     },
-    "Response_224": {
+    "Response_226": {
       "type": "object",
       "properties": {
         "algorithm": { "type": "string" },
@@ -4949,50 +4968,51 @@
       },
       "required": ["algorithm", "fingerprint", "id"]
     },
-    "Response_223": {
+    "Response_225": {
       "type": "object",
       "properties": {
-        "hostKey": { "$ref": "#/components/schemas/Response_224" }
+        "hostKey": { "$ref": "#/components/schemas/Response_226" }
       },
       "required": ["hostKey"]
     },
-    "Response_225": {
+    "Response_227": {
       "type": "object",
       "properties": { "pending": { "type": "boolean" } },
       "required": ["pending"]
     },
-    "Response_226": {
+    "Response_228": {
       "type": "object",
       "properties": {
         "resources": {
           "type": "array",
           "items": { "$ref": "#/components/schemas/Response_90" }
-        }
+        },
+        "counts": { "$ref": "#/components/schemas/Response_116" }
       },
-      "required": ["resources"]
+      "required": ["resources", "counts"]
     },
-    "Response_227": {
+    "Response_229": {
       "type": "object",
       "properties": {
-        "resource": { "$ref": "#/components/schemas/Response_117" }
+        "resource": { "$ref": "#/components/schemas/Response_118" }
       },
       "required": ["resource"]
     },
-    "Response_228": {
+    "Response_230": {
       "type": "object",
       "properties": {
-        "autoDeploy": { "$ref": "#/components/schemas/Response_120" },
+        "autoDeploy": { "$ref": "#/components/schemas/Response_121" },
         "canManageAutoDeploy": { "type": "boolean" }
       },
       "required": ["autoDeploy", "canManageAutoDeploy"]
     },
-    "autoDeploy_230": {
+    "autoDeploy_232": {
       "type": "object",
       "properties": {
         "effective": {
           "anyOf": [
-            { "$ref": "#/components/schemas/Response_121" },
-            { "$ref": "#/components/schemas/Response_123" }
+            { "$ref": "#/components/schemas/Response_122" },
+            { "$ref": "#/components/schemas/Response_124" }
           ]
         },
         "manifestAutoDeployEnabled": { "type": "boolean" },
@@ -5000,45 +5020,45 @@
       },
       "required": ["effective", "manifestAutoDeployEnabled", "paused"]
     },
-    "Response_229": {
+    "Response_231": {
       "type": "object",
       "properties": {
-        "autoDeploy": { "$ref": "#/components/schemas/autoDeploy_230" },
+        "autoDeploy": { "$ref": "#/components/schemas/autoDeploy_232" },
         "canManageAutoDeploy": { "type": "boolean" }
       },
       "required": ["autoDeploy", "canManageAutoDeploy"]
     },
-    "Response_231": {
+    "Response_233": {
       "type": "object",
       "properties": {
         "deployments": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_127" }
+          "items": { "$ref": "#/components/schemas/Response_128" }
         }
       },
       "required": ["deployments"]
     },
-    "Response_232": {
+    "Response_234": {
       "type": "object",
       "properties": {
         "releases": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_129" }
+          "items": { "$ref": "#/components/schemas/Response_130" }
         }
       },
       "required": ["releases"]
     },
-    "Response_233": {
+    "Response_235": {
       "type": "object",
       "properties": {
         "operations": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_133" }
+          "items": { "$ref": "#/components/schemas/Response_134" }
         }
       },
       "required": ["operations"]
     },
-    "Response_236": {
+    "Response_238": {
       "type": "object",
       "properties": {
         "message": { "type": "string" },
@@ -5057,14 +5077,14 @@
       },
       "required": ["message", "name", "passed"]
     },
-    "Response_235": {
+    "Response_237": {
       "type": "object",
       "properties": {
         "backupOperationId": { "type": "string" },
         "checkedAt": { "type": "string", "format": "date-time" },
         "checks": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_236" }
+          "items": { "$ref": "#/components/schemas/Response_238" }
         },
         "resourceId": { "type": "string" },
         "restoreReady": { "type": "boolean" },
@@ -5088,25 +5108,25 @@
         "updatedAt"
       ]
     },
-    "Response_234": {
+    "Response_236": {
       "type": "object",
       "properties": {
         "assurance": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/Response_235" }
+            { "$ref": "#/components/schemas/Response_237" }
           ]
         },
         "assurances": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_235" }
+          "items": { "$ref": "#/components/schemas/Response_237" }
         },
         "awsConfigured": { "type": "boolean" },
         "canRestore": { "type": "boolean" }
       },
       "required": ["assurance", "assurances", "awsConfigured", "canRestore"]
     },
-    "Record_239": {
+    "Record_241": {
       "type": "object",
       "additionalProperties": {
         "anyOf": [
@@ -5117,7 +5137,7 @@
         ]
       }
     },
-    "Response_238": {
+    "Response_240": {
       "type": "object",
       "properties": {
         "command": { "anyOf": [{ "type": "null" }, { "type": "string" }] },
@@ -5131,7 +5151,7 @@
           ]
         },
         "message": { "type": "string" },
-        "metadata": { "$ref": "#/components/schemas/Record_239" },
+        "metadata": { "$ref": "#/components/schemas/Record_241" },
         "phase": {
           "anyOf": [
             { "type": "string", "const": "queued" },
@@ -5164,29 +5184,29 @@
         "sequence"
       ]
     },
-    "Response_237": {
+    "Response_239": {
       "type": "object",
       "properties": {
         "events": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_238" }
+          "items": { "$ref": "#/components/schemas/Response_240" }
         }
       },
       "required": ["events"]
     },
-    "Response_240": {
+    "Response_242": {
       "type": "object",
       "properties": {
-        "operation": { "$ref": "#/components/schemas/Response_133" }
+        "operation": { "$ref": "#/components/schemas/Response_134" }
       },
       "required": ["operation"]
     },
-    "Response_241": {
+    "Response_243": {
       "type": "object",
       "properties": { "accepted": { "type": "boolean" } },
       "required": ["accepted"]
     },
-    "Response_242": {
+    "Response_244": {
       "type": "object",
       "properties": {
         "accepted": { "type": "boolean" },
@@ -5194,53 +5214,11 @@
       },
       "required": ["accepted", "deploymentId"]
     },
-    "Response_244": {
-      "type": "object",
-      "properties": {
-        "branch": { "type": "string" },
-        "createdAt": { "type": "string", "format": "date-time" },
-        "id": { "type": "string" },
-        "latestCommitSha": {
-          "anyOf": [{ "type": "null" }, { "type": "string" }]
-        },
-        "latestManifestDigest": {
-          "anyOf": [{ "type": "null" }, { "type": "string" }]
-        },
-        "repositoryName": { "type": "string" },
-        "repositoryOwner": { "type": "string" },
-        "status": {
-          "anyOf": [
-            { "type": "string", "const": "active" },
-            { "type": "string", "const": "archived" }
-          ]
-        },
-        "updatedAt": { "type": "string", "format": "date-time" }
-      },
-      "required": [
-        "branch",
-        "createdAt",
-        "id",
-        "latestCommitSha",
-        "latestManifestDigest",
-        "repositoryName",
-        "repositoryOwner",
-        "status",
-        "updatedAt"
-      ]
-    },
-    "Response_243": {
-      "type": "object",
-      "properties": {
-        "sources": {
-          "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_244" }
-        }
-      },
-      "required": ["sources"]
-    },
     "Response_246": {
       "type": "object",
       "properties": {
+        "latestSyncStatus": { "type": "string" },
+        "autoDeployPaused": { "type": "boolean" },
         "branch": { "type": "string" },
         "createdAt": { "type": "string", "format": "date-time" },
         "id": { "type": "string" },
@@ -5261,6 +5239,8 @@
         "updatedAt": { "type": "string", "format": "date-time" }
       },
       "required": [
+        "latestSyncStatus",
+        "autoDeployPaused",
         "branch",
         "createdAt",
         "id",
@@ -5271,23 +5251,110 @@
         "status",
         "updatedAt"
       ]
-    },
-    "Response_245": {
-      "type": "object",
-      "properties": {
-        "source": { "$ref": "#/components/schemas/Response_246" }
-      },
-      "required": ["source"]
     },
     "Response_247": {
       "type": "object",
       "properties": {
+        "all": { "type": "number" },
+        "attention": { "type": "number" }
+      },
+      "required": ["all", "attention"]
+    },
+    "Response_245": {
+      "type": "object",
+      "properties": {
+        "sources": {
+          "type": "array",
+          "items": { "$ref": "#/components/schemas/Response_246" }
+        },
+        "counts": { "$ref": "#/components/schemas/Response_247" }
+      },
+      "required": ["sources", "counts"]
+    },
+    "Response_249": {
+      "type": "object",
+      "properties": {
+        "branch": { "type": "string" },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "id": { "type": "string" },
+        "latestCommitSha": {
+          "anyOf": [{ "type": "null" }, { "type": "string" }]
+        },
+        "latestManifestDigest": {
+          "anyOf": [{ "type": "null" }, { "type": "string" }]
+        },
+        "repositoryName": { "type": "string" },
+        "repositoryOwner": { "type": "string" },
+        "status": {
+          "anyOf": [
+            { "type": "string", "const": "active" },
+            { "type": "string", "const": "archived" }
+          ]
+        },
+        "updatedAt": { "type": "string", "format": "date-time" }
+      },
+      "required": [
+        "branch",
+        "createdAt",
+        "id",
+        "latestCommitSha",
+        "latestManifestDigest",
+        "repositoryName",
+        "repositoryOwner",
+        "status",
+        "updatedAt"
+      ]
+    },
+    "Response_248": {
+      "type": "object",
+      "properties": {
+        "source": { "$ref": "#/components/schemas/Response_249" }
+      },
+      "required": ["source"]
+    },
+    "Response_251": {
+      "type": "object",
+      "properties": {
+        "branch": { "type": "string" },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "id": { "type": "string" },
+        "latestCommitSha": {
+          "anyOf": [{ "type": "null" }, { "type": "string" }]
+        },
+        "latestManifestDigest": {
+          "anyOf": [{ "type": "null" }, { "type": "string" }]
+        },
+        "repositoryName": { "type": "string" },
+        "repositoryOwner": { "type": "string" },
+        "status": {
+          "anyOf": [
+            { "type": "string", "const": "active" },
+            { "type": "string", "const": "archived" }
+          ]
+        },
+        "updatedAt": { "type": "string", "format": "date-time" }
+      },
+      "required": [
+        "branch",
+        "createdAt",
+        "id",
+        "latestCommitSha",
+        "latestManifestDigest",
+        "repositoryName",
+        "repositoryOwner",
+        "status",
+        "updatedAt"
+      ]
+    },
+    "Response_250": {
+      "type": "object",
+      "properties": {
         "canManageSource": { "type": "boolean" },
-        "source": { "$ref": "#/components/schemas/Response_244" }
+        "source": { "$ref": "#/components/schemas/Response_251" }
       },
       "required": ["canManageSource", "source"]
     },
-    "Response_250": {
+    "Response_254": {
       "type": "object",
       "properties": {
         "pending": { "type": "null" },
@@ -5296,7 +5363,7 @@
       },
       "required": ["pending", "paused", "scope"]
     },
-    "Response_251": {
+    "Response_255": {
       "type": "object",
       "properties": {
         "pending": { "type": "null" },
@@ -5310,34 +5377,13 @@
       },
       "required": ["pending", "paused", "scope"]
     },
-    "Response_249": {
+    "Response_253": {
       "type": "object",
       "properties": {
         "effective": {
           "anyOf": [
-            { "$ref": "#/components/schemas/Response_250" },
-            { "$ref": "#/components/schemas/Response_251" }
-          ]
-        },
-        "paused": { "type": "boolean" }
-      },
-      "required": ["effective", "paused"]
-    },
-    "Response_248": {
-      "type": "object",
-      "properties": {
-        "autoDeploy": { "$ref": "#/components/schemas/Response_249" },
-        "canManageAutoDeploy": { "type": "boolean" }
-      },
-      "required": ["autoDeploy", "canManageAutoDeploy"]
-    },
-    "autoDeploy_253": {
-      "type": "object",
-      "properties": {
-        "effective": {
-          "anyOf": [
-            { "$ref": "#/components/schemas/Response_250" },
-            { "$ref": "#/components/schemas/Response_251" }
+            { "$ref": "#/components/schemas/Response_254" },
+            { "$ref": "#/components/schemas/Response_255" }
           ]
         },
         "paused": { "type": "boolean" }
@@ -5347,12 +5393,33 @@
     "Response_252": {
       "type": "object",
       "properties": {
-        "autoDeploy": { "$ref": "#/components/schemas/autoDeploy_253" },
+        "autoDeploy": { "$ref": "#/components/schemas/Response_253" },
         "canManageAutoDeploy": { "type": "boolean" }
       },
       "required": ["autoDeploy", "canManageAutoDeploy"]
     },
-    "Response_254": {
+    "autoDeploy_257": {
+      "type": "object",
+      "properties": {
+        "effective": {
+          "anyOf": [
+            { "$ref": "#/components/schemas/Response_254" },
+            { "$ref": "#/components/schemas/Response_255" }
+          ]
+        },
+        "paused": { "type": "boolean" }
+      },
+      "required": ["effective", "paused"]
+    },
+    "Response_256": {
+      "type": "object",
+      "properties": {
+        "autoDeploy": { "$ref": "#/components/schemas/autoDeploy_257" },
+        "canManageAutoDeploy": { "type": "boolean" }
+      },
+      "required": ["autoDeploy", "canManageAutoDeploy"]
+    },
+    "Response_258": {
       "type": "object",
       "properties": {
         "apps": {
@@ -5362,7 +5429,7 @@
       },
       "required": ["apps"]
     },
-    "Response_255": {
+    "Response_259": {
       "type": "object",
       "properties": {
         "resources": {
@@ -5372,27 +5439,27 @@
       },
       "required": ["resources"]
     },
-    "Response_256": {
+    "Response_260": {
       "type": "object",
       "properties": {
         "capacities": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/RuntimeCapacity_204" }
+          "items": { "$ref": "#/components/schemas/RuntimeCapacity_206" }
         }
       },
       "required": ["capacities"]
     },
-    "Response_257": {
+    "Response_261": {
       "type": "object",
       "properties": {
         "deployments": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_155" }
+          "items": { "$ref": "#/components/schemas/Response_156" }
         }
       },
       "required": ["deployments"]
     },
-    "Response_259": {
+    "Response_263": {
       "type": "object",
       "properties": {
         "resourceKind": {
@@ -5450,24 +5517,24 @@
         },
         "request": {
           "anyOf": [
-            { "$ref": "#/components/schemas/Response_134" },
-            { "$ref": "#/components/schemas/Response_136" },
+            { "$ref": "#/components/schemas/Response_135" },
             { "$ref": "#/components/schemas/Response_137" },
-            { "$ref": "#/components/schemas/Response_139" },
+            { "$ref": "#/components/schemas/Response_138" },
             { "$ref": "#/components/schemas/Response_140" },
-            { "$ref": "#/components/schemas/Response_141" }
+            { "$ref": "#/components/schemas/Response_141" },
+            { "$ref": "#/components/schemas/Response_142" }
           ]
         },
         "resourceId": { "anyOf": [{ "type": "null" }, { "type": "string" }] },
         "result": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/BackupOperationResult_142" },
-            { "$ref": "#/components/schemas/Response_143" },
+            { "$ref": "#/components/schemas/BackupOperationResult_143" },
             { "$ref": "#/components/schemas/Response_144" },
             { "$ref": "#/components/schemas/Response_145" },
-            { "$ref": "#/components/schemas/Response_149" },
-            { "$ref": "#/components/schemas/Response_150" }
+            { "$ref": "#/components/schemas/Response_146" },
+            { "$ref": "#/components/schemas/Response_150" },
+            { "$ref": "#/components/schemas/Response_151" }
           ]
         },
         "serverId": { "type": "string" },
@@ -5525,32 +5592,32 @@
         "updatedAt"
       ]
     },
-    "Response_258": {
+    "Response_262": {
       "type": "object",
       "properties": {
         "backups": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_259" }
+          "items": { "$ref": "#/components/schemas/Response_263" }
         }
       },
       "required": ["backups"]
     },
-    "Response_260": {
+    "Response_264": {
       "type": "object",
       "properties": {
         "previews": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_131" }
+          "items": { "$ref": "#/components/schemas/Response_132" }
         }
       },
       "required": ["previews"]
     },
-    "Response_264": {
+    "Response_268": {
       "type": "object",
       "properties": { "branch": { "type": "string" } },
       "required": ["branch"]
     },
-    "NormalizedDeploymentManifest_263": {
+    "NormalizedDeploymentManifest_267": {
       "type": "object",
       "properties": {
         "apps": {
@@ -5561,19 +5628,19 @@
           "type": "array",
           "items": { "$ref": "#/components/schemas/NormalizedResource_102" }
         },
-        "source": { "$ref": "#/components/schemas/Response_264" },
+        "source": { "$ref": "#/components/schemas/Response_268" },
         "version": { "type": "number", "const": 1 }
       },
       "required": ["apps", "source", "version"]
     },
-    "Response_262": {
+    "Response_266": {
       "type": "object",
       "properties": {
         "commitSha": { "anyOf": [{ "type": "null" }, { "type": "string" }] },
         "manifest": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/NormalizedDeploymentManifest_263" }
+            { "$ref": "#/components/schemas/NormalizedDeploymentManifest_267" }
           ]
         },
         "manifestDigest": {
@@ -5583,19 +5650,19 @@
       },
       "required": ["commitSha", "manifest", "manifestDigest", "rawManifest"]
     },
-    "Response_261": {
+    "Response_265": {
       "type": "object",
       "properties": {
         "manifest": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/Response_262" }
+            { "$ref": "#/components/schemas/Response_266" }
           ]
         }
       },
       "required": ["manifest"]
     },
-    "MaterializedManifestEntity_268": {
+    "MaterializedManifestEntity_272": {
       "type": "object",
       "properties": {
         "archivedAt": {
@@ -5611,7 +5678,7 @@
       },
       "required": ["archivedAt", "config", "configDigest", "id", "identity"]
     },
-    "ReconciliationAction_267": {
+    "ReconciliationAction_271": {
       "type": "object",
       "properties": {
         "action": {
@@ -5624,14 +5691,14 @@
           ]
         },
         "current": {
-          "$ref": "#/components/schemas/MaterializedManifestEntity_268"
+          "$ref": "#/components/schemas/MaterializedManifestEntity_272"
         },
         "desired": { "$ref": "#/components/schemas/NormalizedApp_92" },
         "id": { "type": "string" }
       },
       "required": ["action", "id"]
     },
-    "MaterializedManifestEntity_270": {
+    "MaterializedManifestEntity_274": {
       "type": "object",
       "properties": {
         "archivedAt": {
@@ -5647,7 +5714,7 @@
       },
       "required": ["archivedAt", "config", "configDigest", "id", "identity"]
     },
-    "ReconciliationAction_269": {
+    "ReconciliationAction_273": {
       "type": "object",
       "properties": {
         "action": {
@@ -5660,54 +5727,54 @@
           ]
         },
         "current": {
-          "$ref": "#/components/schemas/MaterializedManifestEntity_270"
+          "$ref": "#/components/schemas/MaterializedManifestEntity_274"
         },
         "desired": { "$ref": "#/components/schemas/NormalizedResource_102" },
         "id": { "type": "string" }
       },
       "required": ["action", "id"]
     },
-    "Record_271": { "type": "object" },
-    "ManifestReconciliation_266": {
+    "Record_275": { "type": "object" },
+    "ManifestReconciliation_270": {
       "type": "object",
       "properties": {
         "apps": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/ReconciliationAction_267" }
+          "items": { "$ref": "#/components/schemas/ReconciliationAction_271" }
         },
         "resources": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/ReconciliationAction_269" }
+          "items": { "$ref": "#/components/schemas/ReconciliationAction_273" }
         },
-        "summary": { "$ref": "#/components/schemas/Record_271" }
+        "summary": { "$ref": "#/components/schemas/Record_275" }
       },
       "required": ["apps", "resources", "summary"]
     },
-    "Response_265": {
+    "Response_269": {
       "type": "object",
       "properties": {
         "commitSha": { "type": "string" },
         "manifest": {
-          "$ref": "#/components/schemas/NormalizedDeploymentManifest_263"
+          "$ref": "#/components/schemas/NormalizedDeploymentManifest_267"
         },
         "manifestDigest": { "type": "string" },
         "reconciliation": {
-          "$ref": "#/components/schemas/ManifestReconciliation_266"
+          "$ref": "#/components/schemas/ManifestReconciliation_270"
         }
       },
       "required": ["commitSha", "manifest", "manifestDigest", "reconciliation"]
     },
-    "Response_273": {
+    "Response_277": {
       "type": "object",
       "properties": { "id": { "type": "string" } },
       "required": ["id"]
     },
-    "Response_272": {
+    "Response_276": {
       "type": "object",
-      "properties": { "sync": { "$ref": "#/components/schemas/Response_273" } },
+      "properties": { "sync": { "$ref": "#/components/schemas/Response_277" } },
       "required": ["sync"]
     },
-    "ManifestIssue_276": {
+    "ManifestIssue_280": {
       "type": "object",
       "properties": {
         "column": { "type": "number" },
@@ -5720,7 +5787,7 @@
       },
       "required": ["message", "path"]
     },
-    "Response_275": {
+    "Response_279": {
       "type": "object",
       "properties": {
         "commitSha": { "anyOf": [{ "type": "null" }, { "type": "string" }] },
@@ -5737,7 +5804,7 @@
             { "type": "null" },
             {
               "type": "array",
-              "items": { "$ref": "#/components/schemas/ManifestIssue_276" }
+              "items": { "$ref": "#/components/schemas/ManifestIssue_280" }
             }
           ]
         },
@@ -5747,7 +5814,7 @@
         "reconciliation": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/ManifestReconciliation_266" }
+            { "$ref": "#/components/schemas/ManifestReconciliation_270" }
           ]
         },
         "startedAt": {
@@ -5777,22 +5844,22 @@
         "status"
       ]
     },
-    "Response_274": {
+    "Response_278": {
       "type": "object",
       "properties": {
         "syncs": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_275" }
+          "items": { "$ref": "#/components/schemas/Response_279" }
         }
       },
       "required": ["syncs"]
     },
-    "Response_277": {
+    "Response_281": {
       "type": "object",
-      "properties": { "sync": { "$ref": "#/components/schemas/Response_275" } },
+      "properties": { "sync": { "$ref": "#/components/schemas/Response_279" } },
       "required": ["sync"]
     },
-    "SystemHealthCheck_279": {
+    "SystemHealthCheck_283": {
       "type": "object",
       "properties": {
         "checkedAt": { "anyOf": [{ "type": "null" }, { "type": "string" }] },
@@ -5832,13 +5899,13 @@
         "title"
       ]
     },
-    "SystemHealth_278": {
+    "SystemHealth_282": {
       "type": "object",
       "properties": {
         "checkedAt": { "type": "string" },
         "checks": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/SystemHealthCheck_279" }
+          "items": { "$ref": "#/components/schemas/SystemHealthCheck_283" }
         },
         "status": {
           "anyOf": [
@@ -5852,7 +5919,7 @@
       },
       "required": ["checkedAt", "checks", "status", "version"]
     },
-    "Response_281": {
+    "Response_285": {
       "type": "object",
       "properties": {
         "categories": {
@@ -5899,19 +5966,19 @@
         "updatedAt"
       ]
     },
-    "Response_280": {
+    "Response_284": {
       "type": "object",
       "properties": {
         "canManageNotifications": { "type": "boolean" },
         "destinations": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_281" }
+          "items": { "$ref": "#/components/schemas/Response_285" }
         },
         "providers": { "$ref": "#/components/schemas/Response_41" }
       },
       "required": ["canManageNotifications", "destinations", "providers"]
     },
-    "Response_283": {
+    "Response_287": {
       "type": "object",
       "properties": {
         "categories": {
@@ -5958,21 +6025,21 @@
         "updatedAt"
       ]
     },
-    "Response_282": {
-      "type": "object",
-      "properties": {
-        "destination": { "$ref": "#/components/schemas/Response_283" }
-      },
-      "required": ["destination"]
-    },
-    "Response_284": {
-      "type": "object",
-      "properties": {
-        "destination": { "$ref": "#/components/schemas/Response_281" }
-      },
-      "required": ["destination"]
-    },
     "Response_286": {
+      "type": "object",
+      "properties": {
+        "destination": { "$ref": "#/components/schemas/Response_287" }
+      },
+      "required": ["destination"]
+    },
+    "Response_288": {
+      "type": "object",
+      "properties": {
+        "destination": { "$ref": "#/components/schemas/Response_285" }
+      },
+      "required": ["destination"]
+    },
+    "Response_290": {
       "type": "object",
       "properties": {
         "cycle": { "type": "number" },
@@ -5980,21 +6047,21 @@
       },
       "required": ["cycle", "id"]
     },
-    "Response_285": {
+    "Response_289": {
       "type": "object",
       "properties": {
-        "delivery": { "$ref": "#/components/schemas/Response_286" }
+        "delivery": { "$ref": "#/components/schemas/Response_290" }
       },
       "required": ["delivery"]
     },
-    "Response_287": {
+    "Response_291": {
       "type": "object",
       "properties": {
         "providers": { "$ref": "#/components/schemas/Response_41" }
       },
       "required": ["providers"]
     },
-    "Response_291": {
+    "Response_295": {
       "type": "object",
       "properties": {
         "id": { "type": "string" },
@@ -6015,7 +6082,7 @@
       },
       "required": ["id", "kind", "name"]
     },
-    "Response_292": {
+    "Response_296": {
       "type": "object",
       "properties": {
         "id": { "type": "string" },
@@ -6023,17 +6090,17 @@
       },
       "required": ["id", "name"]
     },
-    "Response_290": {
+    "Response_294": {
       "type": "object",
       "properties": {
-        "details": { "$ref": "#/components/schemas/Record_239" },
-        "entity": { "$ref": "#/components/schemas/Response_291" },
+        "details": { "$ref": "#/components/schemas/Record_241" },
+        "entity": { "$ref": "#/components/schemas/Response_295" },
         "message": { "type": "string" },
         "occurredAt": { "type": "string" },
         "source": {
           "anyOf": [
             { "type": "null" },
-            { "$ref": "#/components/schemas/Response_292" }
+            { "$ref": "#/components/schemas/Response_296" }
           ]
         },
         "title": { "type": "string" }
@@ -6047,7 +6114,7 @@
         "title"
       ]
     },
-    "Response_289": {
+    "Response_293": {
       "type": "object",
       "properties": {
         "category": {
@@ -6064,7 +6131,7 @@
         "createdAt": { "type": "string", "format": "date-time" },
         "id": { "type": "string" },
         "occurredAt": { "type": "string", "format": "date-time" },
-        "payload": { "$ref": "#/components/schemas/Response_290" },
+        "payload": { "$ref": "#/components/schemas/Response_294" },
         "type": {
           "anyOf": [
             { "type": "string", "const": "deployment.queued" },
@@ -6102,12 +6169,12 @@
         "type"
       ]
     },
-    "Response_288": {
+    "Response_292": {
       "type": "object",
       "properties": {
         "notifications": {
           "type": "array",
-          "items": { "$ref": "#/components/schemas/Response_289" }
+          "items": { "$ref": "#/components/schemas/Response_293" }
         }
       },
       "required": ["notifications"]

--- a/apps/towbar-api/src/areas/inventory/integration-tests.ts
+++ b/apps/towbar-api/src/areas/inventory/integration-tests.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import type { TestContext } from "node:test";
+import type { getTowbarDatabase } from "../../infrastructure/database.js";
+
+export async function testInventory({
+  t,
+  db,
+  workspaceId,
+  otherWorkspaceId,
+  sourceId,
+  serverId,
+}: {
+  t: TestContext;
+  db: ReturnType<typeof getTowbarDatabase>;
+  workspaceId: string;
+  otherWorkspaceId: string;
+  sourceId: string;
+  serverId: string;
+}) {
+  await t.test(
+    "inventory latest statuses and counts stay workspace scoped",
+    async () => {
+      const { serverChecks, sourceSyncs } =
+        await import("@workspace/towbar-database/schema");
+      const { listSources } = await import("../sources/service.js");
+      const { listServers } = await import("../servers/service.js");
+      const { listApps } = await import("../apps/service.js");
+      const {
+        filterSources,
+        sourceFilters,
+        filterServers,
+        serverFilters,
+        filterWorkloads,
+        workloadFilters,
+      } = await import("@workspace/towbar-core/inventory");
+      const checkId = randomUUID();
+      const syncId = randomUUID();
+      try {
+        await db.insert(serverChecks).values({
+          id: checkId,
+          serverId,
+          status: "failed",
+          createdAt: new Date("2099-01-01"),
+        });
+        await db.insert(sourceSyncs).values({
+          id: syncId,
+          sourceId,
+          status: "failed",
+          createdAt: new Date("2099-01-01"),
+        });
+        const filteredSources = filterSources(
+          await listSources(workspaceId),
+          sourceFilters.parse({ sync: "failed", view: "attention" }),
+        );
+        assert(filteredSources.items.some((item) => item.id === sourceId));
+        const filteredServers = filterServers(
+          await listServers(workspaceId),
+          serverFilters.parse({ health: "unhealthy" }),
+        );
+        assert(filteredServers.items.some((item) => item.id === serverId));
+        assert(
+          !(await listSources(otherWorkspaceId)).some(
+            (item) => item.id === sourceId,
+          ),
+        );
+        assert(
+          !(await listServers(otherWorkspaceId)).some(
+            (item) => item.id === serverId,
+          ),
+        );
+        assert.equal(
+          filterWorkloads(
+            await listApps(otherWorkspaceId),
+            workloadFilters.parse({ sourceId }),
+          ).items.length,
+          0,
+        );
+      } finally {
+        await db.delete(serverChecks).where(eq(serverChecks.id, checkId));
+        await db.delete(sourceSyncs).where(eq(sourceSyncs.id, syncId));
+      }
+    },
+  );
+}

--- a/apps/towbar-api/src/areas/secrets/store.integration.test.ts
+++ b/apps/towbar-api/src/areas/secrets/store.integration.test.ts
@@ -396,6 +396,16 @@ void test(
         resourceConfig: manifest.resources![0]!,
         serverConfig,
       });
+      const { testInventory } =
+        await import("../inventory/integration-tests.js");
+      await testInventory({
+        t,
+        db,
+        workspaceId,
+        otherWorkspaceId,
+        sourceId,
+        serverId,
+      });
       const { testManagedSecretExecution } =
         await import("./execution-tests.js");
       await testManagedSecretExecution({

--- a/apps/towbar-api/src/areas/secrets/store.integration.test.ts
+++ b/apps/towbar-api/src/areas/secrets/store.integration.test.ts
@@ -381,6 +381,21 @@ void test(
           requestWorkspace = id;
         },
       });
+      const { testDeploymentHistory } =
+        await import("../deployments/history-tests.js");
+      await testDeploymentHistory({
+        t,
+        db,
+        workspaceId,
+        otherWorkspaceId,
+        sourceId,
+        appId,
+        serverId,
+        actorUserId,
+        appConfig,
+        resourceConfig: manifest.resources![0]!,
+        serverConfig,
+      });
       const { testManagedSecretExecution } =
         await import("./execution-tests.js");
       await testManagedSecretExecution({

--- a/apps/towbar-api/src/areas/servers/service.ts
+++ b/apps/towbar-api/src/areas/servers/service.ts
@@ -69,8 +69,33 @@ export async function listServers(workspaceId: string) {
     getServerHardware(ids),
     getServerMonitoringSummaries(workspaceId),
   ]);
+  const checks = ids.length
+    ? await database
+        .selectDistinctOn([serverChecks.serverId], {
+          serverId: serverChecks.serverId,
+          status: serverChecks.status,
+        })
+        .from(serverChecks)
+        .where(inArray(serverChecks.serverId, ids))
+        .orderBy(
+          serverChecks.serverId,
+          desc(serverChecks.createdAt),
+          desc(serverChecks.id),
+        )
+    : [];
+  const health = new Map(
+    checks.map((check) => [
+      check.serverId,
+      check.status === "succeeded"
+        ? "healthy"
+        : check.status === "failed"
+          ? "unhealthy"
+          : "unknown",
+    ]),
+  );
   return rows.map((server) => ({
     ...toPublicServer(server, latestPreparations.get(server.id)),
+    healthStatus: health.get(server.id) ?? "unknown",
     hardware: hardware.get(server.id) ?? null,
     scout: scout.get(server.id),
   }));

--- a/apps/towbar-api/src/areas/sources/service.ts
+++ b/apps/towbar-api/src/areas/sources/service.ts
@@ -44,11 +44,35 @@ import { resolveWorkspaceServers } from "../servers/references.js";
 import type { ManifestIssue } from "@workspace/towbar-core";
 
 export async function listSources(workspaceId: string) {
-  return await getTowbarDatabase()
-    .select(publicSourceSelection)
+  const database = getTowbarDatabase();
+  const rows = await database
+    .select({
+      ...publicSourceSelection,
+      autoDeployPaused: sources.autoDeployPaused,
+    })
     .from(sources)
     .where(eq(sources.workspaceId, workspaceId))
     .orderBy(desc(sources.updatedAt));
+  const ids = rows.map((source) => source.id);
+  const syncs = ids.length
+    ? await database
+        .selectDistinctOn([sourceSyncs.sourceId], {
+          sourceId: sourceSyncs.sourceId,
+          status: sourceSyncs.status,
+        })
+        .from(sourceSyncs)
+        .where(inArray(sourceSyncs.sourceId, ids))
+        .orderBy(
+          sourceSyncs.sourceId,
+          desc(sourceSyncs.createdAt),
+          desc(sourceSyncs.id),
+        )
+    : [];
+  const statuses = new Map(syncs.map((sync) => [sync.sourceId, sync.status]));
+  return rows.map((source) => ({
+    ...source,
+    latestSyncStatus: statuses.get(source.id) ?? "never",
+  }));
 }
 
 export async function createSource(input: {

--- a/apps/towbar-api/src/routes/v1/core/apps.ts
+++ b/apps/towbar-api/src/routes/v1/core/apps.ts
@@ -1,3 +1,7 @@
+import {
+  filterWorkloads,
+  workloadFilters,
+} from "@workspace/towbar-core/inventory";
 import { operation } from "../../../http/operation.js";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -38,12 +42,18 @@ appRoutes.get(
   "/",
   operation({
     responseSchema: 'apps.ts:get:"/"',
+    query: workloadFilters,
     summary: "List apps",
     response: "JSON object containing apps.",
     status: 200,
   }),
-  async (context) =>
-    context.json({ apps: await listApps(context.get("user").workspaceId) }),
+  async (context) => {
+    const result = filterWorkloads(
+      await listApps(context.get("user").workspaceId),
+      workloadFilters.parse(context.req.query()),
+    );
+    return context.json({ apps: result.items, counts: result.counts });
+  },
 );
 
 appRoutes.get(

--- a/apps/towbar-api/src/routes/v1/core/deployments.ts
+++ b/apps/towbar-api/src/routes/v1/core/deployments.ts
@@ -20,12 +20,7 @@ import { badRequest, forbidden } from "../../../http/errors.js";
 
 import type { TowbarHonoEnvironment } from "../../../http/types.js";
 
-const historyQuerySchema = z
-  .object({
-    page: z.coerce.number().int().min(1).max(1_000_000).default(1),
-    limit: z.coerce.number().int().min(1).max(100).default(10),
-  })
-  .strict();
+import { historyQuerySchema } from "../../../areas/deployments/history-query.js";
 
 const afterSchema = z.coerce.number().int().min(-1).optional();
 

--- a/apps/towbar-api/src/routes/v1/core/resources.ts
+++ b/apps/towbar-api/src/routes/v1/core/resources.ts
@@ -1,3 +1,7 @@
+import {
+  filterWorkloads,
+  workloadFilters,
+} from "@workspace/towbar-core/inventory";
 import { operation } from "../../../http/operation.js";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -55,14 +59,18 @@ resourceRoutes.get(
   "/",
   operation({
     responseSchema: 'resources.ts:get:"/"',
+    query: workloadFilters,
     summary: "List resources",
     response: "JSON object containing resources.",
     status: 200,
   }),
-  async (context) =>
-    context.json({
-      resources: await listResources(context.get("user").workspaceId),
-    }),
+  async (context) => {
+    const result = filterWorkloads(
+      await listResources(context.get("user").workspaceId),
+      workloadFilters.parse(context.req.query()),
+    );
+    return context.json({ resources: result.items, counts: result.counts });
+  },
 );
 
 resourceRoutes.get(

--- a/apps/towbar-api/src/routes/v1/core/servers.ts
+++ b/apps/towbar-api/src/routes/v1/core/servers.ts
@@ -1,3 +1,4 @@
+import { filterServers, serverFilters } from "@workspace/towbar-core/inventory";
 import { operation } from "../../../http/operation.js";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -79,14 +80,18 @@ serverRoutes.get(
   "/",
   operation({
     responseSchema: 'servers.ts:get:"/"',
+    query: serverFilters,
     summary: "List servers",
     response: "JSON object containing servers.",
     status: 200,
   }),
-  async (context) =>
-    context.json({
-      servers: await listServers(context.get("user").workspaceId),
-    }),
+  async (context) => {
+    const result = filterServers(
+      await listServers(context.get("user").workspaceId),
+      serverFilters.parse(context.req.query()),
+    );
+    return context.json({ servers: result.items, counts: result.counts });
+  },
 );
 serverRoutes.post(
   "/",

--- a/apps/towbar-api/src/routes/v1/core/sources.ts
+++ b/apps/towbar-api/src/routes/v1/core/sources.ts
@@ -1,3 +1,4 @@
+import { filterSources, sourceFilters } from "@workspace/towbar-core/inventory";
 import { operation } from "../../../http/operation.js";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -43,14 +44,18 @@ sourceRoutes.get(
   "/",
   operation({
     responseSchema: 'sources.ts:get:"/"',
+    query: sourceFilters,
     summary: "List sources",
     response: "JSON object containing sources.",
     status: 200,
   }),
-  async (context) =>
-    context.json({
-      sources: await listSources(context.get("user").workspaceId),
-    }),
+  async (context) => {
+    const result = filterSources(
+      await listSources(context.get("user").workspaceId),
+      sourceFilters.parse(context.req.query()),
+    );
+    return context.json({ sources: result.items, counts: result.counts });
+  },
 );
 
 sourceRoutes.post(

--- a/apps/towbar-web-app/scripts/fixture-api.ts
+++ b/apps/towbar-web-app/scripts/fixture-api.ts
@@ -1730,14 +1730,38 @@ function getFixturePayload(
       100,
       readPositiveInteger(searchParams.get("limit"), 10),
     );
-    const ordered = [...deployments].sort(
-      (left, right) =>
-        right.createdAt.localeCompare(left.createdAt) ||
-        right.id.localeCompare(left.id),
-    );
     const deployables = new Map(
       [...apps, ...resources].map((item) => [item.id, item]),
     );
+    const ordered = deployments
+      .filter((item) => {
+        const type = searchParams.get("type");
+        return (
+          (!type ||
+            (type === "app"
+              ? item.deployableKind === "app"
+              : item.deployableKind !== "app")) &&
+          ["environment", "state", "trigger", "serverId"].every(
+            (key) =>
+              !searchParams.get(key) ||
+              item[key as "environment" | "state" | "trigger" | "serverId"] ===
+                searchParams.get(key),
+          )
+        );
+      })
+      .sort((left, right) => {
+        const sort = searchParams.get("sort");
+        if (sort === "name_asc" || sort === "name_desc") {
+          const names = (deployables.get(left.appId)?.name ?? "").localeCompare(
+            deployables.get(right.appId)?.name ?? "",
+          );
+          if (names) return sort === "name_asc" ? names : -names;
+        }
+        const newest =
+          right.createdAt.localeCompare(left.createdAt) ||
+          right.id.localeCompare(left.id);
+        return sort === "oldest" ? -newest : newest;
+      });
     return {
       deployments: ordered
         .slice((page - 1) * limit, page * limit)

--- a/apps/towbar-web-app/scripts/fixture-api.ts
+++ b/apps/towbar-web-app/scripts/fixture-api.ts
@@ -1,3 +1,11 @@
+import {
+  workloadFilters,
+  serverFilters,
+  sourceFilters,
+  filterWorkloads,
+  filterServers,
+  filterSources,
+} from "@workspace/towbar-core/inventory";
 import { createScoutFixture } from "./scout-fixture.ts";
 import {
   fixtureServerMonitoringSummary,
@@ -878,19 +886,63 @@ export function createFixtureApiServer() {
     const requestUrl = new URL(request.url ?? "/", "http://localhost");
     const path = requestUrl.pathname;
     if (scoutFixture(request, response, requestUrl)) return;
-    if (request.method === "GET" && path === "/v1/core/servers") {
-      response.writeHead(200, { "content-type": "application/json" });
-      response.end(
-        JSON.stringify({
-          servers: servers.map((server) => ({
-            ...server,
-            scout: fixtureServerMonitoringSummary(
-              monitoring.get(server.id)!,
-              server.id,
-            ),
-          })),
-        }),
-      );
+    if (
+      request.method === "GET" &&
+      [
+        "/v1/core/servers",
+        "/v1/core/apps",
+        "/v1/core/resources",
+        "/v1/core/sources",
+      ].includes(path)
+    ) {
+      const query = Object.fromEntries(requestUrl.searchParams);
+      try {
+        if (path.endsWith("/servers")) {
+          const result = filterServers(
+            servers.map((server) => ({
+              ...server,
+              healthStatus:
+                server.setupStatus === "ready" ? "healthy" : "unknown",
+              scout: fixtureServerMonitoringSummary(
+                monitoring.get(server.id)!,
+                server.id,
+              ),
+            })),
+            serverFilters.parse(query),
+          );
+          writeJson(response, 200, {
+            servers: result.items,
+            counts: result.counts,
+          });
+        } else if (path.endsWith("/sources")) {
+          const result = filterSources(
+            sources.map((source) => ({
+              ...source,
+              latestSyncStatus: source.latestManifestDigest
+                ? "succeeded"
+                : "never",
+              autoDeployPaused: false,
+            })),
+            sourceFilters.parse(query),
+          );
+          writeJson(response, 200, {
+            sources: result.items,
+            counts: result.counts,
+          });
+        } else {
+          const resource = path.endsWith("/resources");
+          const result = filterWorkloads<FixtureApp | FixtureResource>(
+            resource ? resources : apps,
+            workloadFilters.parse(query),
+          );
+          writeJson(response, 200, {
+            [resource ? "resources" : "apps"]: result.items,
+            counts: result.counts,
+          });
+        }
+      } catch {
+        writeJson(response, 400, { message: "Invalid inventory filters" });
+      }
       return;
     }
     const monitoringPath = path.match(

--- a/apps/towbar-web-app/src/app/account/profile/page.tsx
+++ b/apps/towbar-web-app/src/app/account/profile/page.tsx
@@ -1,11 +1,4 @@
-import { UserAccountIcon } from "@hugeicons/core-free-icons";
-import { DashboardPage } from "@/components/page-parts";
-import { ProfileSettings } from "@/components/settings-pages";
-
+import { redirect } from "next/navigation";
 export default function Page() {
-  return (
-    <DashboardPage icon={UserAccountIcon} title="Profile">
-      <ProfileSettings />
-    </DashboardPage>
-  );
+  redirect("/settings?settings=profile");
 }

--- a/apps/towbar-web-app/src/app/account/profile/page.tsx
+++ b/apps/towbar-web-app/src/app/account/profile/page.tsx
@@ -1,4 +1,4 @@
 import { redirect } from "next/navigation";
 export default function Page() {
-  redirect("/settings?settings=profile");
+  redirect("/settings/profile");
 }

--- a/apps/towbar-web-app/src/app/account/sessions/page.tsx
+++ b/apps/towbar-web-app/src/app/account/sessions/page.tsx
@@ -1,4 +1,4 @@
 import { redirect } from "next/navigation";
 export default function Page() {
-  redirect("/settings?settings=sessions");
+  redirect("/settings/sessions");
 }

--- a/apps/towbar-web-app/src/app/account/sessions/page.tsx
+++ b/apps/towbar-web-app/src/app/account/sessions/page.tsx
@@ -1,11 +1,4 @@
-import { ComputerIcon } from "@hugeicons/core-free-icons";
-import { DashboardPage } from "@/components/page-parts";
-import { SessionSettings } from "@/components/settings-pages";
-
+import { redirect } from "next/navigation";
 export default function Page() {
-  return (
-    <DashboardPage icon={ComputerIcon} title="Sessions">
-      <SessionSettings />
-    </DashboardPage>
-  );
+  redirect("/settings?settings=sessions");
 }

--- a/apps/towbar-web-app/src/app/servers/[serverId]/[...sectionPath]/page.tsx
+++ b/apps/towbar-web-app/src/app/servers/[serverId]/[...sectionPath]/page.tsx
@@ -1,0 +1,29 @@
+import { notFound } from "next/navigation";
+import { ServerDetail } from "@/components/server-detail";
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ sectionPath: string[] }>;
+}) {
+  const { sectionPath } = await params;
+  const [section, child] = sectionPath;
+  const children: Record<string, string[]> = {
+    settings: ["configuration", "host-keys", "monitoring", "cleanup"],
+  };
+  if (
+    !section ||
+    ![
+      "overview",
+      "monitoring",
+      "apps",
+      "resources",
+      "checks",
+      "settings",
+    ].includes(section) ||
+    sectionPath.length > 2 ||
+    (child && !children[section]?.includes(child))
+  )
+    notFound();
+  return <ServerDetail />;
+}

--- a/apps/towbar-web-app/src/app/settings/page.tsx
+++ b/apps/towbar-web-app/src/app/settings/page.tsx
@@ -1,4 +1,11 @@
-import { AccountSettings } from "@/components/account-settings";
-export default function Page() {
-  return <AccountSettings />;
+import { redirect } from "next/navigation";
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ settings?: string }>;
+}) {
+  const { settings } = await searchParams;
+  redirect(
+    settings === "sessions" ? "/settings/sessions" : "/settings/profile",
+  );
 }

--- a/apps/towbar-web-app/src/app/settings/page.tsx
+++ b/apps/towbar-web-app/src/app/settings/page.tsx
@@ -1,5 +1,4 @@
-import { redirect } from "next/navigation";
-
+import { AccountSettings } from "@/components/account-settings";
 export default function Page() {
-  redirect("/account/profile");
+  return <AccountSettings />;
 }

--- a/apps/towbar-web-app/src/app/settings/profile/page.tsx
+++ b/apps/towbar-web-app/src/app/settings/profile/page.tsx
@@ -1,0 +1,4 @@
+import { AccountSettings } from "@/components/account-settings";
+export default function Page() {
+  return <AccountSettings page="profile" />;
+}

--- a/apps/towbar-web-app/src/app/settings/sessions/page.tsx
+++ b/apps/towbar-web-app/src/app/settings/sessions/page.tsx
@@ -1,0 +1,4 @@
+import { AccountSettings } from "@/components/account-settings";
+export default function Page() {
+  return <AccountSettings page="sessions" />;
+}

--- a/apps/towbar-web-app/src/app/sources/[sourceId]/[...sectionPath]/page.tsx
+++ b/apps/towbar-web-app/src/app/sources/[sourceId]/[...sectionPath]/page.tsx
@@ -1,0 +1,22 @@
+import { notFound } from "next/navigation";
+import { SourceDetail } from "@/components/source-detail";
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ sectionPath: string[] }>;
+}) {
+  const { sectionPath } = await params;
+  const [section, child] = sectionPath;
+  const children: Record<string, string[]> = {
+    info: ["manifest", "sync-history"],
+    settings: ["auto-deploy", "notifications", "secrets", "danger"],
+  };
+  if (
+    !section ||
+    !["apps", "resources", "info", "settings"].includes(section) ||
+    sectionPath.length > 2 ||
+    (child && !children[section]?.includes(child))
+  )
+    notFound();
+  return <SourceDetail />;
+}

--- a/apps/towbar-web-app/src/app/sources/[sourceId]/apps/[appId]/[...sectionPath]/page.tsx
+++ b/apps/towbar-web-app/src/app/sources/[sourceId]/apps/[appId]/[...sectionPath]/page.tsx
@@ -1,0 +1,29 @@
+import { notFound } from "next/navigation";
+import { AppDetail } from "@/components/app-detail";
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ sectionPath: string[] }>;
+}) {
+  const { sectionPath } = await params;
+  const [section, child] = sectionPath;
+  const children: Record<string, string[]> = {
+    settings: ["configuration", "preview", "auto-deploy", "secrets"],
+  };
+  if (
+    !section ||
+    ![
+      "overview",
+      "monitoring",
+      "deployments",
+      "previews",
+      "logs",
+      "settings",
+    ].includes(section) ||
+    sectionPath.length > 2 ||
+    (child && !children[section]?.includes(child))
+  )
+    notFound();
+  return <AppDetail />;
+}

--- a/apps/towbar-web-app/src/app/sources/[sourceId]/resources/[resourceId]/[...sectionPath]/page.tsx
+++ b/apps/towbar-web-app/src/app/sources/[sourceId]/resources/[resourceId]/[...sectionPath]/page.tsx
@@ -1,0 +1,30 @@
+import { notFound } from "next/navigation";
+import { ResourceDetail } from "@/components/resource-detail";
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ sectionPath: string[] }>;
+}) {
+  const { sectionPath } = await params;
+  const [section, child] = sectionPath;
+  const children: Record<string, string[]> = {
+    settings: [
+      "configuration",
+      "connection",
+      "backups",
+      "auto-deploy",
+      "secrets",
+    ],
+  };
+  if (
+    !section ||
+    !["overview", "monitoring", "deployments", "logs", "settings"].includes(
+      section,
+    ) ||
+    sectionPath.length > 2 ||
+    (child && !children[section]?.includes(child))
+  )
+    notFound();
+  return <ResourceDetail />;
+}

--- a/apps/towbar-web-app/src/components/account-settings.tsx
+++ b/apps/towbar-web-app/src/components/account-settings.tsx
@@ -6,30 +6,32 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { DashboardPage } from "./page-parts";
-import { ResponsiveSubtabs } from "./responsive-subtabs";
+import { useRouter } from "next/navigation";
+import { SecondaryItems } from "./secondary-sidebar";
 import { ProfileSettings, SessionSettings } from "./settings-pages";
 
-export function AccountSettings() {
+export function AccountSettings({ page }: { page: "profile" | "sessions" }) {
+  const router = useRouter();
   return (
     <DashboardPage title="Settings" icon={Settings01Icon}>
-      <ResponsiveSubtabs
-        ariaLabel="Account settings"
-        defaultSelectedKey="profile"
-        tabs={[
+      <SecondaryItems
+        title="Account settings"
+        selected={page}
+        onSelect={(value) => router.push(`/settings/${value}`)}
+        items={[
           {
-            value: "profile",
+            id: "profile",
             label: "Profile",
             icon: <HugeiconsIcon icon={UserAccountIcon} />,
-            content: <ProfileSettings />,
           },
           {
-            value: "sessions",
+            id: "sessions",
             label: "Sessions",
             icon: <HugeiconsIcon icon={ComputerIcon} />,
-            content: <SessionSettings />,
           },
         ]}
       />
+      {page === "profile" ? <ProfileSettings /> : <SessionSettings />}
     </DashboardPage>
   );
 }

--- a/apps/towbar-web-app/src/components/account-settings.tsx
+++ b/apps/towbar-web-app/src/components/account-settings.tsx
@@ -1,0 +1,35 @@
+"use client";
+import {
+  ComputerIcon,
+  Settings01Icon,
+  UserAccountIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { DashboardPage } from "./page-parts";
+import { ResponsiveSubtabs } from "./responsive-subtabs";
+import { ProfileSettings, SessionSettings } from "./settings-pages";
+
+export function AccountSettings() {
+  return (
+    <DashboardPage title="Settings" icon={Settings01Icon}>
+      <ResponsiveSubtabs
+        ariaLabel="Account settings"
+        defaultSelectedKey="profile"
+        tabs={[
+          {
+            value: "profile",
+            label: "Profile",
+            icon: <HugeiconsIcon icon={UserAccountIcon} />,
+            content: <ProfileSettings />,
+          },
+          {
+            value: "sessions",
+            label: "Sessions",
+            icon: <HugeiconsIcon icon={ComputerIcon} />,
+            content: <SessionSettings />,
+          },
+        ]}
+      />
+    </DashboardPage>
+  );
+}

--- a/apps/towbar-web-app/src/components/account-settings.tsx
+++ b/apps/towbar-web-app/src/components/account-settings.tsx
@@ -1,9 +1,5 @@
 "use client";
-import {
-  ComputerIcon,
-  Settings01Icon,
-  UserAccountIcon,
-} from "@hugeicons/core-free-icons";
+import { ComputerIcon, UserAccountIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { DashboardPage } from "./page-parts";
 import { useRouter } from "next/navigation";
@@ -13,7 +9,10 @@ import { ProfileSettings, SessionSettings } from "./settings-pages";
 export function AccountSettings({ page }: { page: "profile" | "sessions" }) {
   const router = useRouter();
   return (
-    <DashboardPage title="Settings" icon={Settings01Icon}>
+    <DashboardPage
+      title={page === "profile" ? "Profile" : "Sessions"}
+      icon={page === "profile" ? UserAccountIcon : ComputerIcon}
+    >
       <SecondaryItems
         title="Account settings"
         selected={page}

--- a/apps/towbar-web-app/src/components/api-mcp-settings.tsx
+++ b/apps/towbar-web-app/src/components/api-mcp-settings.tsx
@@ -207,6 +207,7 @@ export function ApiMcpSettings() {
         tabs={[
           {
             value: "keys",
+            group: "Settings",
             label: "API Keys",
             content: (
               <div className="content-grid">
@@ -231,11 +232,13 @@ export function ApiMcpSettings() {
           },
           {
             value: "mcp",
+            group: "Docs",
             label: "MCP Guide",
             content: <McpSetup url={data.mcpUrl} />,
           },
           {
             value: "api",
+            group: "Docs",
             label: "API Guide",
             content: (
               <div className="content-grid">

--- a/apps/towbar-web-app/src/components/app-detail.tsx
+++ b/apps/towbar-web-app/src/components/app-detail.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useDetailNavigation } from "@/hooks/use-detail-navigation";
 import { ScoutPanel } from "./scout-panel";
 
 import {
@@ -13,7 +14,7 @@ import {
   Key01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import type { ReactNode } from "react";
 import type { App, Deployment, Release } from "@workspace/towbar-web-client";
 import { Attributes } from "@workspace/web-design-system/data-display/attributes";
@@ -321,7 +322,7 @@ export function AppDetail() {
 }
 
 function AppSettings({ appId, item }: { appId: string; item: AppRecord }) {
-  const requestedSettings = useSearchParams().get("settings");
+  const requestedSettings = useDetailNavigation().settings;
   const tabs: Array<{
     content: ReactNode;
     icon: ReactNode;

--- a/apps/towbar-web-app/src/components/app-detail.tsx
+++ b/apps/towbar-web-app/src/components/app-detail.tsx
@@ -119,6 +119,12 @@ export function AppDetail() {
               type="app"
             />
             <ActionButton
+              confirm={{
+                title: "Deploy this app?",
+                description:
+                  "Queue a new app deployment. A successful deployment will replace the running release.",
+                actionLabel: "Deploy app",
+              }}
               action={() =>
                 api.post<{ deployment: Deployment }>(
                   `/v1/core/apps/${appId}/actions/deploy`,

--- a/apps/towbar-web-app/src/components/app-secrets.tsx
+++ b/apps/towbar-web-app/src/components/app-secrets.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { usePageQuery, useQueryChoice } from "@/hooks/use-page-query";
+import { PageSelectionTitle } from "./page-selection-title";
 import { SecondaryItems } from "./secondary-sidebar";
 import {
   Add01Icon,
@@ -129,6 +130,18 @@ function EnvironmentSecretSettings({
   if (!active) return null;
   return (
     <div className={scope === "global" ? "w-full" : "max-w-5xl"}>
+      {scope === "global" ? (
+        <PageSelectionTitle
+          icon={
+            <HugeiconsIcon
+              icon={
+                environment === "production" ? ServerStack01Icon : Rocket01Icon
+              }
+            />
+          }
+          label={`${environment === "production" ? "Production" : "Preview"} shared secrets`}
+        />
+      ) : null}
       {scope === "global" ? (
         <SecondaryItems
           title="Environment"

--- a/apps/towbar-web-app/src/components/app-secrets.tsx
+++ b/apps/towbar-web-app/src/components/app-secrets.tsx
@@ -123,44 +123,37 @@ function EnvironmentSecretSettings({
     "production",
   );
   const { update } = usePageQuery();
-  const [stage] = useQueryChoice(
-    "stage",
-    ["build", "deployment", "pre_deploy", "post_deploy"],
-    "build",
-  );
   const query = useApiQuery<AppSecretsResponse>(
     active ? `${endpoint}?environment=${environment}` : null,
   );
   if (!active) return null;
   return (
     <div className={scope === "global" ? "w-full" : "max-w-5xl"}>
-      {scope === "global"
-        ? (["production", "preview"] as const).map((group) => (
-            <SecondaryItems
-              key={group}
-              title={group === "production" ? "Production" : "Preview"}
-              selected={environment === group ? stage : ""}
-              onSelect={(value) =>
-                update({
-                  environment: group === "production" ? null : group,
-                  stage: value === "build" ? null : value,
-                })
-              }
-              items={(
-                ["build", "deployment", "pre_deploy", "post_deploy"] as const
-              ).map((value) => ({
-                id: value,
-                label: stageLabels[value],
-                icon: <HugeiconsIcon icon={stageIcons[value]} />,
-              }))}
-            />
-          ))
-        : null}
+      {scope === "global" ? (
+        <SecondaryItems
+          title="Environment"
+          selected={environment}
+          onSelect={(value) =>
+            update({ environment: value === "production" ? null : value })
+          }
+          items={[
+            {
+              id: "production",
+              label: "Production",
+              icon: <HugeiconsIcon icon={ServerStack01Icon} />,
+            },
+            {
+              id: "preview",
+              label: "Preview",
+              icon: <HugeiconsIcon icon={Rocket01Icon} />,
+            },
+          ]}
+        />
+      ) : null}
       <EnvironmentEditors
         key={environment}
         endpoint={endpoint}
         query={query}
-        hideStageNavigation={scope === "global"}
         environment={scope !== "global" ? environment : undefined}
         onEnvironmentChange={(value) =>
           update({ environment: value === "production" ? null : value })
@@ -270,13 +263,11 @@ function SecretSelector({
 function EnvironmentEditors({
   query,
   endpoint,
-  hideStageNavigation = false,
   environment,
   onEnvironmentChange,
 }: {
   query: Query;
   endpoint: string;
-  hideStageNavigation?: boolean;
   environment?: "production" | "preview";
   onEnvironmentChange?: (value: string) => void;
 }) {
@@ -312,7 +303,7 @@ function EnvironmentEditors({
             ]}
           />
         ) : null}
-        {!hideStageNavigation && binding && data ? (
+        {binding && data ? (
           <SecretSelector
             label="Secret stage"
             value={binding.stage}

--- a/apps/towbar-web-app/src/components/app-secrets.tsx
+++ b/apps/towbar-web-app/src/components/app-secrets.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useDetailNavigation } from "@/hooks/use-detail-navigation";
 import { usePageQuery, useQueryChoice } from "@/hooks/use-page-query";
 import { PageSelectionTitle } from "./page-selection-title";
 import { SecondaryItems } from "./secondary-sidebar";
@@ -27,7 +28,6 @@ import { Select, ListBox } from "@workspace/web-design-system/forms/select";
 import { Label } from "@workspace/web-design-system/forms/label";
 import { Tabs } from "@workspace/web-design-system/navigation/tabs";
 import { parseSecretEnv, serializeSecretEnv } from "@/lib/secret-env";
-import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState, type FormEvent } from "react";
 
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -59,7 +59,7 @@ export const stageLabels: Record<AppSecretStage, string> = {
 };
 
 export function AppSecrets({ appId }: { appId: string }) {
-  const active = useSearchParams().get("section") === "settings";
+  const active = useDetailNavigation().section === "settings";
   return (
     <EnvironmentSecretSettings
       active={active}
@@ -70,7 +70,7 @@ export function AppSecrets({ appId }: { appId: string }) {
 }
 
 export function ResourceSecrets({ resourceId }: { resourceId: string }) {
-  const active = useSearchParams().get("section") === "settings";
+  const active = useDetailNavigation().section === "settings";
   const endpoint = `/v1/core/resources/${resourceId}/secrets`;
   const query = useApiQuery<AppSecretsResponse>(active ? endpoint : null);
   if (!active) return null;

--- a/apps/towbar-web-app/src/components/app-secrets.tsx
+++ b/apps/towbar-web-app/src/components/app-secrets.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { SecondaryItems } from "./secondary-sidebar";
 import {
   Add01Icon,
   ArrowLeft01Icon,
@@ -41,8 +42,6 @@ import { toast } from "@workspace/web-design-system/overlays/toast";
 import { QueryError, QueryLoading } from "@workspace/towbar-web-ui/query-state";
 import { useApiQuery } from "@/hooks/use-api-query";
 import { api } from "@/lib/api";
-import { Select, ListBox } from "@workspace/web-design-system/forms/select";
-import { Label } from "@workspace/web-design-system/forms/label";
 
 const CodeEditor = dynamic(() => import("./code-editor"), {
   ssr: false,
@@ -157,82 +156,17 @@ function SecretSelector({
   options: Array<{ value: string; label: string; icon: typeof PackageIcon }>;
   onChange: (value: string) => void;
 }) {
-  const selected = options.find((option) => option.value === value);
   return (
-    <>
-      <Select
-        className="md:hidden"
-        fullWidth
-        variant="secondary"
-        selectedKey={value}
-        onSelectionChange={(key) => {
-          if (key !== null) onChange(String(key));
-        }}
-      >
-        <Label className="sr-only">{label}</Label>
-        <Select.Trigger>
-          <Select.Value>
-            <span className="inline-flex min-w-0 items-center gap-2">
-              <HugeiconsIcon
-                aria-hidden="true"
-                icon={selected?.icon ?? PackageIcon}
-                className="size-4 shrink-0"
-              />
-              <span className="truncate">{selected?.label}</span>
-            </span>
-          </Select.Value>
-          <Select.Indicator />
-        </Select.Trigger>
-        <Select.Popover>
-          <ListBox>
-            {options.map((option) => (
-              <ListBox.Item
-                key={option.value}
-                id={option.value}
-                textValue={option.label}
-              >
-                <span className="inline-flex items-center gap-2">
-                  <HugeiconsIcon
-                    aria-hidden="true"
-                    icon={option.icon}
-                    className="size-4 shrink-0"
-                  />
-                  {option.label}
-                </span>
-                <ListBox.ItemIndicator />
-              </ListBox.Item>
-            ))}
-          </ListBox>
-        </Select.Popover>
-      </Select>
-      <Tabs
-        className="hidden min-w-0 md:block"
-        selectedKey={value}
-        onSelectionChange={(key) => {
-          if (key !== null) onChange(String(key));
-        }}
-      >
-        <Tabs.ListContainer className="w-fit max-w-full overflow-x-auto">
-          <Tabs.List aria-label={label} className="min-w-max">
-            {options.map((option) => (
-              <Tabs.Tab
-                key={option.value}
-                id={option.value}
-                className="w-auto shrink-0 gap-2 whitespace-nowrap"
-              >
-                <HugeiconsIcon
-                  aria-hidden="true"
-                  icon={option.icon}
-                  className="size-4 shrink-0"
-                />
-                {option.label}
-                <Tabs.Indicator />
-              </Tabs.Tab>
-            ))}
-          </Tabs.List>
-        </Tabs.ListContainer>
-      </Tabs>
-    </>
+    <SecondaryItems
+      title={label}
+      selected={value}
+      onSelect={onChange}
+      items={options.map((option) => ({
+        id: option.value,
+        label: option.label,
+        icon: <HugeiconsIcon icon={option.icon} />,
+      }))}
+    />
   );
 }
 

--- a/apps/towbar-web-app/src/components/app-secrets.tsx
+++ b/apps/towbar-web-app/src/components/app-secrets.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useQueryChoice } from "@/hooks/use-page-query";
 import { SecondaryItems } from "./secondary-sidebar";
 import {
   Add01Icon,
@@ -114,7 +115,9 @@ function EnvironmentSecretSettings({
   endpoint: string;
   scope: "global" | "source" | "app";
 }) {
-  const [environment, setEnvironment] = useState<"production" | "preview">(
+  const [environment, setEnvironment] = useQueryChoice(
+    "environment",
+    ["production", "preview"],
     "production",
   );
   const query = useApiQuery<AppSecretsResponse>(
@@ -181,7 +184,11 @@ function EnvironmentEditors({
   environment?: "production" | "preview";
   onEnvironmentChange?: (value: "production" | "preview") => void;
 }) {
-  const [stage, setStage] = useState<AppSecretStage>("build");
+  const [stage, setStage] = useQueryChoice(
+    "stage",
+    ["build", "deployment", "pre_deploy", "post_deploy"],
+    "build",
+  );
   const data = query.data;
   const binding =
     data?.bindings.find((item) => item.stage === stage) ?? data?.bindings[0];

--- a/apps/towbar-web-app/src/components/app-secrets.tsx
+++ b/apps/towbar-web-app/src/components/app-secrets.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useQueryChoice } from "@/hooks/use-page-query";
+import { usePageQuery, useQueryChoice } from "@/hooks/use-page-query";
 import { SecondaryItems } from "./secondary-sidebar";
 import {
   Add01Icon,
@@ -14,8 +14,6 @@ import {
   PlayIcon,
   ReloadIcon,
   RestoreBinIcon,
-  Rocket01Icon,
-  ServerStack01Icon,
   SourceCodeIcon,
   ViewIcon,
   ViewOffSlashIcon,
@@ -115,10 +113,16 @@ function EnvironmentSecretSettings({
   endpoint: string;
   scope: "global" | "source" | "app";
 }) {
-  const [environment, setEnvironment] = useQueryChoice(
+  const [environment] = useQueryChoice(
     "environment",
     ["production", "preview"],
     "production",
+  );
+  const { update } = usePageQuery();
+  const [stage] = useQueryChoice(
+    "stage",
+    ["build", "deployment", "pre_deploy", "post_deploy"],
+    "build",
   );
   const query = useApiQuery<AppSecretsResponse>(
     active ? `${endpoint}?environment=${environment}` : null,
@@ -126,12 +130,31 @@ function EnvironmentSecretSettings({
   if (!active) return null;
   return (
     <div className={scope === "global" ? "w-full" : "max-w-5xl"}>
+      {(["production", "preview"] as const).map((group) => (
+        <SecondaryItems
+          key={group}
+          title={group === "production" ? "Production" : "Preview"}
+          selected={environment === group ? stage : ""}
+          onSelect={(value) =>
+            update({
+              environment: group === "production" ? null : group,
+              stage: value === "build" ? null : value,
+            })
+          }
+          items={(
+            ["build", "deployment", "pre_deploy", "post_deploy"] as const
+          ).map((value) => ({
+            id: value,
+            label: stageLabels[value],
+            icon: <HugeiconsIcon icon={stageIcons[value]} />,
+          }))}
+        />
+      ))}
       <EnvironmentEditors
         key={environment}
         endpoint={endpoint}
         query={query}
-        environment={environment}
-        onEnvironmentChange={setEnvironment}
+        hideStageNavigation
       />
     </div>
   );
@@ -143,10 +166,6 @@ const stageIcons = {
   pre_deploy: ArrowLeft01Icon,
   post_deploy: ArrowRight01Icon,
 };
-const environmentOptions = [
-  { value: "production", label: "Production", icon: ServerStack01Icon },
-  { value: "preview", label: "Preview", icon: Rocket01Icon },
-];
 
 function SecretSelector({
   label,
@@ -176,13 +195,11 @@ function SecretSelector({
 function EnvironmentEditors({
   query,
   endpoint,
-  environment,
-  onEnvironmentChange,
+  hideStageNavigation = false,
 }: {
   query: Query;
   endpoint: string;
-  environment?: "production" | "preview";
-  onEnvironmentChange?: (value: "production" | "preview") => void;
+  hideStageNavigation?: boolean;
 }) {
   const [stage, setStage] = useQueryChoice(
     "stage",
@@ -194,36 +211,18 @@ function EnvironmentEditors({
     data?.bindings.find((item) => item.stage === stage) ?? data?.bindings[0];
   return (
     <div className="grid min-w-0 gap-4">
-      <div
-        className={
-          environment
-            ? "grid min-w-0 grid-cols-2 gap-3 md:grid-cols-1"
-            : "grid min-w-0"
-        }
-      >
-        {environment && onEnvironmentChange ? (
-          <SecretSelector
-            label="Secret environment"
-            value={environment}
-            options={environmentOptions}
-            onChange={(value) =>
-              onEnvironmentChange(value as "production" | "preview")
-            }
-          />
-        ) : null}
-        {binding && data ? (
-          <SecretSelector
-            label="Secret stage"
-            value={binding.stage}
-            options={data.bindings.map((item) => ({
-              value: item.stage,
-              label: stageLabels[item.stage],
-              icon: stageIcons[item.stage],
-            }))}
-            onChange={(value) => setStage(value as AppSecretStage)}
-          />
-        ) : null}
-      </div>
+      {!hideStageNavigation && binding && data ? (
+        <SecretSelector
+          label="Secret stage"
+          value={binding.stage}
+          options={data.bindings.map((item) => ({
+            value: item.stage,
+            label: stageLabels[item.stage],
+            icon: stageIcons[item.stage],
+          }))}
+          onChange={(value) => setStage(value as AppSecretStage)}
+        />
+      ) : null}
       {query.error ? (
         <QueryError message={query.error} />
       ) : !data ? (

--- a/apps/towbar-web-app/src/components/app-secrets.tsx
+++ b/apps/towbar-web-app/src/components/app-secrets.tsx
@@ -13,6 +13,8 @@ import {
   PackageIcon,
   PlayIcon,
   ReloadIcon,
+  Rocket01Icon,
+  ServerStack01Icon,
   RestoreBinIcon,
   SourceCodeIcon,
   ViewIcon,
@@ -20,6 +22,8 @@ import {
 } from "@hugeicons/core-free-icons";
 
 import dynamic from "next/dynamic";
+import { Select, ListBox } from "@workspace/web-design-system/forms/select";
+import { Label } from "@workspace/web-design-system/forms/label";
 import { Tabs } from "@workspace/web-design-system/navigation/tabs";
 import { parseSecretEnv, serializeSecretEnv } from "@/lib/secret-env";
 import { useSearchParams } from "next/navigation";
@@ -130,31 +134,37 @@ function EnvironmentSecretSettings({
   if (!active) return null;
   return (
     <div className={scope === "global" ? "w-full" : "max-w-5xl"}>
-      {(["production", "preview"] as const).map((group) => (
-        <SecondaryItems
-          key={group}
-          title={group === "production" ? "Production" : "Preview"}
-          selected={environment === group ? stage : ""}
-          onSelect={(value) =>
-            update({
-              environment: group === "production" ? null : group,
-              stage: value === "build" ? null : value,
-            })
-          }
-          items={(
-            ["build", "deployment", "pre_deploy", "post_deploy"] as const
-          ).map((value) => ({
-            id: value,
-            label: stageLabels[value],
-            icon: <HugeiconsIcon icon={stageIcons[value]} />,
-          }))}
-        />
-      ))}
+      {scope === "global"
+        ? (["production", "preview"] as const).map((group) => (
+            <SecondaryItems
+              key={group}
+              title={group === "production" ? "Production" : "Preview"}
+              selected={environment === group ? stage : ""}
+              onSelect={(value) =>
+                update({
+                  environment: group === "production" ? null : group,
+                  stage: value === "build" ? null : value,
+                })
+              }
+              items={(
+                ["build", "deployment", "pre_deploy", "post_deploy"] as const
+              ).map((value) => ({
+                id: value,
+                label: stageLabels[value],
+                icon: <HugeiconsIcon icon={stageIcons[value]} />,
+              }))}
+            />
+          ))
+        : null}
       <EnvironmentEditors
         key={environment}
         endpoint={endpoint}
         query={query}
-        hideStageNavigation
+        hideStageNavigation={scope === "global"}
+        environment={scope !== "global" ? environment : undefined}
+        onEnvironmentChange={(value) =>
+          update({ environment: value === "production" ? null : value })
+        }
       />
     </div>
   );
@@ -178,17 +188,82 @@ function SecretSelector({
   options: Array<{ value: string; label: string; icon: typeof PackageIcon }>;
   onChange: (value: string) => void;
 }) {
+  const selected = options.find((option) => option.value === value);
   return (
-    <SecondaryItems
-      title={label}
-      selected={value}
-      onSelect={onChange}
-      items={options.map((option) => ({
-        id: option.value,
-        label: option.label,
-        icon: <HugeiconsIcon icon={option.icon} />,
-      }))}
-    />
+    <>
+      <Select
+        className="md:hidden"
+        fullWidth
+        variant="secondary"
+        selectedKey={value}
+        onSelectionChange={(key) => {
+          if (key !== null) onChange(String(key));
+        }}
+      >
+        <Label className="sr-only">{label}</Label>
+        <Select.Trigger>
+          <Select.Value>
+            <span className="inline-flex min-w-0 items-center gap-2">
+              <HugeiconsIcon
+                aria-hidden="true"
+                icon={selected?.icon ?? PackageIcon}
+                className="size-4 shrink-0"
+              />
+              <span className="truncate">{selected?.label}</span>
+            </span>
+          </Select.Value>
+          <Select.Indicator />
+        </Select.Trigger>
+        <Select.Popover>
+          <ListBox>
+            {options.map((option) => (
+              <ListBox.Item
+                key={option.value}
+                id={option.value}
+                textValue={option.label}
+              >
+                <span className="inline-flex items-center gap-2">
+                  <HugeiconsIcon
+                    aria-hidden="true"
+                    icon={option.icon}
+                    className="size-4 shrink-0"
+                  />
+                  {option.label}
+                </span>
+                <ListBox.ItemIndicator />
+              </ListBox.Item>
+            ))}
+          </ListBox>
+        </Select.Popover>
+      </Select>
+      <Tabs
+        className="hidden min-w-0 md:block"
+        selectedKey={value}
+        onSelectionChange={(key) => {
+          if (key !== null) onChange(String(key));
+        }}
+      >
+        <Tabs.ListContainer className="w-fit max-w-full overflow-x-auto">
+          <Tabs.List aria-label={label} className="min-w-max">
+            {options.map((option) => (
+              <Tabs.Tab
+                key={option.value}
+                id={option.value}
+                className="w-auto shrink-0 gap-2 whitespace-nowrap"
+              >
+                <HugeiconsIcon
+                  aria-hidden="true"
+                  icon={option.icon}
+                  className="size-4 shrink-0"
+                />
+                {option.label}
+                <Tabs.Indicator />
+              </Tabs.Tab>
+            ))}
+          </Tabs.List>
+        </Tabs.ListContainer>
+      </Tabs>
+    </>
   );
 }
 
@@ -196,10 +271,14 @@ function EnvironmentEditors({
   query,
   endpoint,
   hideStageNavigation = false,
+  environment,
+  onEnvironmentChange,
 }: {
   query: Query;
   endpoint: string;
   hideStageNavigation?: boolean;
+  environment?: "production" | "preview";
+  onEnvironmentChange?: (value: string) => void;
 }) {
   const [stage, setStage] = useQueryChoice(
     "stage",
@@ -211,18 +290,41 @@ function EnvironmentEditors({
     data?.bindings.find((item) => item.stage === stage) ?? data?.bindings[0];
   return (
     <div className="grid min-w-0 gap-4">
-      {!hideStageNavigation && binding && data ? (
-        <SecretSelector
-          label="Secret stage"
-          value={binding.stage}
-          options={data.bindings.map((item) => ({
-            value: item.stage,
-            label: stageLabels[item.stage],
-            icon: stageIcons[item.stage],
-          }))}
-          onChange={(value) => setStage(value as AppSecretStage)}
-        />
-      ) : null}
+      <div
+        className={
+          environment
+            ? "grid min-w-0 gap-3 grid-cols-2 md:grid-cols-1"
+            : "grid min-w-0 gap-3"
+        }
+      >
+        {environment && onEnvironmentChange ? (
+          <SecretSelector
+            label="Secret environment"
+            value={environment}
+            onChange={onEnvironmentChange}
+            options={[
+              {
+                value: "production",
+                label: "Production",
+                icon: ServerStack01Icon,
+              },
+              { value: "preview", label: "Preview", icon: Rocket01Icon },
+            ]}
+          />
+        ) : null}
+        {!hideStageNavigation && binding && data ? (
+          <SecretSelector
+            label="Secret stage"
+            value={binding.stage}
+            options={data.bindings.map((item) => ({
+              value: item.stage,
+              label: stageLabels[item.stage],
+              icon: stageIcons[item.stage],
+            }))}
+            onChange={(value) => setStage(value as AppSecretStage)}
+          />
+        ) : null}
+      </div>
       {query.error ? (
         <QueryError message={query.error} />
       ) : !data ? (

--- a/apps/towbar-web-app/src/components/application-frame.tsx
+++ b/apps/towbar-web-app/src/components/application-frame.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { SecondarySidebarLayout } from "./secondary-sidebar";
 
 import { useCallback, useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
@@ -122,12 +123,14 @@ export function ApplicationFrame({ children }: { children: React.ReactNode }) {
         toggleShortcut
         {...sidebarState}
       >
-        <AppShell.Content
-          className="pt-0 pb-20 sm:pt-0 sm:pb-24"
-          variant="broad"
-        >
-          <RelativeTimeProvider>{children}</RelativeTimeProvider>
-        </AppShell.Content>
+        <SecondarySidebarLayout>
+          <AppShell.Content
+            className="pt-0 pb-20 sm:pt-0 sm:pb-24"
+            variant="broad"
+          >
+            <RelativeTimeProvider>{children}</RelativeTimeProvider>
+          </AppShell.Content>
+        </SecondarySidebarLayout>
         <DeploymentQueue />
       </AppLayout>
     </AppShell>

--- a/apps/towbar-web-app/src/components/deployment-detail.tsx
+++ b/apps/towbar-web-app/src/components/deployment-detail.tsx
@@ -171,6 +171,12 @@ export function DeploymentDetail() {
   ) : item.environment === "production" &&
     (item.state === "failed" || item.state === "cancelled") ? (
     <ActionButton
+      confirm={{
+        title: "Retry this deployment?",
+        description:
+          "Queue another deployment attempt. A successful attempt may replace the running release.",
+        actionLabel: "Retry deployment",
+      }}
       action={() =>
         api.post<{ deployment: Deployment }>(
           `/v1/core/deployments/${deploymentId}/actions/retry`,

--- a/apps/towbar-web-app/src/components/deployment-vulnerability-scan.tsx
+++ b/apps/towbar-web-app/src/components/deployment-vulnerability-scan.tsx
@@ -171,6 +171,12 @@ export function DeploymentVulnerabilityScanPanel({
           sessionQuery.data?.user.workspaceRole === "owner" ? (
             <div>
               <ActionButton
+                confirm={{
+                  title: "Scan this deployment image?",
+                  description:
+                    "Queue a vulnerability scan of this deployment\u2019s image on its server.",
+                  actionLabel: "Scan image",
+                }}
                 action={async () => {
                   const result = await api.post<{
                     replayed: boolean;

--- a/apps/towbar-web-app/src/components/deployments-index.tsx
+++ b/apps/towbar-web-app/src/components/deployments-index.tsx
@@ -1,15 +1,18 @@
 "use client";
 
 import {
+  Cancel01Icon,
   DashboardCircleIcon,
   DatabaseIcon,
   Rocket01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect } from "react";
-import type {
-  DeploymentHistoryItem,
-  DeploymentHistoryPage,
+import {
+  deploymentStates,
+  type DeploymentHistoryItem,
+  type DeploymentHistoryPage,
+  type Server,
 } from "@workspace/towbar-web-client";
 import { QueryError, QueryLoading } from "@workspace/towbar-web-ui/query-state";
 import {
@@ -28,6 +31,11 @@ import { getDeploymentDisplayStatus } from "@/lib/deployment-status";
 import { DeploymentTriggerChip } from "./deployment-table";
 import { DeploymentDuration } from "./elapsed-time";
 import { RelativeTime } from "./last-synced-time";
+
+import { usePathname, useSearchParams } from "next/navigation";
+import { SecondarySection } from "./secondary-sidebar";
+import { ScoutSelect } from "./scout-controls";
+import { Button } from "@workspace/web-design-system/buttons/button";
 
 const columns: ResourceTableColumn<DeploymentHistoryItem>[] = [
   {
@@ -96,11 +104,41 @@ const columns: ResourceTableColumn<DeploymentHistoryItem>[] = [
 
 export function DeploymentsIndex() {
   const pagination = useTablePagination({ pageSize: 10 });
+  const search = useSearchParams();
+  const pathname = usePathname();
+  const servers = useApiQuery<{ servers: Server[] }>("/v1/core/servers");
+  const filters = [
+    "type",
+    "environment",
+    "state",
+    "trigger",
+    "serverId",
+    "sort",
+  ];
+  const params = new URLSearchParams();
+  for (const name of filters) {
+    const value = search.get(name);
+    if (value) params.set(name, value);
+  }
+  function setFilter(name: string, value: string) {
+    const next = new URLSearchParams(search.toString());
+    if (value === "all" || value === "newest") next.delete(name);
+    else next.set(name, value);
+    pagination.reset();
+    window.history.pushState(
+      null,
+      "",
+      `${pathname}${next.size ? `?${next}` : ""}`,
+    );
+  }
+
   const query = useApiQuery<DeploymentHistoryPage>(
-    `/v1/core/deployments/history?page=${pagination.page}&limit=${pagination.pageSize}`,
+    `/v1/core/deployments/history?page=${pagination.page}&limit=${pagination.pageSize}&${params}`,
     5_000,
   );
   const { setTotal, reset } = pagination;
+  const filterKey = params.toString();
+  useEffect(() => reset(), [filterKey, reset]);
   useEffect(() => {
     if (!query.data) return;
     setTotal(query.data.pagination.total);
@@ -109,6 +147,94 @@ export function DeploymentsIndex() {
 
   return (
     <DashboardPage icon={Rocket01Icon} title="Deployments">
+      <SecondarySection title="Filter deployments">
+        <div className="grid gap-4">
+          <ScoutSelect
+            label="Type"
+            value={search.get("type") ?? "all"}
+            onChange={(v) => setFilter("type", v)}
+            options={[
+              { id: "all", label: "All workloads" },
+              { id: "app", label: "Apps" },
+              { id: "resource", label: "Resources" },
+            ]}
+          />
+          <ScoutSelect
+            label="Environment"
+            value={search.get("environment") ?? "all"}
+            onChange={(v) => setFilter("environment", v)}
+            options={[
+              { id: "all", label: "All environments" },
+              { id: "production", label: "Production" },
+              { id: "preview", label: "Preview" },
+            ]}
+          />
+          <ScoutSelect
+            label="Status"
+            value={search.get("state") ?? "all"}
+            onChange={(v) => setFilter("state", v)}
+            options={[
+              { id: "all", label: "All statuses" },
+              ...deploymentStates.map((id) => ({
+                id,
+                label: id
+                  .replaceAll("_", " ")
+                  .replace(/^./, (c) => c.toUpperCase()),
+              })),
+            ]}
+          />
+          <ScoutSelect
+            label="Trigger"
+            value={search.get("trigger") ?? "all"}
+            onChange={(v) => setFilter("trigger", v)}
+            options={[
+              { id: "all", label: "All triggers" },
+              { id: "manual", label: "Manual" },
+              { id: "auto_deploy", label: "Auto-deploy" },
+              { id: "rollback", label: "Rollback" },
+            ]}
+          />
+          <ScoutSelect
+            label="Server"
+            value={search.get("serverId") ?? "all"}
+            onChange={(v) => setFilter("serverId", v)}
+            options={[
+              { id: "all", label: "All servers" },
+              ...(servers.data?.servers ?? []).map((server) => ({
+                id: server.id,
+                label: server.canonicalIp,
+              })),
+            ]}
+          />
+          {params.size > 0 ? (
+            <Button
+              size="sm"
+              variant="secondary"
+              onPress={() => {
+                pagination.reset();
+                window.history.pushState(null, "", pathname);
+              }}
+            >
+              <HugeiconsIcon icon={Cancel01Icon} className="size-4" />
+              Clear filters
+            </Button>
+          ) : null}
+        </div>
+      </SecondarySection>
+      <SecondarySection title="Sort deployments">
+        <ScoutSelect
+          label="Sort"
+          hideLabel
+          value={search.get("sort") ?? "newest"}
+          onChange={(v) => setFilter("sort", v)}
+          options={[
+            { id: "newest", label: "Newest first" },
+            { id: "oldest", label: "Oldest first" },
+            { id: "name_asc", label: "Workload A–Z" },
+            { id: "name_desc", label: "Workload Z–A" },
+          ]}
+        />
+      </SecondarySection>
       <div className="grid gap-4">
         {query.error ? (
           <QueryError message={query.error} />
@@ -118,8 +244,14 @@ export function DeploymentsIndex() {
           <ResourceTable
             ariaLabel="All deployments"
             columns={columns}
-            emptyTitle="No deployments yet"
-            emptyDescription="Deploy an app or resource to see its deployment history here."
+            emptyTitle={
+              params.size ? "No matching deployments" : "No deployments yet"
+            }
+            emptyDescription={
+              params.size
+                ? "Try changing or clearing the filters."
+                : "Deploy an app or resource to see its deployment history here."
+            }
             getRowHref={(item) =>
               `/sources/${item.sourceId}/deployments/${item.id}`
             }

--- a/apps/towbar-web-app/src/components/github-settings.tsx
+++ b/apps/towbar-web-app/src/components/github-settings.tsx
@@ -131,6 +131,12 @@ export function GitHubSettings() {
             </Alert.Description>
             <div className="mt-3">
               <ActionButton
+                confirm={{
+                  title: "Retry GitHub reporting?",
+                  description:
+                    "Retry pending or failed Preview reports. This can update deployment statuses and comments on GitHub.",
+                  actionLabel: "Retry reporting",
+                }}
                 action={async () => {
                   const result = await api.post<{
                     attempted: number;

--- a/apps/towbar-web-app/src/components/integrations.tsx
+++ b/apps/towbar-web-app/src/components/integrations.tsx
@@ -14,6 +14,7 @@ import type {
 import { useApiQuery } from "@/hooks/use-api-query";
 import { usePageQuery } from "@/hooks/use-page-query";
 
+import { PageSelectionTitle } from "./page-selection-title";
 import { AwsIntegration } from "@/components/aws-integration";
 import { GitHubSettings } from "@/components/github-settings";
 import { NotificationIntegration } from "@/components/notification-integration";
@@ -106,6 +107,10 @@ export function Integrations() {
 
   return (
     <>
+      <PageSelectionTitle
+        label={activeProvider.label}
+        icon={<HugeiconsIcon icon={activeProvider.icon} />}
+      />
       {integrationGroups.map((group) => (
         <SecondaryItems
           key={group.value}

--- a/apps/towbar-web-app/src/components/integrations.tsx
+++ b/apps/towbar-web-app/src/components/integrations.tsx
@@ -3,25 +3,26 @@
 import {
   CloudIcon,
   GithubIcon,
-  GitBranchIcon,
   Mail01Icon,
-  Notification03Icon,
   SlackIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import type { Key } from "react";
+import type {
+  AwsCredentialMetadata,
+  GitHubConnection,
+} from "@workspace/towbar-web-client";
+import { useApiQuery } from "@/hooks/use-api-query";
+import { usePageQuery } from "@/hooks/use-page-query";
 
 import { AwsIntegration } from "@/components/aws-integration";
 import { GitHubSettings } from "@/components/github-settings";
 import { NotificationIntegration } from "@/components/notification-integration";
-import { ResponsiveSubtabs } from "@/components/responsive-subtabs";
+import { SecondaryItems } from "@/components/secondary-sidebar";
 
 const integrationGroups = [
   {
     value: "source-control",
     label: "Source control",
-    icon: GitBranchIcon,
     providers: [
       {
         value: "github",
@@ -47,7 +48,6 @@ const integrationGroups = [
   {
     value: "notifications",
     label: "Notifications",
-    icon: Notification03Icon,
     providers: [
       {
         value: "slack",
@@ -66,56 +66,68 @@ const integrationGroups = [
 ];
 
 export function Integrations() {
-  const pathname = usePathname();
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const requested = searchParams.get("integration");
-  const activeGroup =
-    integrationGroups.find((group) =>
-      group.providers.some((provider) => provider.value === requested),
-    ) ?? integrationGroups[0]!;
+  const { search, update } = usePageQuery();
+  const github = useApiQuery<{ connection: GitHubConnection | null }>(
+    "/v1/core/github",
+    30_000,
+  );
+  const aws = useApiQuery<{ credential: AwsCredentialMetadata | null }>(
+    "/v1/core/aws",
+    30_000,
+  );
+  const notifications = useApiQuery<{
+    providers: { slack: boolean; smtp: boolean };
+  }>("/v1/core/notifications/providers", 30_000);
+  const statuses: Record<string, string | undefined> = {
+    github:
+      !github.error &&
+      github.data?.connection &&
+      !github.data.connection.suspendedAt
+        ? "Connected"
+        : undefined,
+    aws:
+      !aws.error && aws.data?.credential?.status === "verified"
+        ? "Connected"
+        : undefined,
+    slack:
+      !notifications.error && notifications.data?.providers.slack
+        ? "Configured"
+        : undefined,
+    email:
+      !notifications.error && notifications.data?.providers.smtp
+        ? "Configured"
+        : undefined,
+  };
+  const providers = integrationGroups.flatMap((group) => group.providers);
   const activeProvider =
-    activeGroup.providers.find((provider) => provider.value === requested) ??
-    activeGroup.providers[0]!;
-
-  function selectProvider(key: Key) {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set("integration", String(key));
-    router.push(`${pathname}?${params.toString()}`, { scroll: false });
-  }
+    providers.find(
+      (provider) => provider.value === search.get("integration"),
+    ) ?? providers[0]!;
 
   return (
-    <ResponsiveSubtabs
-      ariaLabel="Integration categories"
-      defaultSelectedKey="source-control"
-      selectedKey={activeGroup.value}
-      onSelectionChange={(key) => {
-        const group = integrationGroups.find((item) => item.value === key);
-        if (group) selectProvider(group.providers[0]!.value);
-      }}
-      tabs={integrationGroups.map((group) => ({
-        value: group.value,
-        label: group.label,
-        icon: <HugeiconsIcon icon={group.icon} />,
-        content: (
-          <ResponsiveSubtabs
-            ariaLabel={`${group.label} integrations`}
-            layout="inline"
-            collapseOnMobile={false}
-            defaultSelectedKey={group.providers[0]!.value}
-            selectedKey={
-              group === activeGroup
-                ? activeProvider.value
-                : group.providers[0]!.value
-            }
-            onSelectionChange={selectProvider}
-            tabs={group.providers.map((provider) => ({
-              ...provider,
-              icon: <HugeiconsIcon icon={provider.icon} />,
-            }))}
-          />
-        ),
-      }))}
-    />
+    <>
+      {integrationGroups.map((group) => (
+        <SecondaryItems
+          key={group.value}
+          title={group.label}
+          selected={activeProvider.value}
+          onSelect={(value) => update({ integration: value })}
+          items={group.providers.map((provider) => ({
+            id: provider.value,
+            label: provider.label,
+            icon: <HugeiconsIcon icon={provider.icon} />,
+            badge: statuses[provider.value] ? (
+              <span
+                role="img"
+                aria-label={statuses[provider.value]}
+                title={statuses[provider.value]}
+                className="block size-1.5 rounded-full bg-success"
+              />
+            ) : undefined,
+          }))}
+        />
+      ))}
+      {activeProvider.content}
+    </>
   );
 }

--- a/apps/towbar-web-app/src/components/inventory-sidebar.tsx
+++ b/apps/towbar-web-app/src/components/inventory-sidebar.tsx
@@ -1,0 +1,211 @@
+"use client";
+import {
+  AlertCircleIcon,
+  DashboardCircleIcon,
+  Cancel01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import type { Server, Source } from "@workspace/towbar-web-client";
+import { Input } from "@workspace/web-design-system/forms/input";
+import { Button } from "@workspace/web-design-system/buttons/button";
+import { usePageQuery } from "@/hooks/use-page-query";
+import { SecondaryItems, SecondarySection } from "./secondary-sidebar";
+import { ScoutSelect } from "./scout-controls";
+
+type Kind = "apps" | "resources" | "servers" | "sources";
+export type InventoryCounts = { all: number; attention: number };
+const keys: Record<Kind, string[]> = {
+  apps: ["q", "view", "sourceId", "serverIp", "running", "health"],
+  resources: [
+    "q",
+    "view",
+    "sourceId",
+    "serverIp",
+    "resourceType",
+    "running",
+    "health",
+  ],
+  servers: ["q", "view", "setup", "health", "scout"],
+  sources: ["q", "view", "sync", "autoDeploy"],
+};
+export function useInventoryQuery(kind: Kind) {
+  const { search } = usePageQuery();
+  const params = new URLSearchParams();
+  for (const key of keys[kind]) {
+    const value = search.get(key);
+    if (value) params.set(key, value);
+  }
+  return `/v1/core/${kind}${params.size ? `?${params}` : ""}`;
+}
+export function InventorySidebar({
+  kind,
+  counts,
+  sources = [],
+  servers = [],
+}: {
+  kind: Kind;
+  counts?: InventoryCounts;
+  sources?: Source[];
+  servers?: Server[];
+}) {
+  const { search, update } = usePageQuery();
+  const workload = kind === "apps" || kind === "resources";
+  const controls: Array<{
+    key: string;
+    label: string;
+    options: Array<{ id: string; label: string }>;
+  }> = [];
+  const options = (values: string[]) =>
+    values.map((id) => ({ id, label: id[0]!.toUpperCase() + id.slice(1) }));
+  if (workload)
+    controls.push(
+      {
+        key: "sourceId",
+        label: "Source",
+        options: sources.map((s) => ({
+          id: s.id,
+          label: `${s.repositoryOwner}/${s.repositoryName}`,
+        })),
+      },
+      {
+        key: "serverIp",
+        label: "Server",
+        options: servers.map((s) => ({
+          id: s.canonicalIp,
+          label: s.canonicalIp,
+        })),
+      },
+      ...(kind === "resources"
+        ? [
+            {
+              key: "resourceType",
+              label: "Resource type",
+              options: [
+                { id: "postgres", label: "PostgreSQL" },
+                { id: "redis", label: "Redis" },
+                { id: "image", label: "Docker image" },
+              ],
+            },
+          ]
+        : []),
+      {
+        key: "running",
+        label: "Running state",
+        options: options(["running", "stopped", "missing", "unknown"]),
+      },
+      {
+        key: "health",
+        label: "Health",
+        options: options([
+          "healthy",
+          "unhealthy",
+          "starting",
+          "none",
+          "unknown",
+        ]),
+      },
+    );
+  if (kind === "servers")
+    controls.push(
+      {
+        key: "setup",
+        label: "Setup status",
+        options: options(["ready", "pending", "preparing", "failed"]),
+      },
+      {
+        key: "health",
+        label: "Health",
+        options: options(["healthy", "unhealthy", "unknown"]),
+      },
+      {
+        key: "scout",
+        label: "Scout Agent",
+        options: options([
+          "online",
+          "offline",
+          "disabled",
+          "queued",
+          "installing",
+          "uninstalling",
+          "waiting",
+          "failed",
+        ]),
+      },
+    );
+  if (kind === "sources")
+    controls.push(
+      {
+        key: "sync",
+        label: "Sync status",
+        options: [
+          { id: "never", label: "Not synced" },
+          ...options(["queued", "running", "succeeded", "failed"]),
+        ],
+      },
+      {
+        key: "autoDeploy",
+        label: "Auto-deploy",
+        options: options(["enabled", "paused"]),
+      },
+    );
+  return (
+    <>
+      <SecondaryItems
+        title="Views"
+        selected={search.get("view") ?? "all"}
+        onSelect={(value) => update({ view: value === "all" ? null : value })}
+        items={[
+          {
+            id: "all",
+            label: `All ${kind}`,
+            badge: counts?.all?.toString(),
+            icon: <HugeiconsIcon icon={DashboardCircleIcon} />,
+          },
+          {
+            id: "attention",
+            label: "Needs attention",
+            badge: counts?.attention?.toString(),
+            icon: <HugeiconsIcon icon={AlertCircleIcon} />,
+          },
+        ]}
+      />
+      <SecondarySection title={`Filter ${kind}`}>
+        <div className="grid gap-4">
+          {controls.map((control) => (
+            <ScoutSelect
+              key={control.key}
+              label={control.label}
+              value={search.get(control.key) ?? "all"}
+              onChange={(value) =>
+                update({ [control.key]: value === "all" ? null : value })
+              }
+              options={[{ id: "all", label: "All" }, ...control.options]}
+            />
+          ))}
+          {keys[kind].some((key) => search.has(key)) ? (
+            <Button
+              variant="secondary"
+              size="sm"
+              onPress={() =>
+                update(Object.fromEntries(keys[kind].map((key) => [key, null])))
+              }
+            >
+              <HugeiconsIcon icon={Cancel01Icon} className="size-4" />
+              Clear filters
+            </Button>
+          ) : null}
+        </div>
+      </SecondarySection>
+      <Input
+        className="w-full max-w-sm"
+        aria-label={`Search ${kind}`}
+        placeholder={
+          kind === "servers" ? "Search IP address…" : `Search ${kind}…`
+        }
+        value={search.get("q") ?? ""}
+        maxLength={200}
+        onChange={(event) => update({ q: event.target.value }, true)}
+      />
+    </>
+  );
+}

--- a/apps/towbar-web-app/src/components/inventory-sidebar.tsx
+++ b/apps/towbar-web-app/src/components/inventory-sidebar.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { PageSelectionTitle } from "./page-selection-title";
 import {
   AlertCircleIcon,
   DashboardCircleIcon,
@@ -150,6 +151,22 @@ export function InventorySidebar({
     );
   return (
     <>
+      <PageSelectionTitle
+        icon={
+          <HugeiconsIcon
+            icon={
+              search.get("view") === "attention"
+                ? AlertCircleIcon
+                : DashboardCircleIcon
+            }
+          />
+        }
+        label={
+          search.get("view") === "attention"
+            ? `${kind[0]!.toUpperCase()}${kind.slice(1)} needing attention`
+            : `All ${kind}`
+        }
+      />
       <SecondaryItems
         title="Views"
         selected={search.get("view") ?? "all"}

--- a/apps/towbar-web-app/src/components/monitoring-agent-settings.tsx
+++ b/apps/towbar-web-app/src/components/monitoring-agent-settings.tsx
@@ -169,6 +169,15 @@ function MonitoringAgentForm({
           {canManage && days !== agent.retentionDays ? (
             <div>
               <ActionButton
+                confirm={
+                  days < agent.retentionDays
+                    ? {
+                        title: "Reduce performance retention?",
+                        description: `Performance data older than ${days} days will be removed. This cannot be undone.`,
+                        actionLabel: "Reduce retention",
+                      }
+                    : undefined
+                }
                 action={() => api.patch(endpoint, { retentionDays: days })}
                 onSuccess={() => setRetention(null)}
                 isDisabled={busy}
@@ -210,7 +219,12 @@ function MonitoringAgentForm({
                           "Install the latest version of Scout Agent. Reporting may pause briefly.",
                         actionLabel: "Update Scout Agent",
                       }
-                    : undefined
+                    : {
+                        title: "Install Scout Agent?",
+                        description:
+                          "Install Scout Agent on this server and begin collecting performance data.",
+                        actionLabel: "Install Scout Agent",
+                      }
                 }
                 onSuccess={() => {
                   setAcknowledged(false);

--- a/apps/towbar-web-app/src/components/monitoring-entity-picker.tsx
+++ b/apps/towbar-web-app/src/components/monitoring-entity-picker.tsx
@@ -145,7 +145,7 @@ export function MonitoringEntityPicker({
               <span className="grid gap-0.5">
                 <span>{entity.name}</span>
                 {entity.kind !== "server" ? (
-                  <span className="text-xs font-normal text-muted">
+                  <span className="text-xs font-normal">
                     {entity.serverName}
                   </span>
                 ) : null}

--- a/apps/towbar-web-app/src/components/monitoring-entity-picker.tsx
+++ b/apps/towbar-web-app/src/components/monitoring-entity-picker.tsx
@@ -1,17 +1,10 @@
 "use client";
-import { HugeiconsIcon } from "@hugeicons/react";
-import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
-import { useEffect, useState } from "react";
-import {
-  Autocomplete,
-  SearchField,
-} from "@workspace/web-design-system/pickers/autocomplete";
-import { ListBox } from "@workspace/web-design-system/forms/select";
-import { Label } from "@workspace/web-design-system/forms/label";
-import { Chip } from "@workspace/web-design-system/data-display/chip";
-import { Button } from "@workspace/web-design-system/buttons/button";
+
+import { useEffect, useMemo, useState } from "react";
 import { QueryError } from "@workspace/towbar-web-ui/query-state";
-import { useApiQuery } from "@/hooks/use-api-query";
+import { Input } from "@workspace/web-design-system/forms/input";
+import { api } from "@/lib/api";
+import { SecondaryItems, SecondarySection } from "./secondary-sidebar";
 import { ScoutIcon } from "./scout-icons";
 import { ScoutSelect } from "./scout-controls";
 import type { MonitoringEntity } from "./workspace-monitoring-shared";
@@ -30,202 +23,127 @@ export function MonitoringEntityPicker({
   allowAll?: boolean;
 }) {
   const [search, setSearch] = useState("");
-  const [debounced, setDebounced] = useState("");
-  const [after, setAfter] = useState("");
-  const [open, setOpen] = useState(false);
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebounced(search);
-      setAfter("");
-    }, 200);
-    return () => clearTimeout(timer);
-  }, [search]);
-  const query = useApiQuery<{
+  const [result, setResult] = useState<{
+    kind: string;
     entities: MonitoringEntity[];
-    nextAfter: string | null;
-  }>(
-    `/v1/core/monitoring/entities?kind=${kind}&search=${encodeURIComponent(debounced)}&after=${encodeURIComponent(after)}&limit=100`,
-    30_000,
+  }>();
+  const [error, setError] = useState<string>();
+  useEffect(() => {
+    let active = true;
+    async function load() {
+      try {
+        const entities: MonitoringEntity[] = [];
+        let after: string | null = "";
+        do {
+          const page: {
+            entities: MonitoringEntity[];
+            nextAfter: string | null;
+          } = await api.get(
+            `/v1/core/monitoring/entities?kind=${kind}&after=${encodeURIComponent(after)}&limit=100`,
+          );
+          if (!active) return;
+          entities.push(...page.entities);
+          after = page.nextAfter;
+        } while (after);
+        setResult({ kind, entities });
+        setError(undefined);
+      } catch (cause) {
+        if (active)
+          setError(
+            cause instanceof Error ? cause.message : "Could not load entities",
+          );
+      }
+    }
+    void load();
+    const timer = setInterval(() => void load(), 30_000);
+    return () => {
+      active = false;
+      clearInterval(timer);
+    };
+  }, [kind]);
+  const entities = useMemo(
+    () => (result?.kind === kind ? result.entities : []),
+    [result, kind],
   );
   useEffect(() => {
-    if (
-      !allowAll &&
-      (!selected || (kind !== "all" && selected.kind !== kind)) &&
-      query.data?.entities[0]
-    )
-      onSelect(query.data.entities[0]);
-  }, [allowAll, kind, selected, query.data, onSelect]);
-  const entities = [...(query.data?.entities ?? [])];
-  if (
-    selected &&
-    !debounced &&
-    (kind === "all" || selected.kind === kind) &&
-    !entities.some((e) => e.key === selected.key)
-  )
-    entities.unshift(selected);
-  return (
-    <div className="grid min-w-0 items-start gap-4 sm:grid-cols-[10rem_minmax(0,1fr)]">
-      <ScoutSelect
-        label="Type"
-        value={kind}
-        options={[
-          { id: "all", label: "All types" },
-          { id: "server", label: "Servers" },
-          { id: "app", label: "Apps" },
-          { id: "resource", label: "Resources" },
-        ]}
-        onChange={(value) => {
-          setSearch("");
-          setDebounced("");
-          setAfter("");
-          onKindChange(value);
-          if (selected && value !== "all" && selected.kind !== value)
-            onSelect(null);
-        }}
-      />
-      <div className="grid min-w-0 gap-2">
-        <Autocomplete
-          aria-label="Server, app, or resource"
-          selectedKey={selected?.key ?? (allowAll ? "all" : null)}
-          variant="secondary"
-          fullWidth
-          isOpen={open}
-          onOpenChange={(value) => {
-            setOpen(value);
-            if (!value) {
-              setSearch("");
-              setDebounced("");
-              setAfter("");
-            }
-          }}
-          onSelectionChange={(key) => {
-            if (key === "all") onSelect(null);
-            else {
-              const entity = entities.find((e) => e.key === key);
-              if (entity) onSelect(entity);
-            }
-          }}
-        >
-          <Label>Server, app, or resource</Label>
-          <Autocomplete.Trigger>
-            <Autocomplete.Value className="flex min-w-0 items-center">
-              {() =>
-                selected ? (
-                  <EntityOption entity={selected} />
-                ) : (
-                  <span>{allowAll ? "All entities" : "Select an entity"}</span>
-                )
-              }
-            </Autocomplete.Value>
-            <Autocomplete.Indicator />
-          </Autocomplete.Trigger>
-          <Autocomplete.Popover className="max-w-[calc(100vw-2rem)]">
-            <Autocomplete.Filter inputValue={search} onInputChange={setSearch}>
-              <SearchField
-                aria-label="Search entities"
-                variant="secondary"
-                className="px-2 pt-2"
-              >
-                <SearchField.Group>
-                  <SearchField.SearchIcon />
-                  <SearchField.Input placeholder="Search by name or IP…" />
-                  <SearchField.ClearButton />
-                </SearchField.Group>
-              </SearchField>
-              <ListBox
-                aria-label="Entities"
-                className="max-h-80 overflow-y-auto"
-                renderEmptyState={() => (
-                  <p className="p-4 text-sm text-muted">
-                    {query.data ? "No matching entities." : "Loading entities…"}
-                  </p>
-                )}
-              >
-                {allowAll ? (
-                  <ListBox.Item id="all" textValue="All entities">
-                    <span className="flex items-center gap-2">
-                      <ScoutIcon name="all" />
-                      All entities
-                    </span>
-                    <ListBox.ItemIndicator />
-                  </ListBox.Item>
-                ) : null}
-                {entities.map((entity) => (
-                  <ListBox.Item
-                    id={entity.key}
-                    key={entity.key}
-                    textValue={`${entity.name} ${entity.kind} ${entity.serverName}`}
-                  >
-                    <EntityOption entity={entity} />
-                    <ListBox.ItemIndicator />
-                  </ListBox.Item>
-                ))}
-              </ListBox>
-            </Autocomplete.Filter>
-            {query.data?.nextAfter || after ? (
-              <div className="flex justify-end gap-2 p-2">
-                {after ? (
-                  <Button
-                    size="sm"
-                    variant="secondary"
-                    onPress={() => setAfter("")}
-                  >
-                    <HugeiconsIcon
-                      aria-hidden="true"
-                      icon={ArrowLeft01Icon}
-                      className="size-4 shrink-0"
-                    />
-                    First results
-                  </Button>
-                ) : null}
-                {query.data?.nextAfter ? (
-                  <Button
-                    size="sm"
-                    variant="secondary"
-                    onPress={() => setAfter(query.data!.nextAfter!)}
-                  >
-                    More results
-                    <ScoutIcon name="next" />
-                  </Button>
-                ) : null}
-              </div>
-            ) : null}
-          </Autocomplete.Popover>
-        </Autocomplete>
-        {query.error ? <QueryError message={query.error} /> : null}
-        {!allowAll && query.data && !query.data.entities.length && !selected ? (
-          <p className="text-sm text-muted">No matching entities.</p>
-        ) : null}
-      </div>
-    </div>
+    if (result?.kind !== kind) return;
+    if (selected && entities.some((entity) => entity.key === selected.key))
+      return;
+    if (!allowAll || selected)
+      onSelect(allowAll ? null : (entities[0] ?? null));
+  }, [kind, result, entities, selected, allowAll, onSelect]);
+  const filtered = entities.filter((entity) =>
+    `${entity.name} ${entity.serverName}`
+      .toLowerCase()
+      .includes(search.toLowerCase()),
   );
-}
-function EntityOption({ entity }: { entity: MonitoringEntity }) {
   return (
-    <span className="flex min-w-0 flex-wrap items-center gap-2 py-0.5">
-      <ScoutIcon name={entity.kind} />
-      <span className="truncate">{entity.name}</span>
-      <Chip
-        size="small"
-        variant={
-          entity.kind === "server"
-            ? "info"
-            : entity.kind === "app"
-              ? "success"
-              : "warning"
+    <>
+      <SecondarySection title="Entity type">
+        <ScoutSelect
+          label="Type"
+          hideLabel
+          value={kind}
+          options={[
+            { id: "all", label: "All types" },
+            { id: "server", label: "Servers" },
+            { id: "app", label: "Apps" },
+            { id: "resource", label: "Resources" },
+          ]}
+          onChange={(value) => {
+            setSearch("");
+            onKindChange(value);
+            if (selected && value !== "all" && selected.kind !== value)
+              onSelect(null);
+          }}
+        />
+        <Input
+          aria-label="Search entities"
+          placeholder="Search name or IP…"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          className="mt-2 w-full"
+        />
+        {error ? <QueryError message={error} /> : null}
+        {result?.kind !== kind && !error ? (
+          <p className="px-2 text-sm text-muted">Loading entities…</p>
+        ) : null}
+      </SecondarySection>
+      <SecondaryItems
+        title="Entities"
+        selected={selected?.key ?? "all"}
+        onSelect={(key) =>
+          onSelect(entities.find((entity) => entity.key === key) ?? null)
         }
-      >
-        {entity.kind === "server"
-          ? "Server"
-          : entity.kind === "app"
-            ? "App"
-            : "Resource"}
-      </Chip>
-      {entity.kind !== "server" ? (
-        <Chip size="small" variant="secondary">
-          {entity.serverName}
-        </Chip>
-      ) : null}
-    </span>
+        items={[
+          ...(allowAll
+            ? [
+                {
+                  id: "all",
+                  label: "All entities",
+                  icon: <ScoutIcon name="all" />,
+                },
+              ]
+            : []),
+          ...filtered.map((entity) => ({
+            id: entity.key,
+            icon: <ScoutIcon name={entity.kind} />,
+            label: (
+              <span className="grid gap-0.5">
+                <span>{entity.name}</span>
+                {entity.kind !== "server" ? (
+                  <span className="text-xs font-normal text-muted">
+                    {entity.serverName}
+                  </span>
+                ) : null}
+              </span>
+            ),
+          })),
+          ...(!filtered.length && result?.kind === kind
+            ? [{ id: "empty", label: "No matching entities", disabled: true }]
+            : []),
+        ]}
+      />
+    </>
   );
 }

--- a/apps/towbar-web-app/src/components/monitoring-entity-picker.tsx
+++ b/apps/towbar-web-app/src/components/monitoring-entity-picker.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { usePageQuery } from "@/hooks/use-page-query";
 
 import { useEffect, useMemo, useState } from "react";
 import { QueryError } from "@workspace/towbar-web-ui/query-state";
@@ -13,16 +14,23 @@ export function MonitoringEntityPicker({
   kind,
   onKindChange,
   selected,
+  entityKey,
+  onResolve,
   onSelect,
   allowAll = false,
 }: {
   kind: string;
   onKindChange: (kind: string) => void;
   selected: MonitoringEntity | null;
-  onSelect: (entity: MonitoringEntity | null) => void;
+  entityKey: string | null;
+  onResolve: (entity: MonitoringEntity | null) => void;
+  onSelect: (entity: MonitoringEntity | null, replace?: boolean) => void;
   allowAll?: boolean;
 }) {
-  const [search, setSearch] = useState("");
+  const { search: pageQuery, update } = usePageQuery();
+  const search = pageQuery.get("entitySearch") ?? "";
+  const setSearch = (value: string) =>
+    update({ entitySearch: value || null }, true);
   const [result, setResult] = useState<{
     kind: string;
     entities: MonitoringEntity[];
@@ -67,11 +75,12 @@ export function MonitoringEntityPicker({
   );
   useEffect(() => {
     if (result?.kind !== kind) return;
-    if (selected && entities.some((entity) => entity.key === selected.key))
-      return;
-    if (!allowAll || selected)
-      onSelect(allowAll ? null : (entities[0] ?? null));
-  }, [kind, result, entities, selected, allowAll, onSelect]);
+    if (entityKey) {
+      onResolve(entities.find((entity) => entity.key === entityKey) ?? null);
+    } else if (!allowAll && entities.length) {
+      onSelect(entities[0]!, true);
+    } else onResolve(null);
+  }, [kind, result, entities, entityKey, allowAll, onSelect, onResolve]);
   const filtered = entities.filter((entity) =>
     `${entity.name} ${entity.serverName}`
       .toLowerCase()
@@ -91,10 +100,7 @@ export function MonitoringEntityPicker({
             { id: "resource", label: "Resources" },
           ]}
           onChange={(value) => {
-            setSearch("");
             onKindChange(value);
-            if (selected && value !== "all" && selected.kind !== value)
-              onSelect(null);
           }}
         />
         <Input
@@ -105,6 +111,13 @@ export function MonitoringEntityPicker({
           className="mt-2 w-full"
         />
         {error ? <QueryError message={error} /> : null}
+        {entityKey &&
+        result?.kind === kind &&
+        !entities.some((entity) => entity.key === entityKey) ? (
+          <p role="status" className="px-2 text-sm text-muted">
+            This entity is unavailable. Choose another entity.
+          </p>
+        ) : null}
         {result?.kind !== kind && !error ? (
           <p className="px-2 text-sm text-muted">Loading entities…</p>
         ) : null}

--- a/apps/towbar-web-app/src/components/monitoring-history.tsx
+++ b/apps/towbar-web-app/src/components/monitoring-history.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { usePageQuery, useQueryChoice } from "@/hooks/use-page-query";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Settings01Icon } from "@hugeicons/core-free-icons";
 import { ScoutOptionIcon } from "./scout-icons";
@@ -60,24 +61,54 @@ export function MonitoringHistory({
   serverId?: string;
   workload?: boolean;
 }) {
-  const [range, setRange] = useState("15m");
-  const [custom, setCustom] = useState<CustomMonitoringRange>();
+  const { search, update } = usePageQuery();
+  const requestedRange = search.get("range");
+  const range =
+    monitoringRanges.some((row) => row.id === requestedRange) &&
+    requestedRange !== "custom"
+      ? requestedRange!
+      : "15m";
+  const startAt = search.get("startAt");
+  const endAt = search.get("endAt");
+  const custom =
+    requestedRange === "custom" &&
+    startAt &&
+    endAt &&
+    Number.isFinite(Date.parse(startAt)) &&
+    Number.isFinite(Date.parse(endAt)) &&
+    Date.parse(endAt) > Date.parse(startAt)
+      ? { startAt, endAt }
+      : undefined;
   const [pickerOpen, setPickerOpen] = useState(false);
   const applyCustom = useCallback(
-    (value: CustomMonitoringRange) => setCustom(value),
-    [],
+    (value: CustomMonitoringRange) =>
+      update({ range: "custom", startAt: value.startAt, endAt: value.endAt }),
+    [update],
   );
-  const selectRange = useCallback((start: number, end: number) => {
-    const to = Math.min(end, Date.now());
-    if (to - start < 30_000) return;
-    setCustom({
-      startAt: new Date(Math.ceil(start)).toISOString(),
-      endAt: new Date(Math.floor(to)).toISOString(),
-    });
-  }, []);
-  const [environment, setEnvironment] = useState("production");
-  const [view, setView] = useState("average");
-  const [instance, setInstance] = useState("all");
+  const selectRange = useCallback(
+    (start: number, end: number) => {
+      const to = Math.min(end, Date.now());
+      if (to - start < 30_000) return;
+      applyCustom({
+        startAt: new Date(Math.ceil(start)).toISOString(),
+        endAt: new Date(Math.floor(to)).toISOString(),
+      });
+    },
+    [applyCustom],
+  );
+  const [environment] = useQueryChoice(
+    "environment",
+    ["production", "preview"],
+    "production",
+  );
+  const [view, setView] = useQueryChoice(
+    "metricView",
+    ["average", "peak"],
+    "average",
+  );
+  const instance = search.get("instance") ?? "all";
+  const setInstance = (value: string) =>
+    update({ instance: value === "all" ? null : value });
   const syncId = useId();
   const query = useApiQuery<History>(
     `${path}?${new URLSearchParams({ range: custom ? "custom" : range, environment, ...custom })}`,
@@ -133,8 +164,10 @@ export function MonitoringHistory({
               label="Environment"
               value={environment}
               onChange={(value) => {
-                setEnvironment(value);
-                setInstance("all");
+                update({
+                  environment: value === "production" ? null : value,
+                  instance: null,
+                });
               }}
               options={[
                 { id: "production", label: "Production" },
@@ -173,8 +206,11 @@ export function MonitoringHistory({
                 setPickerOpen(true);
                 return;
               }
-              setRange(value);
-              setCustom(undefined);
+              update({
+                range: value === "15m" ? null : value,
+                startAt: null,
+                endAt: null,
+              });
             }}
             onReselect={(value) => {
               if (value === "custom") setPickerOpen(true);

--- a/apps/towbar-web-app/src/components/page-parts.tsx
+++ b/apps/towbar-web-app/src/components/page-parts.tsx
@@ -1,4 +1,9 @@
 "use client";
+import {
+  PageSelectionContext,
+  PageSelectionTitle,
+  type PageSelection,
+} from "./page-selection-title";
 import { DetailSettingsContext, SecondaryItems } from "./secondary-sidebar";
 import {
   FloppyDiskIcon,
@@ -65,36 +70,50 @@ export function DashboardPage({
   title: string;
   titleContent?: ReactNode;
 }) {
+  const [selection, setSelection] = useState<PageSelection | null>(null);
+  const heading = selection
+    ? selection.keepEntityName
+      ? `${title} · ${selection.label}`
+      : selection.label
+    : title;
   return (
-    <ApplicationPage
-      actions={actions}
-      badge={badge}
-      breadcrumbAncestors={breadcrumbAncestors}
-      breadcrumbLabel={breadcrumbLabel}
-      title={title}
-      titleContent={
-        <span className="inline-flex min-w-0 items-center gap-2">
-          <HugeiconsIcon
-            aria-hidden="true"
-            className="size-6 shrink-0"
-            icon={icon}
-          />
-          {titleContent ?? (
-            <TooltipText className="truncate" tooltip={title}>
-              {title}
-            </TooltipText>
-          )}
-        </span>
-      }
-    >
-      <PageSection
-        className="content-grid pt-0"
-        xPadding="none"
-        yPadding="compact"
+    <PageSelectionContext.Provider value={setSelection}>
+      <ApplicationPage
+        actions={actions}
+        badge={badge}
+        breadcrumbAncestors={breadcrumbAncestors}
+        breadcrumbLabel={breadcrumbLabel}
+        title={heading}
+        titleContent={
+          <span className="inline-flex min-w-0 items-center gap-2">
+            <span
+              aria-hidden="true"
+              className="inline-flex shrink-0 [&_svg]:size-6"
+            >
+              {selection?.icon ?? <HugeiconsIcon icon={icon} />}
+            </span>
+            {titleContent && (!selection || selection.keepEntityName) ? (
+              <>
+                {titleContent}
+                {selection ? ` · ${selection.label}` : null}
+              </>
+            ) : (
+              <TooltipText className="truncate" tooltip={heading}>
+                {heading}
+              </TooltipText>
+            )}
+          </span>
+        }
       >
-        {Children.toArray(children)}
-      </PageSection>
-    </ApplicationPage>
+        <PageSection
+          className="content-grid pt-0"
+          xPadding="none"
+          yPadding="compact"
+        >
+          {Children.toArray(children)}
+        </PageSection>
+      </ApplicationPage>
+    </PageSelectionContext.Provider>
   );
 }
 
@@ -154,6 +173,13 @@ export function PageTabs({
   const active = tabs.find((tab) => tab.value === selectedKey);
   return (
     <>
+      {selectedKey !== "settings" && active ? (
+        <PageSelectionTitle
+          label={active.label}
+          icon={active.icon}
+          keepEntityName
+        />
+      ) : null}
       <SecondaryItems
         title="Sections"
         selected={selectedKey}

--- a/apps/towbar-web-app/src/components/page-parts.tsx
+++ b/apps/towbar-web-app/src/components/page-parts.tsx
@@ -176,6 +176,7 @@ export function PageTabs({
             : selectedKey === "info"
               ? (searchParams.get("source-information") ?? detail.subpage)
               : undefined,
+          true,
         ),
       );
     }

--- a/apps/towbar-web-app/src/components/page-parts.tsx
+++ b/apps/towbar-web-app/src/components/page-parts.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { SecondaryItems } from "./secondary-sidebar";
+import { DetailSettingsContext, SecondaryItems } from "./secondary-sidebar";
 import {
   FloppyDiskIcon,
   Cancel01Icon,
@@ -158,27 +158,34 @@ export function PageTabs({
         title="Sections"
         selected={selectedKey}
         onSelect={selectSection}
-        items={tabs.map((tab) => ({
-          id: tab.value,
-          label: tab.label,
-          icon: tab.icon,
-          badge:
-            typeof tab.indicator === "object" ? (
-              tab.indicator.dot ? (
-                <span
-                  role="img"
-                  aria-label={tab.indicator.ariaLabel ?? "Needs attention"}
-                  className="inline-block size-2 rounded-full bg-warning"
-                />
+        items={tabs
+          .filter((tab) => tab.value !== "settings")
+          .map((tab) => ({
+            id: tab.value,
+            label: tab.label,
+            icon: tab.icon,
+            badge:
+              typeof tab.indicator === "object" ? (
+                tab.indicator.dot ? (
+                  <span
+                    role="img"
+                    aria-label={tab.indicator.ariaLabel ?? "Needs attention"}
+                    className="inline-block size-2 rounded-full bg-warning"
+                  />
+                ) : (
+                  tab.indicator.label
+                )
               ) : (
-                tab.indicator.label
-              )
-            ) : (
-              tab.indicator
-            ),
-        }))}
+                tab.indicator
+              ),
+          }))}
       />
-      <div className="min-w-0">{active?.content}</div>
+      <DetailSettingsContext.Provider value={selectedKey === "settings"}>
+        {tabs.find((tab) => tab.value === "settings")?.content}
+      </DetailSettingsContext.Provider>
+      {selectedKey !== "settings" ? (
+        <div className="min-w-0">{active?.content}</div>
+      ) : null}
     </>
   );
 }

--- a/apps/towbar-web-app/src/components/page-parts.tsx
+++ b/apps/towbar-web-app/src/components/page-parts.tsx
@@ -105,7 +105,12 @@ export function DashboardPage({
         }
       >
         {selection?.keepEntityName ? (
-          <SecondaryEntityHeader>{titleContent ?? title}</SecondaryEntityHeader>
+          <SecondaryEntityHeader
+            title={title}
+            icon={<HugeiconsIcon icon={icon} />}
+          >
+            {titleContent ?? title}
+          </SecondaryEntityHeader>
         ) : null}
         <PageSection
           className="content-grid pt-0"

--- a/apps/towbar-web-app/src/components/page-parts.tsx
+++ b/apps/towbar-web-app/src/components/page-parts.tsx
@@ -16,7 +16,9 @@ import { TooltipText } from "@workspace/web-design-system/overlays/tooltip";
 
 import Link from "next/link";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { Children } from "react";
+import { useDetailNavigation } from "@/hooks/use-detail-navigation";
+import { SecondaryEntityHeader } from "./secondary-sidebar";
+import { Children, useEffect } from "react";
 import type { ComponentProps, FormEvent, Key, ReactNode } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useId, useState } from "react";
@@ -71,17 +73,17 @@ export function DashboardPage({
   titleContent?: ReactNode;
 }) {
   const [selection, setSelection] = useState<PageSelection | null>(null);
-  const heading = selection
-    ? selection.keepEntityName
-      ? `${title} · ${selection.label}`
-      : selection.label
-    : title;
+  const heading = selection ? selection.label : title;
   return (
     <PageSelectionContext.Provider value={setSelection}>
       <ApplicationPage
         actions={actions}
         badge={badge}
-        breadcrumbAncestors={breadcrumbAncestors}
+        breadcrumbAncestors={
+          selection?.keepEntityName
+            ? [...breadcrumbAncestors, { label: title }]
+            : breadcrumbAncestors
+        }
         breadcrumbLabel={breadcrumbLabel}
         title={heading}
         titleContent={
@@ -92,11 +94,8 @@ export function DashboardPage({
             >
               {selection?.icon ?? <HugeiconsIcon icon={icon} />}
             </span>
-            {titleContent && (!selection || selection.keepEntityName) ? (
-              <>
-                {titleContent}
-                {selection ? ` · ${selection.label}` : null}
-              </>
+            {titleContent && !selection ? (
+              <>{titleContent}</>
             ) : (
               <TooltipText className="truncate" tooltip={heading}>
                 {heading}
@@ -105,6 +104,9 @@ export function DashboardPage({
           </span>
         }
       >
+        {selection?.keepEntityName ? (
+          <SecondaryEntityHeader>{titleContent ?? title}</SecondaryEntityHeader>
+        ) : null}
         <PageSection
           className="content-grid pt-0"
           xPadding="none"
@@ -147,15 +149,40 @@ export function PageTabs({
 }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const section = searchParams.get("section");
+  const detail = useDetailNavigation();
+  const section = detail.base ? detail.section : searchParams.get("section");
   const requestedSection = section ? (aliases?.[section] ?? section) : null;
   const selectedKey = tabs.some((tab) => tab.value === requestedSection)
     ? requestedSection!
     : defaultValue;
 
+  useEffect(() => {
+    if (
+      detail.base &&
+      (!detail.pathname.slice(detail.base.length) ||
+        searchParams.has("section") ||
+        searchParams.has("settings"))
+    ) {
+      detail.router.replace(
+        detail.href(
+          selectedKey,
+          selectedKey === "settings"
+            ? (detail.settings ?? undefined)
+            : selectedKey === "info"
+              ? (searchParams.get("source-information") ?? detail.subpage)
+              : undefined,
+        ),
+      );
+    }
+  }, [detail, searchParams, selectedKey]);
+
   function selectSection(key: Key) {
     const value = String(key);
     if (value === selectedKey) return;
+    if (detail.base) {
+      detail.router.push(detail.href(value));
+      return;
+    }
     const params = new URLSearchParams(searchParams.toString());
     if (value === defaultValue) params.delete("section");
     else params.set("section", value);

--- a/apps/towbar-web-app/src/components/page-parts.tsx
+++ b/apps/towbar-web-app/src/components/page-parts.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { SecondaryItems } from "./secondary-sidebar";
 import {
   FloppyDiskIcon,
   Cancel01Icon,
@@ -19,7 +20,6 @@ import { Alert } from "@workspace/web-design-system/feedback/alert";
 import { Spinner } from "@workspace/web-design-system/feedback/spinner";
 import { AlertDialog } from "@workspace/web-design-system/overlays/alert-dialog";
 import { Button } from "@workspace/web-design-system/buttons/button";
-import { Chip } from "@workspace/web-design-system/data-display/chip";
 import { Widget } from "@workspace/web-design-system/data-display/widget";
 import {
   Field,
@@ -28,7 +28,6 @@ import {
 } from "@workspace/web-design-system/forms/field";
 import { Input } from "@workspace/web-design-system/forms/input";
 import type { InputProps } from "@workspace/web-design-system/forms/input";
-import { Tabs } from "@workspace/web-design-system/navigation/tabs";
 import { toast } from "@workspace/web-design-system/overlays/toast";
 import { PageSection } from "@workspace/web-design-system/layouts/page";
 import { cn } from "@workspace/web-design-system/lib/utils";
@@ -152,86 +151,35 @@ export function PageTabs({
     );
   }
 
+  const active = tabs.find((tab) => tab.value === selectedKey);
   return (
-    <Tabs
-      className="grid w-full min-w-0 max-w-full gap-4"
-      selectedKey={selectedKey}
-      onSelectionChange={selectSection}
-    >
-      <Tabs.ListContainer className="min-w-0 max-w-full">
-        <Tabs.List aria-label="Page sections">
-          {tabs.map((tab) => (
-            <Tabs.Tab id={tab.value} key={tab.value}>
-              <span className="inline-flex min-w-0 items-center gap-2">
-                {tab.icon ? (
-                  <span
-                    aria-hidden="true"
-                    className="flex shrink-0 items-center justify-center [&_svg]:size-4"
-                  >
-                    {tab.icon}
-                  </span>
-                ) : null}
-                <TooltipText
-                  tabIndex={-1}
-                  className="truncate"
-                  tooltip={
-                    typeof tab.label === "string" ? tab.label : undefined
-                  }
-                >
-                  {tab.label}
-                </TooltipText>
-                {tab.indicator ? (
-                  typeof tab.indicator === "object" && tab.indicator.dot ? (
-                    <TooltipText
-                      aria-label={
-                        tab.indicator.ariaLabel ??
-                        tab.indicator.label ??
-                        "Warning"
-                      }
-                      className="bg-warning size-2 shrink-0 rounded-full"
-                      role="img"
-                      tooltip={
-                        tab.indicator.ariaLabel ??
-                        tab.indicator.label ??
-                        "Warning"
-                      }
-                    />
-                  ) : (
-                    <Chip
-                      aria-label={
-                        typeof tab.indicator === "object"
-                          ? (tab.indicator.ariaLabel ?? tab.indicator.label)
-                          : undefined
-                      }
-                      size="small"
-                      variant={
-                        typeof tab.indicator === "object"
-                          ? tab.indicator.variant
-                          : "default"
-                      }
-                    >
-                      {typeof tab.indicator === "object"
-                        ? (tab.indicator.label ?? "Active")
-                        : "Active"}
-                    </Chip>
-                  )
-                ) : null}
-              </span>
-              <Tabs.Indicator />
-            </Tabs.Tab>
-          ))}
-        </Tabs.List>
-      </Tabs.ListContainer>
-      {tabs.map((tab) => (
-        <Tabs.Panel
-          className="m-0 w-full min-w-0 max-w-full p-0 outline-none"
-          id={tab.value}
-          key={tab.value}
-        >
-          {tab.content}
-        </Tabs.Panel>
-      ))}
-    </Tabs>
+    <>
+      <SecondaryItems
+        title="Sections"
+        selected={selectedKey}
+        onSelect={selectSection}
+        items={tabs.map((tab) => ({
+          id: tab.value,
+          label: tab.label,
+          icon: tab.icon,
+          badge:
+            typeof tab.indicator === "object" ? (
+              tab.indicator.dot ? (
+                <span
+                  role="img"
+                  aria-label={tab.indicator.ariaLabel ?? "Needs attention"}
+                  className="inline-block size-2 rounded-full bg-warning"
+                />
+              ) : (
+                tab.indicator.label
+              )
+            ) : (
+              tab.indicator
+            ),
+        }))}
+      />
+      <div className="min-w-0">{active?.content}</div>
+    </>
   );
 }
 

--- a/apps/towbar-web-app/src/components/page-selection-title.tsx
+++ b/apps/towbar-web-app/src/components/page-selection-title.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { createContext, useContext, useEffect } from "react";
+import type { Dispatch, SetStateAction, ReactNode } from "react";
+
+export type PageSelection = {
+  label: string;
+  keepEntityName?: boolean;
+  icon?: ReactNode;
+};
+export const PageSelectionContext = createContext<Dispatch<
+  SetStateAction<PageSelection | null>
+> | null>(null);
+
+export function PageSelectionTitle({
+  label,
+  icon,
+  keepEntityName = false,
+}: PageSelection) {
+  const setSelection = useContext(PageSelectionContext);
+  useEffect(() => {
+    setSelection?.({ label, keepEntityName, icon });
+    return () => setSelection?.(null);
+  }, [setSelection, label, keepEntityName, icon]);
+  return null;
+}

--- a/apps/towbar-web-app/src/components/preview-environments.tsx
+++ b/apps/towbar-web-app/src/components/preview-environments.tsx
@@ -142,6 +142,12 @@ export function PreviewEnvironments({
           ) : null}
           {preview.status === "cleanup_failed" ? (
             <ActionButton
+              confirm={{
+                title: "Retry Preview cleanup?",
+                description:
+                  "Retry removing this Preview\u2019s container, image, route, and DNS record.",
+                actionLabel: "Retry cleanup",
+              }}
               action={() =>
                 api.post(`/v1/core/previews/${preview.id}/actions/delete`)
               }

--- a/apps/towbar-web-app/src/components/resource-backup-configuration.tsx
+++ b/apps/towbar-web-app/src/components/resource-backup-configuration.tsx
@@ -252,6 +252,12 @@ export function ResourceBackupConfiguration({
                 ) : null}
                 {active ? (
                   <ActionButton
+                    confirm={{
+                      title: "Back up this resource?",
+                      description:
+                        "Create a new backup on the server and upload it to the configured storage.",
+                      actionLabel: "Back up now",
+                    }}
                     action={() =>
                       api.post(
                         `/v1/core/resources/${resource.id}/actions/backup`,
@@ -743,6 +749,12 @@ function RestoreOperationAction({
   if (!canManage || (!cancellable && !cleanable)) return "—";
   return cancellable ? (
     <ActionButton
+      confirm={{
+        title: "Cancel this restore?",
+        description:
+          "Request cancellation of this restore. Review the operation result before using the restored data.",
+        actionLabel: "Cancel restore",
+      }}
       action={() =>
         api.post(
           `/v1/core/resources/${resourceId}/operations/${operation.id}/actions/cancel`,

--- a/apps/towbar-web-app/src/components/resource-detail.tsx
+++ b/apps/towbar-web-app/src/components/resource-detail.tsx
@@ -268,6 +268,12 @@ export function ResourceDetail() {
               type="resource"
             />
             <ActionButton
+              confirm={{
+                title: "Deploy this resource?",
+                description:
+                  "Queue a new resource deployment. This may replace its running container and briefly interrupt connections.",
+                actionLabel: "Deploy resource",
+              }}
               action={() =>
                 api.post<{ deployment: Deployment }>(
                   `/v1/core/resources/${resourceId}/actions/deploy`,

--- a/apps/towbar-web-app/src/components/resource-detail.tsx
+++ b/apps/towbar-web-app/src/components/resource-detail.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useDetailNavigation } from "@/hooks/use-detail-navigation";
 import { ScoutPanel } from "./scout-panel";
 
 import {
@@ -12,7 +13,7 @@ import {
   Settings01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import type { ReactNode } from "react";
 import type {
   Deployment,
@@ -325,7 +326,7 @@ function ResourceSettings({
   item: ResourceRecord;
   resourceId: string;
 }) {
-  const requestedSettings = useSearchParams().get("settings");
+  const requestedSettings = useDetailNavigation().settings;
   const tabs: Array<{ content: ReactNode; label: string; value: string }> = [
     {
       value: "configuration",

--- a/apps/towbar-web-app/src/components/resource-index.tsx
+++ b/apps/towbar-web-app/src/components/resource-index.tsx
@@ -1,5 +1,10 @@
 "use client";
 import {
+  InventorySidebar,
+  useInventoryQuery,
+  type InventoryCounts,
+} from "./inventory-sidebar";
+import {
   Add01Icon,
   DashboardCircleIcon,
   DatabaseIcon,
@@ -28,7 +33,11 @@ import { LastSyncedTime } from "./last-synced-time";
 
 export function SourceIndex() {
   const router = useRouter();
-  const query = useApiQuery<{ sources: Source[] }>("/v1/core/sources", 5_000);
+  const filtered = useInventoryQuery("sources").includes("?");
+  const query = useApiQuery<{ sources: Source[]; counts: InventoryCounts }>(
+    useInventoryQuery("sources"),
+    5_000,
+  );
   const apps = useApiQuery<{ apps: App[] }>("/v1/core/apps", 5_000);
   const resources = useApiQuery<{ resources: Resource[] }>(
     "/v1/core/resources",
@@ -157,6 +166,7 @@ export function SourceIndex() {
       }
       title="Sources"
     >
+      <InventorySidebar kind="sources" counts={query.data?.counts} />
       {error ? (
         <QueryError message={error} />
       ) : !query.data || !apps.data || !resources.data ? (
@@ -175,8 +185,12 @@ export function SourceIndex() {
               Add source
             </ButtonLink>
           }
-          emptyDescription="Connect a GitHub repository to import its Towbar manifest."
-          emptyTitle="No sources yet"
+          emptyDescription={
+            filtered
+              ? "Try changing or clearing the filters."
+              : "Connect a GitHub repository to import its Towbar manifest."
+          }
+          emptyTitle={filtered ? "No matching sources" : "No sources yet"}
           getRowHref={(source) => `/sources/${source.id}`}
           getRowKey={(source) => source.id}
           items={query.data.sources}

--- a/apps/towbar-web-app/src/components/responsive-subtabs.tsx
+++ b/apps/towbar-web-app/src/components/responsive-subtabs.tsx
@@ -1,16 +1,9 @@
 "use client";
 
-import { TooltipText } from "@workspace/web-design-system/overlays/tooltip";
-
-import { useState } from "react";
-import type { Key, ReactNode } from "react";
-
-import { Label } from "@workspace/web-design-system/forms/label";
-import { ListBox, Select } from "@workspace/web-design-system/forms/select";
+import { type Key, type ReactNode } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
 import { cn } from "@workspace/web-design-system/lib/utils";
-import { Tabs } from "@workspace/web-design-system/navigation/tabs";
-
-import { useResponsiveTabsOrientation } from "@/hooks/use-responsive-tabs-orientation";
+import { SecondaryItems } from "./secondary-sidebar";
 
 type ResponsiveSubtab = {
   content: ReactNode;
@@ -23,13 +16,10 @@ type ResponsiveSubtab = {
 
 export function ResponsiveSubtabs({
   ariaLabel,
-  collapseOnMobile = true,
   defaultSelectedKey,
-  layout = "sidebar",
   onSelectionChange,
   panelClassName,
   selectedKey,
-  sidebarWidth = "default",
   tabs,
 }: {
   ariaLabel: string;
@@ -42,149 +32,38 @@ export function ResponsiveSubtabs({
   sidebarWidth?: "default" | "wide";
   tabs: ResponsiveSubtab[];
 }) {
-  const responsiveOrientation = useResponsiveTabsOrientation();
-  const orientation =
-    layout === "sidebar" ? responsiveOrientation : "horizontal";
-  const [internalSelectedKey, setInternalSelectedKey] =
-    useState(defaultSelectedKey);
-  const activeKey = selectedKey ?? internalSelectedKey;
-  const activeTab = tabs.find((tab) => tab.value === activeKey);
-
-  function selectTab(key: Key | null) {
-    if (key === null) return;
-    if (selectedKey === undefined) setInternalSelectedKey(String(key));
+  const pathname = usePathname();
+  const search = useSearchParams();
+  const parameter = ariaLabel.endsWith("settings")
+    ? "settings"
+    : ariaLabel.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  const requested = selectedKey ?? search.get(parameter) ?? defaultSelectedKey;
+  const active =
+    tabs.find((tab) => tab.value === requested && !tab.isDisabled) ??
+    tabs.find((tab) => !tab.isDisabled);
+  function select(key: string) {
+    if (selectedKey === undefined) {
+      const params = new URLSearchParams(search.toString());
+      params.set(parameter, key);
+      window.history.pushState(null, "", `${pathname}?${params}`);
+    }
     onSelectionChange?.(key);
   }
-
   return (
-    <Tabs
-      className="block min-w-0"
-      orientation={orientation}
-      selectedKey={activeKey}
-      onSelectionChange={selectTab}
-    >
-      <div
-        className={cn(
-          "grid min-w-0 grid-cols-1 items-start gap-4",
-          layout === "sidebar"
-            ? sidebarWidth === "wide"
-              ? "lg:grid-cols-[14rem_minmax(0,1fr)]"
-              : "lg:grid-cols-[13rem_minmax(0,1fr)]"
-            : undefined,
-        )}
-      >
-        {collapseOnMobile ? (
-          <Select
-            fullWidth
-            className="md:hidden"
-            selectedKey={activeKey}
-            variant="secondary"
-            onSelectionChange={selectTab}
-          >
-            <Label className="sr-only">{ariaLabel}</Label>
-            <Select.Trigger>
-              <Select.Value>
-                <span className="inline-flex min-w-0 items-center gap-2">
-                  {activeTab?.icon ? (
-                    <span
-                      aria-hidden="true"
-                      className="inline-flex shrink-0 [&_svg]:size-4"
-                    >
-                      {activeTab.icon}
-                    </span>
-                  ) : null}
-                  <span className="truncate">{activeTab?.label}</span>
-                </span>
-              </Select.Value>
-              <Select.Indicator />
-            </Select.Trigger>
-            <Select.Popover>
-              <ListBox>
-                {tabs.map((tab) => (
-                  <ListBox.Item
-                    id={tab.value}
-                    isDisabled={tab.isDisabled}
-                    key={tab.value}
-                    textValue={tab.label}
-                  >
-                    <span className="inline-flex min-w-0 items-center gap-2">
-                      {tab.icon ? (
-                        <span
-                          aria-hidden="true"
-                          className="inline-flex shrink-0 [&_svg]:size-4"
-                        >
-                          {tab.icon}
-                        </span>
-                      ) : null}
-                      {tab.label}
-                    </span>
-                    <ListBox.ItemIndicator />
-                  </ListBox.Item>
-                ))}
-              </ListBox>
-            </Select.Popover>
-          </Select>
-        ) : null}
-        <Tabs.ListContainer
-          className={cn(
-            layout === "sidebar"
-              ? "h-fit w-full self-start"
-              : "w-fit max-w-full overflow-x-auto",
-            collapseOnMobile && "hidden md:block",
-          )}
-        >
-          <Tabs.List
-            aria-label={ariaLabel}
-            className={layout === "sidebar" ? "w-full" : "min-w-max"}
-          >
-            {tabs.map((tab) => (
-              <Tabs.Tab
-                aria-label={
-                  tab.isDisabled && tab.disabledReason
-                    ? `${tab.label}. ${tab.disabledReason}`
-                    : undefined
-                }
-                className={
-                  orientation === "vertical" ? "justify-start" : undefined
-                }
-                id={tab.value}
-                isDisabled={tab.isDisabled}
-                key={tab.value}
-              >
-                <TooltipText
-                  className={cn(
-                    "relative z-10 inline-flex min-w-0 items-center gap-2",
-                    layout === "inline" && "whitespace-nowrap",
-                  )}
-                  tooltip={tab.isDisabled ? tab.disabledReason : undefined}
-                >
-                  {tab.icon ? (
-                    <span
-                      aria-hidden="true"
-                      className="inline-flex shrink-0 [&_svg]:size-4"
-                    >
-                      {tab.icon}
-                    </span>
-                  ) : null}
-                  {tab.label}
-                </TooltipText>
-                <Tabs.Indicator />
-              </Tabs.Tab>
-            ))}
-          </Tabs.List>
-        </Tabs.ListContainer>
-        <div className="min-w-0">
-          {tabs.map((tab) => (
-            <Tabs.Panel
-              className={cn("m-0 block p-0", panelClassName)}
-              id={tab.value}
-              key={tab.value}
-            >
-              {tab.content}
-            </Tabs.Panel>
-          ))}
-        </div>
-      </div>
-    </Tabs>
+    <>
+      <SecondaryItems
+        title={ariaLabel}
+        selected={active?.value ?? ""}
+        onSelect={select}
+        items={tabs.map((tab) => ({
+          id: tab.value,
+          label: tab.label,
+          icon: tab.icon,
+          disabled: tab.isDisabled,
+          disabledReason: tab.disabledReason,
+        }))}
+      />
+      <div className={cn("min-w-0", panelClassName)}>{active?.content}</div>
+    </>
   );
 }

--- a/apps/towbar-web-app/src/components/responsive-subtabs.tsx
+++ b/apps/towbar-web-app/src/components/responsive-subtabs.tsx
@@ -2,8 +2,9 @@
 
 import { HugeiconsIcon } from "@hugeicons/react";
 import { menuIcons } from "./secondary-sidebar";
+import { useDetailNavigation } from "@/hooks/use-detail-navigation";
 import { PageSelectionTitle } from "./page-selection-title";
-import { useContext, type Key, type ReactNode } from "react";
+import { useContext, useEffect, type Key, type ReactNode } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { cn } from "@workspace/web-design-system/lib/utils";
 import { DetailSettingsContext, SecondaryItems } from "./secondary-sidebar";
@@ -36,17 +37,47 @@ export function ResponsiveSubtabs({
   sidebarWidth?: "default" | "wide";
   tabs: ResponsiveSubtab[];
 }) {
+  const detail = useDetailNavigation();
   const detailSettings = useContext(DetailSettingsContext);
   const pathname = usePathname();
   const search = useSearchParams();
   const parameter = ariaLabel.endsWith("settings")
     ? "settings"
     : ariaLabel.toLowerCase().replace(/[^a-z0-9]+/g, "-");
-  const requested = selectedKey ?? search.get(parameter) ?? defaultSelectedKey;
+  const requested =
+    selectedKey ??
+    (detailSettings !== null
+      ? detail.settings
+      : detail.base && detail.section === "info"
+        ? (detail.subpage ?? search.get(parameter))
+        : search.get(parameter)) ??
+    defaultSelectedKey;
   const active =
     tabs.find((tab) => tab.value === requested && !tab.isDisabled) ??
     tabs.find((tab) => !tab.isDisabled);
+  const routeSection =
+    detailSettings !== null
+      ? "settings"
+      : detail.base && detail.section === "info"
+        ? "info"
+        : null;
+  useEffect(() => {
+    if (
+      detail.base &&
+      routeSection &&
+      detailSettings !== false &&
+      active &&
+      !detail.subpage
+    ) {
+      detail.router.replace(detail.href(routeSection, active.value));
+    }
+  }, [detail, routeSection, detailSettings, active]);
   function select(key: string) {
+    if (routeSection && detail.base) {
+      detail.router.push(detail.href(routeSection, key));
+      onSelectionChange?.(key);
+      return;
+    }
     if (selectedKey === undefined) {
       const params = new URLSearchParams(search.toString());
       params.set(parameter, key);
@@ -66,7 +97,7 @@ export function ResponsiveSubtabs({
               <HugeiconsIcon icon={menuIcons[active.value]!} />
             ) : undefined)
           }
-          keepEntityName={detailSettings !== null}
+          keepEntityName={!!detail.base}
         />
       ) : null}
       {Array.from(new Set(tabs.map((tab) => tab.group))).map((group) => (

--- a/apps/towbar-web-app/src/components/responsive-subtabs.tsx
+++ b/apps/towbar-web-app/src/components/responsive-subtabs.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { HugeiconsIcon } from "@hugeicons/react";
+import { menuIcons } from "./secondary-sidebar";
+import { PageSelectionTitle } from "./page-selection-title";
 import { useContext, type Key, type ReactNode } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { cn } from "@workspace/web-design-system/lib/utils";
@@ -54,6 +57,18 @@ export function ResponsiveSubtabs({
   }
   return (
     <>
+      {detailSettings !== false && active ? (
+        <PageSelectionTitle
+          label={active.label}
+          icon={
+            active.icon ??
+            (menuIcons[active.value] ? (
+              <HugeiconsIcon icon={menuIcons[active.value]!} />
+            ) : undefined)
+          }
+          keepEntityName={detailSettings !== null}
+        />
+      ) : null}
       {Array.from(new Set(tabs.map((tab) => tab.group))).map((group) => (
         <SecondaryItems
           key={group ?? ariaLabel}

--- a/apps/towbar-web-app/src/components/responsive-subtabs.tsx
+++ b/apps/towbar-web-app/src/components/responsive-subtabs.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { type Key, type ReactNode } from "react";
+import { useContext, type Key, type ReactNode } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { cn } from "@workspace/web-design-system/lib/utils";
-import { SecondaryItems } from "./secondary-sidebar";
+import { DetailSettingsContext, SecondaryItems } from "./secondary-sidebar";
 
 type ResponsiveSubtab = {
   content: ReactNode;
@@ -32,6 +32,7 @@ export function ResponsiveSubtabs({
   sidebarWidth?: "default" | "wide";
   tabs: ResponsiveSubtab[];
 }) {
+  const detailSettings = useContext(DetailSettingsContext);
   const pathname = usePathname();
   const search = useSearchParams();
   const parameter = ariaLabel.endsWith("settings")
@@ -45,6 +46,7 @@ export function ResponsiveSubtabs({
     if (selectedKey === undefined) {
       const params = new URLSearchParams(search.toString());
       params.set(parameter, key);
+      if (detailSettings !== null) params.set("section", "settings");
       window.history.pushState(null, "", `${pathname}?${params}`);
     }
     onSelectionChange?.(key);
@@ -52,8 +54,8 @@ export function ResponsiveSubtabs({
   return (
     <>
       <SecondaryItems
-        title={ariaLabel}
-        selected={active?.value ?? ""}
+        title={detailSettings !== null ? "Settings" : ariaLabel}
+        selected={detailSettings === false ? "" : (active?.value ?? "")}
         onSelect={select}
         items={tabs.map((tab) => ({
           id: tab.value,
@@ -63,7 +65,11 @@ export function ResponsiveSubtabs({
           disabledReason: tab.disabledReason,
         }))}
       />
-      <div className={cn("min-w-0", panelClassName)}>{active?.content}</div>
+      {detailSettings !== false ? (
+        <DetailSettingsContext.Provider value={null}>
+          <div className={cn("min-w-0", panelClassName)}>{active?.content}</div>
+        </DetailSettingsContext.Provider>
+      ) : null}
     </>
   );
 }

--- a/apps/towbar-web-app/src/components/responsive-subtabs.tsx
+++ b/apps/towbar-web-app/src/components/responsive-subtabs.tsx
@@ -69,7 +69,7 @@ export function ResponsiveSubtabs({
       active &&
       !detail.subpage
     ) {
-      detail.router.replace(detail.href(routeSection, active.value));
+      detail.router.replace(detail.href(routeSection, active.value, true));
     }
   }, [detail, routeSection, detailSettings, active]);
   function select(key: string) {

--- a/apps/towbar-web-app/src/components/responsive-subtabs.tsx
+++ b/apps/towbar-web-app/src/components/responsive-subtabs.tsx
@@ -7,6 +7,7 @@ import { DetailSettingsContext, SecondaryItems } from "./secondary-sidebar";
 
 type ResponsiveSubtab = {
   content: ReactNode;
+  group?: string;
   disabledReason?: string;
   isDisabled?: boolean;
   icon?: ReactNode;
@@ -53,18 +54,23 @@ export function ResponsiveSubtabs({
   }
   return (
     <>
-      <SecondaryItems
-        title={detailSettings !== null ? "Settings" : ariaLabel}
-        selected={detailSettings === false ? "" : (active?.value ?? "")}
-        onSelect={select}
-        items={tabs.map((tab) => ({
-          id: tab.value,
-          label: tab.label,
-          icon: tab.icon,
-          disabled: tab.isDisabled,
-          disabledReason: tab.disabledReason,
-        }))}
-      />
+      {Array.from(new Set(tabs.map((tab) => tab.group))).map((group) => (
+        <SecondaryItems
+          key={group ?? ariaLabel}
+          title={group ?? (detailSettings !== null ? "Settings" : ariaLabel)}
+          selected={detailSettings === false ? "" : (active?.value ?? "")}
+          onSelect={select}
+          items={tabs
+            .filter((tab) => tab.group === group)
+            .map((tab) => ({
+              id: tab.value,
+              label: tab.label,
+              icon: tab.icon,
+              disabled: tab.isDisabled,
+              disabledReason: tab.disabledReason,
+            }))}
+        />
+      ))}
       {detailSettings !== false ? (
         <DetailSettingsContext.Provider value={null}>
           <div className={cn("min-w-0", panelClassName)}>{active?.content}</div>

--- a/apps/towbar-web-app/src/components/runtime-operations.tsx
+++ b/apps/towbar-web-app/src/components/runtime-operations.tsx
@@ -277,6 +277,12 @@ export function RuntimeLogs({
   const result = readLogResult(latest?.result);
   const captureLogsButton = active ? (
     <ActionButton
+      confirm={{
+        title: "Capture container logs?",
+        description:
+          "Queue a server operation to capture the latest 500 log lines from this container.",
+        actionLabel: "Capture logs",
+      }}
       action={() =>
         api.post(
           `/v1/core/${path}/${deployableId}/actions/logs`,

--- a/apps/towbar-web-app/src/components/scout-controls.tsx
+++ b/apps/towbar-web-app/src/components/scout-controls.tsx
@@ -159,7 +159,15 @@ export function ScoutSelect({
       isDisabled={disabled}
       className="min-w-0"
     >
-      <Label className={hideLabel ? "sr-only" : undefined}>{label}</Label>
+      <Label
+        className={
+          hideLabel
+            ? "sr-only"
+            : "[[data-secondary-menu]_&]:pl-2 [[data-secondary-menu]_&]:text-xs [[data-secondary-menu]_&]:text-muted"
+        }
+      >
+        {label}
+      </Label>
       <Select.Trigger>
         <Select.Value className="flex min-w-0 items-center" />
         <Select.Indicator />

--- a/apps/towbar-web-app/src/components/scout-controls.tsx
+++ b/apps/towbar-web-app/src/components/scout-controls.tsx
@@ -169,7 +169,14 @@ export function ScoutSelect({
         {label}
       </Label>
       <Select.Trigger>
-        <Select.Value className="flex min-w-0 items-center" />
+        <Select.Value className="flex min-w-0 flex-1 items-center overflow-hidden">
+          <span className="flex min-w-0 items-center gap-2">
+            <ScoutOptionIcon value={value} label={label} />
+            <span className="truncate">
+              {options.find((option) => option.id === value)?.label}
+            </span>
+          </span>
+        </Select.Value>
         <Select.Indicator />
       </Select.Trigger>
       <Select.Popover>

--- a/apps/towbar-web-app/src/components/scout-icons.tsx
+++ b/apps/towbar-web-app/src/components/scout-icons.tsx
@@ -23,6 +23,8 @@ import {
   GitCompareIcon,
   Globe02Icon,
   Layers01Icon,
+  GitBranchIcon,
+  PlayIcon,
   Mail01Icon,
   Notification01Icon,
   NotificationOff01Icon,
@@ -37,6 +39,34 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { MonitoringMetricIcon } from "./monitoring-metric-icon";
 
 const icons = {
+  healthy: CheckmarkCircle01Icon,
+  unhealthy: AlertCircleIcon,
+  unknown: Clock01Icon,
+  none: Cancel01Icon,
+  missing: AlertCircleIcon,
+  ready: CheckmarkCircle01Icon,
+  pending: Clock01Icon,
+  preparing: RefreshIcon,
+  failed: AlertCircleIcon,
+  queued: Clock01Icon,
+  succeeded: CheckmarkCircle01Icon,
+  never: Clock01Icon,
+  running: PlayIcon,
+  stopped: Cancel01Icon,
+  starting: RefreshIcon,
+  installing: RefreshIcon,
+  uninstalling: RefreshIcon,
+  waiting: Clock01Icon,
+  enabled: CheckmarkCircle01Icon,
+  disabled: Cancel01Icon,
+  paused: Cancel01Icon,
+  online: CheckmarkCircle01Icon,
+  offline: AlertCircleIcon,
+  error: AlertCircleIcon,
+  postgres: DatabaseIcon,
+  redis: DatabaseIcon,
+  image: Layers01Icon,
+  source: GitBranchIcon,
   add: Add01Icon,
   docs: BookOpen01Icon,
   install: Download01Icon,
@@ -102,6 +132,8 @@ export function ScoutOptionIcon({
     return <ScoutIcon name="time" />;
   if (label === "Baseline" || label === "Compare with")
     return <ScoutIcon name="preview" />;
+  if (value !== "all" && label === "Source") return <ScoutIcon name="source" />;
+  if (value !== "all" && label === "Server") return <ScoutIcon name="server" />;
   const key = value.split(":")[0]!;
   return (
     <ScoutIcon

--- a/apps/towbar-web-app/src/components/secondary-sidebar.tsx
+++ b/apps/towbar-web-app/src/components/secondary-sidebar.tsx
@@ -97,6 +97,21 @@ export function SecondarySection({
   return host ? createPortal(content, host) : null;
 }
 
+export function SecondaryEntityHeader({ children }: { children: ReactNode }) {
+  const { host } = useContext(SecondaryContext);
+  return host
+    ? createPortal(
+        <div
+          data-secondary-menu
+          className="order-first min-w-0 border-b border-separator px-2 pb-3 pt-1 text-xl font-medium text-foreground"
+        >
+          {children}
+        </div>,
+        host,
+      )
+    : null;
+}
+
 export type SecondaryItem = {
   id: string;
   label: ReactNode;

--- a/apps/towbar-web-app/src/components/secondary-sidebar.tsx
+++ b/apps/towbar-web-app/src/components/secondary-sidebar.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useId,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  Menu01Icon,
+  DashboardCircleIcon,
+  Settings01Icon,
+  Key01Icon,
+  SourceCodeIcon,
+  ReloadIcon,
+  Rocket01Icon,
+  PlugSocketIcon,
+  ServerStack01Icon,
+  Notification01Icon,
+  GitBranchIcon,
+} from "@hugeicons/core-free-icons";
+import { usePathname } from "next/navigation";
+import { cn } from "@workspace/web-design-system/lib/utils";
+import { Button } from "@workspace/web-design-system/buttons/button";
+
+const SecondaryContext = createContext<{
+  host: HTMLElement | null;
+  close: () => void;
+}>({ host: null, close: () => {} });
+
+export function SecondarySidebarLayout({ children }: { children: ReactNode }) {
+  const [host, setHost] = useState<HTMLElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+  const id = useId();
+  return (
+    <SecondaryContext.Provider value={{ host, close: () => setOpen(false) }}>
+      <div className="min-w-0 lg:grid lg:has-[[data-secondary-menu]]:grid-cols-[13rem_minmax(0,1fr)]">
+        <aside className="hidden min-w-0 border-b border-separator bg-background has-[[data-secondary-menu]]:block lg:sticky lg:top-16 lg:h-[calc(100dvh-4rem)] lg:self-start lg:border-b-0 lg:border-r">
+          <div className="p-3 lg:hidden">
+            <Button
+              variant="secondary"
+              aria-expanded={open}
+              aria-controls={id}
+              onPress={() => setOpen(!open)}
+            >
+              <HugeiconsIcon
+                icon={Menu01Icon}
+                className="size-4"
+                aria-hidden="true"
+              />
+              Page menu
+            </Button>
+          </div>
+          <div
+            id={id}
+            className={cn(
+              "max-h-[60dvh] overflow-y-auto overscroll-contain px-3 py-2 lg:max-h-full lg:h-full",
+              !open && "hidden lg:block",
+            )}
+          >
+            <nav
+              aria-label="Page navigation"
+              key={pathname}
+              className="grid content-start gap-3"
+              ref={setHost}
+            />
+          </div>
+        </aside>
+        <div className="min-w-0">{children}</div>
+      </div>
+    </SecondaryContext.Provider>
+  );
+}
+
+export function SecondarySection({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  const { host } = useContext(SecondaryContext);
+  const content = (
+    <section data-secondary-menu className="grid min-w-0 gap-1">
+      <h2 className="px-2 py-1.5 text-xs font-medium text-muted">{title}</h2>
+      {children}
+    </section>
+  );
+  return host ? createPortal(content, host) : null;
+}
+
+export type SecondaryItem = {
+  id: string;
+  label: ReactNode;
+  icon?: ReactNode;
+  badge?: ReactNode;
+  disabled?: boolean;
+  disabledReason?: string;
+};
+const menuIcons: Record<string, typeof Menu01Icon> = {
+  keys: Key01Icon,
+  api: SourceCodeIcon,
+  mcp: SourceCodeIcon,
+  configuration: Settings01Icon,
+  connection: PlugSocketIcon,
+  "auto-deploy": Rocket01Icon,
+  secrets: Key01Icon,
+  manifest: SourceCodeIcon,
+  "sync-history": ReloadIcon,
+  "source-control": GitBranchIcon,
+  cloud: ServerStack01Icon,
+  notifications: Notification01Icon,
+};
+
+export function SecondaryItems({
+  title,
+  items,
+  selected,
+  onSelect,
+}: {
+  title: string;
+  items: SecondaryItem[];
+  selected: string;
+  onSelect: (id: string) => void;
+}) {
+  const { close } = useContext(SecondaryContext);
+  return (
+    <SecondarySection title={title}>
+      <div className="grid gap-0.5">
+        {items.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            disabled={item.disabled}
+            aria-current={selected === item.id ? "page" : undefined}
+            title={item.disabledReason}
+            onClick={() => {
+              onSelect(item.id);
+              close();
+            }}
+            className={cn(
+              "flex min-h-9 w-full min-w-0 items-center gap-3 rounded-2xl px-2 py-1.5 text-start text-sm outline-offset-2 focus-visible:outline-2 focus-visible:outline-focus disabled:cursor-not-allowed disabled:opacity-50",
+              selected === item.id
+                ? "bg-default font-medium text-foreground"
+                : "font-normal text-muted hover:bg-default/60 hover:text-foreground",
+            )}
+          >
+            {!item.disabled ? (
+              <span
+                aria-hidden="true"
+                className="inline-flex shrink-0 [&_svg]:size-4"
+              >
+                {item.icon ?? (
+                  <HugeiconsIcon
+                    icon={menuIcons[item.id] ?? DashboardCircleIcon}
+                  />
+                )}
+              </span>
+            ) : null}
+            <span className="min-w-0 flex-1 break-words">{item.label}</span>
+            {item.badge ? (
+              <span className="shrink-0 text-xs tabular-nums">
+                {item.badge}
+              </span>
+            ) : null}
+          </button>
+        ))}
+      </div>
+    </SecondarySection>
+  );
+}

--- a/apps/towbar-web-app/src/components/secondary-sidebar.tsx
+++ b/apps/towbar-web-app/src/components/secondary-sidebar.tsx
@@ -10,6 +10,8 @@ import {
 import { createPortal } from "react-dom";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
+  Activity01Icon,
+  Delete02Icon,
   Menu01Icon,
   DashboardCircleIcon,
   Settings01Icon,
@@ -103,7 +105,13 @@ export type SecondaryItem = {
   disabled?: boolean;
   disabledReason?: string;
 };
-const menuIcons: Record<string, typeof Menu01Icon> = {
+export const menuIcons: Record<string, typeof Menu01Icon> = {
+  "host-keys": Key01Icon,
+  monitoring: Activity01Icon,
+  cleanup: Delete02Icon,
+  danger: Delete02Icon,
+  backups: ReloadIcon,
+  preview: Rocket01Icon,
   keys: Key01Icon,
   api: SourceCodeIcon,
   mcp: SourceCodeIcon,

--- a/apps/towbar-web-app/src/components/secondary-sidebar.tsx
+++ b/apps/towbar-web-app/src/components/secondary-sidebar.tsx
@@ -38,7 +38,7 @@ export function SecondarySidebarLayout({ children }: { children: ReactNode }) {
   const id = useId();
   return (
     <SecondaryContext.Provider value={{ host, close: () => setOpen(false) }}>
-      <div className="min-w-0 lg:grid lg:has-[[data-secondary-menu]]:grid-cols-[13rem_minmax(0,1fr)]">
+      <div className="min-w-0 lg:grid lg:has-[[data-secondary-menu]]:grid-cols-[15rem_minmax(0,1fr)]">
         <aside className="hidden min-w-0 border-b border-separator bg-background has-[[data-secondary-menu]]:block lg:sticky lg:top-16 lg:h-[calc(100dvh-4rem)] lg:self-start lg:border-b-0 lg:border-r">
           <div className="p-3 lg:hidden">
             <Button

--- a/apps/towbar-web-app/src/components/secondary-sidebar.tsx
+++ b/apps/towbar-web-app/src/components/secondary-sidebar.tsx
@@ -145,10 +145,8 @@ export function SecondaryItems({
               close();
             }}
             className={cn(
-              "flex min-h-9 w-full min-w-0 items-center gap-3 rounded-2xl px-2 py-1.5 text-start text-sm outline-offset-2 focus-visible:outline-2 focus-visible:outline-focus disabled:cursor-not-allowed disabled:opacity-50",
-              selected === item.id
-                ? "bg-default font-medium text-foreground"
-                : "font-normal text-muted hover:bg-default/60 hover:text-foreground",
+              "flex min-h-9 w-full min-w-0 items-center gap-3 rounded-2xl px-2 py-1.5 text-start text-sm text-foreground hover:bg-default/60 outline-offset-2 focus-visible:outline-2 focus-visible:outline-focus disabled:cursor-not-allowed disabled:opacity-50",
+              selected === item.id ? "font-medium" : "font-normal",
             )}
           >
             {!item.disabled ? (

--- a/apps/towbar-web-app/src/components/secondary-sidebar.tsx
+++ b/apps/towbar-web-app/src/components/secondary-sidebar.tsx
@@ -112,7 +112,7 @@ export function SecondaryEntityHeader({
     ? createPortal(
         <div
           data-secondary-menu
-          className="order-first flex min-w-0 items-center gap-2 border-b border-separator px-2 pb-3 pt-5 text-xl font-medium text-foreground"
+          className="order-first flex min-w-0 items-center gap-2 px-2 pb-3 pt-5 text-xl font-medium text-foreground"
         >
           <span
             aria-hidden="true"

--- a/apps/towbar-web-app/src/components/secondary-sidebar.tsx
+++ b/apps/towbar-web-app/src/components/secondary-sidebar.tsx
@@ -26,6 +26,8 @@ import { usePathname } from "next/navigation";
 import { cn } from "@workspace/web-design-system/lib/utils";
 import { Button } from "@workspace/web-design-system/buttons/button";
 
+export const DetailSettingsContext = createContext<boolean | null>(null);
+
 const SecondaryContext = createContext<{
   host: HTMLElement | null;
   close: () => void;

--- a/apps/towbar-web-app/src/components/secondary-sidebar.tsx
+++ b/apps/towbar-web-app/src/components/secondary-sidebar.tsx
@@ -145,8 +145,10 @@ export function SecondaryItems({
               close();
             }}
             className={cn(
-              "flex min-h-9 w-full min-w-0 items-center gap-3 rounded-2xl px-2 py-1.5 text-start text-sm text-foreground hover:bg-default/60 outline-offset-2 focus-visible:outline-2 focus-visible:outline-focus disabled:cursor-not-allowed disabled:opacity-50",
-              selected === item.id ? "font-medium" : "font-normal",
+              "flex min-h-9 w-full min-w-0 items-center gap-3 rounded-2xl px-2 py-1.5 text-start text-sm text-foreground outline-offset-2 focus-visible:outline-2 focus-visible:outline-focus disabled:cursor-not-allowed disabled:opacity-50",
+              selected === item.id
+                ? "bg-default font-medium"
+                : "font-normal hover:bg-default/60",
             )}
           >
             {!item.disabled ? (

--- a/apps/towbar-web-app/src/components/secondary-sidebar.tsx
+++ b/apps/towbar-web-app/src/components/secondary-sidebar.tsx
@@ -40,8 +40,8 @@ export function SecondarySidebarLayout({ children }: { children: ReactNode }) {
   const id = useId();
   return (
     <SecondaryContext.Provider value={{ host, close: () => setOpen(false) }}>
-      <div className="min-w-0 lg:grid lg:has-[[data-secondary-menu]]:grid-cols-[15rem_minmax(0,1fr)]">
-        <aside className="hidden min-w-0 border-b border-separator bg-background has-[[data-secondary-menu]]:block lg:sticky lg:top-16 lg:h-[calc(100dvh-4rem)] lg:self-start lg:border-b-0 lg:border-r">
+      <div className="min-w-0 lg:grid lg:has-[[data-secondary-menu]]:grid-cols-[auto_minmax(0,1fr)]">
+        <aside className="hidden min-w-0 border-b border-separator bg-background has-[[data-secondary-menu]]:block lg:w-66 lg:sticky lg:top-16 lg:h-[calc(100dvh-4rem)] lg:self-start lg:border-b-0 lg:border-r">
           <div className="p-3 lg:hidden">
             <Button
               variant="secondary"

--- a/apps/towbar-web-app/src/components/secondary-sidebar.tsx
+++ b/apps/towbar-web-app/src/components/secondary-sidebar.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { TooltipText } from "@workspace/web-design-system/overlays/tooltip";
 import { createPortal } from "react-dom";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
@@ -97,15 +98,31 @@ export function SecondarySection({
   return host ? createPortal(content, host) : null;
 }
 
-export function SecondaryEntityHeader({ children }: { children: ReactNode }) {
+export function SecondaryEntityHeader({
+  children,
+  title,
+  icon,
+}: {
+  children: ReactNode;
+  title: string;
+  icon: ReactNode;
+}) {
   const { host } = useContext(SecondaryContext);
   return host
     ? createPortal(
         <div
           data-secondary-menu
-          className="order-first min-w-0 border-b border-separator px-2 pb-3 pt-1 text-xl font-medium text-foreground"
+          className="order-first flex min-w-0 items-center gap-2 border-b border-separator px-2 pb-3 pt-5 text-xl font-medium text-foreground"
         >
-          {children}
+          <span
+            aria-hidden="true"
+            className="inline-flex shrink-0 [&_svg]:size-6"
+          >
+            {icon}
+          </span>
+          <TooltipText className="min-w-0 flex-1 truncate" tooltip={title}>
+            {children}
+          </TooltipText>
         </div>,
         host,
       )

--- a/apps/towbar-web-app/src/components/server-detail.tsx
+++ b/apps/towbar-web-app/src/components/server-detail.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useDetailNavigation } from "@/hooks/use-detail-navigation";
 import {
   Activity01Icon,
   Cancel01Icon,
@@ -22,7 +23,7 @@ import { ServerEditor } from "./server-editor";
 import { ServerHardwareDescription } from "./server-hardware";
 
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useParams, useSearchParams } from "next/navigation";
+import { useParams } from "next/navigation";
 import { useEffect } from "react";
 import type {
   OrphanItem,
@@ -81,7 +82,7 @@ type HostKeyRow = {
 const SERVER_CHECK_PAGE_SIZE = 10;
 
 export function ServerDetail() {
-  const requestedSettings = useSearchParams().get("settings");
+  const requestedSettings = useDetailNavigation().settings;
   const settingsTab = ["monitoring", "host-keys", "cleanup"].includes(
     requestedSettings ?? "",
   )

--- a/apps/towbar-web-app/src/components/server-detail.tsx
+++ b/apps/towbar-web-app/src/components/server-detail.tsx
@@ -369,6 +369,12 @@ export function ServerDetail() {
       icon={ServerStack01Icon}
       actions={
         <ActionButton
+          confirm={{
+            title: "Check this server?",
+            description:
+              "Towbar will connect over SSH, inspect the server and its containers, and record a fresh check result.",
+            actionLabel: "Check server",
+          }}
           action={() => api.post(`/v1/core/servers/${serverId}/actions/check`)}
           pendingLabel="Checking…"
           success="Server check queued"

--- a/apps/towbar-web-app/src/components/server-detail.tsx
+++ b/apps/towbar-web-app/src/components/server-detail.tsx
@@ -556,15 +556,6 @@ export function ServerDetail() {
                   ariaLabel="Server settings"
                   defaultSelectedKey={settingsTab}
                   key={settingsTab}
-                  onSelectionChange={(key) => {
-                    const params = new URLSearchParams(window.location.search);
-                    params.set("settings", String(key));
-                    window.history.pushState(
-                      null,
-                      "",
-                      `/servers/${serverId}?${params.toString()}`,
-                    );
-                  }}
                   tabs={[
                     {
                       value: "configuration",

--- a/apps/towbar-web-app/src/components/source-detail.tsx
+++ b/apps/towbar-web-app/src/components/source-detail.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useDetailNavigation } from "@/hooks/use-detail-navigation";
 import {
   DashboardCircleIcon,
   DatabaseIcon,
@@ -12,7 +13,7 @@ import {
 import { ElapsedTime } from "./elapsed-time";
 
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { type Key, type ReactNode } from "react";
 import type {
   App,
@@ -73,7 +74,7 @@ const SOURCE_SYNC_PAGE_SIZE = 10;
 export function SourceDetail() {
   const { sourceId } = useParams<{ sourceId: string }>();
   const router = useRouter();
-  const searchParams = useSearchParams();
+  const detailNavigation = useDetailNavigation();
   const source = useApiQuery<{
     canManageSource: boolean;
     source: Source;
@@ -348,7 +349,7 @@ export function SourceDetail() {
             content: (
               <SourceSettings
                 canManage={source.data.canManageSource}
-                isActive={searchParams.get("section") === "settings"}
+                isActive={detailNavigation.section === "settings"}
                 onDelete={() => router.push("/sources")}
                 sourceId={sourceId}
               />

--- a/apps/towbar-web-app/src/components/source-notifications.tsx
+++ b/apps/towbar-web-app/src/components/source-notifications.tsx
@@ -148,6 +148,12 @@ export function SourceNotifications({
         canManage ? (
           <div className="flex flex-wrap justify-end gap-2">
             <ActionButton
+              confirm={{
+                title: "Send a test notification?",
+                description:
+                  "Send a test message to this notification destination.",
+                actionLabel: "Send test",
+              }}
               action={() =>
                 api.post(
                   `${endpoint}/destinations/${destination.id}/actions/test`,

--- a/apps/towbar-web-app/src/components/system-health.tsx
+++ b/apps/towbar-web-app/src/components/system-health.tsx
@@ -79,6 +79,12 @@ export function SystemHealthPage() {
       icon={HealthIcon}
       actions={
         <ActionButton<SystemHealth>
+          confirm={{
+            title: "Run system checks?",
+            description:
+              "Run fresh checks against the control plane and configured integrations.",
+            actionLabel: "Run checks",
+          }}
           action={() => api.post("/v1/core/system-health/actions/check")}
           onSuccess={() => query.refresh()}
           pendingLabel="Running checks…"

--- a/apps/towbar-web-app/src/components/workspace-inventory.tsx
+++ b/apps/towbar-web-app/src/components/workspace-inventory.tsx
@@ -1,5 +1,10 @@
 "use client";
 import {
+  InventorySidebar,
+  useInventoryQuery,
+  type InventoryCounts,
+} from "./inventory-sidebar";
+import {
   Add01Icon,
   DashboardCircleIcon,
   DatabaseIcon,
@@ -43,7 +48,10 @@ import { ServerIpLink } from "./source-inventory";
 import { AppIdentity, ResourceIdentity } from "./deployable-identity";
 
 export function AppsIndex() {
-  const apps = useApiQuery<{ apps: App[] }>("/v1/core/apps", 5_000);
+  const apps = useApiQuery<{ apps: App[]; counts: InventoryCounts }>(
+    useInventoryQuery("apps"),
+    5_000,
+  );
   const deployments = useApiQuery<{ deployments: Deployment[] }>(
     "/v1/core/deployments",
     5_000,
@@ -55,6 +63,12 @@ export function AppsIndex() {
 
   return (
     <DashboardPage icon={DashboardCircleIcon} title="Apps">
+      <InventorySidebar
+        kind="apps"
+        counts={apps.data?.counts}
+        sources={sources.data?.sources}
+        servers={servers.data?.servers}
+      />
       {error ? (
         <QueryError message={error} />
       ) : !apps.data || !deployments.data || !sources.data || !servers.data ? (
@@ -77,10 +91,10 @@ export function ResourcesIndex() {
     "/v1/core/deployments",
     5_000,
   );
-  const resources = useApiQuery<{ resources: Resource[] }>(
-    "/v1/core/resources",
-    5_000,
-  );
+  const resources = useApiQuery<{
+    resources: Resource[];
+    counts: InventoryCounts;
+  }>(useInventoryQuery("resources"), 5_000);
   const sources = useApiQuery<{ sources: Source[] }>("/v1/core/sources");
   const servers = useApiQuery<{ servers: Server[] }>("/v1/core/servers");
   const error =
@@ -88,6 +102,12 @@ export function ResourcesIndex() {
 
   return (
     <DashboardPage icon={DatabaseIcon} title="Resources">
+      <InventorySidebar
+        kind="resources"
+        counts={resources.data?.counts}
+        sources={sources.data?.sources}
+        servers={servers.data?.servers}
+      />
       {error ? (
         <QueryError message={error} />
       ) : !deployments.data ||
@@ -114,8 +134,8 @@ export function ServersIndex() {
     "/v1/core/resources",
     5_000,
   );
-  const servers = useApiQuery<{ servers: Server[] }>(
-    "/v1/core/servers",
+  const servers = useApiQuery<{ servers: Server[]; counts: InventoryCounts }>(
+    useInventoryQuery("servers"),
     30_000,
   );
   const error = apps.error ?? resources.error ?? servers.error;
@@ -135,6 +155,7 @@ export function ServersIndex() {
       }
       title="Servers"
     >
+      <InventorySidebar kind="servers" counts={servers.data?.counts} />
       {error ? (
         <QueryError message={error} />
       ) : !apps.data || !resources.data || !servers.data ? (
@@ -177,6 +198,9 @@ function DeployableInventoryTable({
   servers,
   sources,
 }: DeployableInventoryProps) {
+  const filtered = useInventoryQuery(
+    kind === "app" ? "apps" : "resources",
+  ).includes("?");
   const runtimeById = useInventoryRuntimeCapacity();
   const activeDeploymentStates = getActiveDeploymentStates(deployments);
   const sourcesById = new Map(sources.map((source) => [source.id, source]));
@@ -264,11 +288,19 @@ function DeployableInventoryTable({
       ariaLabel={kind === "app" ? "Apps" : "Resources"}
       columns={columns}
       emptyDescription={
-        kind === "app"
-          ? "A successful Source sync imports apps into this workspace."
-          : "A successful Source sync imports resources into this workspace."
+        filtered
+          ? "Try changing or clearing the filters."
+          : kind === "app"
+            ? "A successful Source sync imports apps into this workspace."
+            : "A successful Source sync imports resources into this workspace."
       }
-      emptyTitle={kind === "app" ? "No apps yet" : "No resources yet"}
+      emptyTitle={
+        filtered
+          ? "No matching workloads"
+          : kind === "app"
+            ? "No apps yet"
+            : "No resources yet"
+      }
       getRowHref={(item) =>
         `/sources/${item.sourceId}/${kind === "app" ? "apps" : "resources"}/${item.id}`
       }
@@ -308,6 +340,7 @@ function ServerInventory({
   resources: Resource[];
   servers: Server[];
 }) {
+  const filtered = useInventoryQuery("servers").includes("?");
   const appCounts = countBy(apps, (app) => app.serverIp);
   const resourceCounts = countBy(resources, (resource) => resource.serverIp);
   const columns: ResourceTableColumn<Server>[] = [
@@ -404,8 +437,12 @@ function ServerInventory({
     <ResourceTable
       ariaLabel="Servers"
       columns={columns}
-      emptyDescription="Add a server before syncing a Source that targets its IP address."
-      emptyTitle="No servers yet"
+      emptyDescription={
+        filtered
+          ? "Try changing or clearing the filters."
+          : "Add a server before syncing a Source that targets its IP address."
+      }
+      emptyTitle={filtered ? "No matching servers" : "No servers yet"}
       getRowHref={(server) => `/servers/${server.id}`}
       getRowKey={(server) => server.id}
       items={servers}

--- a/apps/towbar-web-app/src/components/workspace-monitoring-alerts.tsx
+++ b/apps/towbar-web-app/src/components/workspace-monitoring-alerts.tsx
@@ -1,7 +1,6 @@
 "use client";
-import { useState } from "react";
+import { useMonitoringSelection } from "@/hooks/use-monitoring-selection";
 import { MonitoringEntityPicker } from "./monitoring-entity-picker";
-import type { MonitoringEntity } from "./workspace-monitoring-shared";
 import { ScoutIcon } from "./scout-icons";
 import { Notification01Icon } from "@hugeicons/core-free-icons";
 import { Chip } from "@workspace/web-design-system/data-display/chip";
@@ -21,8 +20,14 @@ import {
 } from "./workspace-monitoring-shared";
 
 export function WorkspaceAlerts() {
-  const [kind, setKind] = useState("all");
-  const [selected, setSelected] = useState<MonitoringEntity | null>(null);
+  const {
+    kind,
+    setKind,
+    selected,
+    select: setSelected,
+    entityKey,
+    resolve,
+  } = useMonitoringSelection();
   const { query, pagination, reset } = useMonitoringOverview<OverviewRule>(
     "alerts",
     "all",
@@ -165,18 +170,24 @@ export function WorkspaceAlerts() {
         <MonitoringEntityPicker
           allowAll
           kind={kind}
+          entityKey={entityKey}
+          onResolve={resolve}
           onKindChange={(value) => {
             setKind(value);
             reset();
           }}
           selected={selected}
-          onSelect={(entity) => {
-            setSelected(entity);
+          onSelect={(entity, replace) => {
+            setSelected(entity, replace);
             reset();
           }}
         />
         {query.error ? <QueryError message={query.error} /> : null}
-        {query.data ? (
+        {entityKey && !selected ? (
+          <p className="text-sm text-muted">
+            Select an available entity to view its alerts.
+          </p>
+        ) : query.data ? (
           <ResourceTable
             ariaLabel="Workspace alerts"
             columns={columns}

--- a/apps/towbar-web-app/src/components/workspace-monitoring-alerts.tsx
+++ b/apps/towbar-web-app/src/components/workspace-monitoring-alerts.tsx
@@ -10,6 +10,7 @@ import {
   ResourceTable,
   type ResourceTableColumn,
 } from "@workspace/towbar-web-ui/resource-table";
+import { PageSelectionTitle } from "./page-selection-title";
 import { DashboardPage } from "./page-parts";
 import { conditionDescription, scoutValue } from "./scout-controls";
 import {
@@ -162,7 +163,16 @@ export function WorkspaceAlerts() {
     },
   ];
   return (
-    <DashboardPage title="Alerts" icon={Notification01Icon}>
+    <DashboardPage
+      title={selected ? `${selected.name} · Alerts` : "Alerts"}
+      icon={Notification01Icon}
+    >
+      {selected ? (
+        <PageSelectionTitle
+          label={`${selected.name} · Alerts`}
+          icon={<ScoutIcon name={selected.kind} />}
+        />
+      ) : null}
       <div className="grid gap-5">
         <p className="text-sm text-muted">
           All configured alerts. Open an alert’s entity to manage its rules.

--- a/apps/towbar-web-app/src/components/workspace-monitoring-incidents.tsx
+++ b/apps/towbar-web-app/src/components/workspace-monitoring-incidents.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { SecondaryItems } from "./secondary-sidebar";
 import { ScoutIcon } from "./scout-icons";
 import { useState } from "react";
 import { AlertCircleIcon } from "@hugeicons/core-free-icons";
@@ -10,11 +11,7 @@ import {
   type ResourceTableColumn,
 } from "@workspace/towbar-web-ui/resource-table";
 import { DashboardPage } from "./page-parts";
-import {
-  ScoutSelect,
-  conditionDescription,
-  scoutValue,
-} from "./scout-controls";
+import { conditionDescription, scoutValue } from "./scout-controls";
 import { RelativeTime } from "./last-synced-time";
 import { ScoutIncidentDrawer } from "./scout-incident-drawer";
 import {
@@ -136,30 +133,28 @@ export function WorkspaceIncidents() {
     },
   ];
   return (
-    <DashboardPage
-      title="Incidents"
-      icon={AlertCircleIcon}
-      actions={
-        <div className="flex justify-end">
-          <div className="w-48">
-            <ScoutSelect
-              label="Incident status"
-              hideLabel
-              value={state}
-              onChange={(value) => {
-                setState(value);
-                reset();
-              }}
-              options={[
-                { id: "all", label: "All incidents" },
-                { id: "active", label: "Active" },
-                { id: "resolved", label: "Resolved" },
-              ]}
-            />
-          </div>
-        </div>
-      }
-    >
+    <DashboardPage title="Incidents" icon={AlertCircleIcon}>
+      <SecondaryItems
+        title="Incident status"
+        selected={state}
+        onSelect={(value) => {
+          setState(value);
+          reset();
+        }}
+        items={[
+          { id: "all", label: "All incidents", icon: <ScoutIcon name="all" /> },
+          {
+            id: "active",
+            label: "Active",
+            icon: <ScoutIcon name="critical" />,
+          },
+          {
+            id: "resolved",
+            label: "Resolved",
+            icon: <ScoutIcon name="resolved" />,
+          },
+        ]}
+      />
       <div className="grid gap-5">
         {query.error ? <QueryError message={query.error} /> : null}
         {query.data ? (

--- a/apps/towbar-web-app/src/components/workspace-monitoring-incidents.tsx
+++ b/apps/towbar-web-app/src/components/workspace-monitoring-incidents.tsx
@@ -3,7 +3,10 @@ import { SecondaryItems } from "./secondary-sidebar";
 import { ScoutIcon } from "./scout-icons";
 import { useState } from "react";
 import { useQueryChoice } from "@/hooks/use-page-query";
-import { AlertCircleIcon } from "@hugeicons/core-free-icons";
+import {
+  AlertCircleIcon,
+  CheckmarkCircle02Icon,
+} from "@hugeicons/core-free-icons";
 import { Button } from "@workspace/web-design-system/buttons/button";
 import { Chip } from "@workspace/web-design-system/data-display/chip";
 import { QueryError, QueryLoading } from "@workspace/towbar-web-ui/query-state";
@@ -138,7 +141,16 @@ export function WorkspaceIncidents() {
     },
   ];
   return (
-    <DashboardPage title="Incidents" icon={AlertCircleIcon}>
+    <DashboardPage
+      title={
+        state === "active"
+          ? "Active incidents"
+          : state === "resolved"
+            ? "Resolved incidents"
+            : "All incidents"
+      }
+      icon={state === "resolved" ? CheckmarkCircle02Icon : AlertCircleIcon}
+    >
       <SecondaryItems
         title="Incident status"
         selected={state}

--- a/apps/towbar-web-app/src/components/workspace-monitoring-incidents.tsx
+++ b/apps/towbar-web-app/src/components/workspace-monitoring-incidents.tsx
@@ -2,6 +2,7 @@
 import { SecondaryItems } from "./secondary-sidebar";
 import { ScoutIcon } from "./scout-icons";
 import { useState } from "react";
+import { useQueryChoice } from "@/hooks/use-page-query";
 import { AlertCircleIcon } from "@hugeicons/core-free-icons";
 import { Button } from "@workspace/web-design-system/buttons/button";
 import { Chip } from "@workspace/web-design-system/data-display/chip";
@@ -21,7 +22,11 @@ import {
 } from "./workspace-monitoring-shared";
 
 export function WorkspaceIncidents() {
-  const [state, setState] = useState("all");
+  const [state, setState] = useQueryChoice(
+    "state",
+    ["all", "active", "resolved"],
+    "all",
+  );
   const [selected, setSelected] = useState<OverviewIncident | null>(null);
   const { query, pagination, reset } = useMonitoringOverview<OverviewIncident>(
     "incidents",

--- a/apps/towbar-web-app/src/components/workspace-monitoring-performance.tsx
+++ b/apps/towbar-web-app/src/components/workspace-monitoring-performance.tsx
@@ -1,14 +1,19 @@
 "use client";
-import { useState } from "react";
+import { useMonitoringSelection } from "@/hooks/use-monitoring-selection";
 import { Analytics01Icon } from "@hugeicons/core-free-icons";
 import { DashboardPage } from "./page-parts";
 import { MonitoringEntityPicker } from "./monitoring-entity-picker";
 import { MonitoringHistory } from "./monitoring-history";
-import type { MonitoringEntity } from "./workspace-monitoring-shared";
 
 export function WorkspacePerformance() {
-  const [kind, setKind] = useState("all");
-  const [selected, setSelected] = useState<MonitoringEntity | null>(null);
+  const {
+    kind,
+    setKind,
+    selected,
+    select: setSelected,
+    entityKey,
+    resolve,
+  } = useMonitoringSelection();
   return (
     <DashboardPage
       title={selected?.name ?? "Performance"}
@@ -18,6 +23,8 @@ export function WorkspacePerformance() {
       <div className="grid min-w-0 gap-6">
         <MonitoringEntityPicker
           kind={kind}
+          entityKey={entityKey}
+          onResolve={resolve}
           onKindChange={setKind}
           selected={selected}
           onSelect={setSelected}

--- a/apps/towbar-web-app/src/components/workspace-monitoring-performance.tsx
+++ b/apps/towbar-web-app/src/components/workspace-monitoring-performance.tsx
@@ -10,7 +10,11 @@ export function WorkspacePerformance() {
   const [kind, setKind] = useState("all");
   const [selected, setSelected] = useState<MonitoringEntity | null>(null);
   return (
-    <DashboardPage title="Performance" icon={Analytics01Icon}>
+    <DashboardPage
+      title={selected?.name ?? "Performance"}
+      breadcrumbLabel="Performance"
+      icon={Analytics01Icon}
+    >
       <div className="grid min-w-0 gap-6">
         <MonitoringEntityPicker
           kind={kind}

--- a/apps/towbar-web-app/src/components/workspace-monitoring-performance.tsx
+++ b/apps/towbar-web-app/src/components/workspace-monitoring-performance.tsx
@@ -1,6 +1,8 @@
 "use client";
+import { ScoutIcon } from "./scout-icons";
 import { useMonitoringSelection } from "@/hooks/use-monitoring-selection";
 import { Analytics01Icon } from "@hugeicons/core-free-icons";
+import { PageSelectionTitle } from "./page-selection-title";
 import { DashboardPage } from "./page-parts";
 import { MonitoringEntityPicker } from "./monitoring-entity-picker";
 import { MonitoringHistory } from "./monitoring-history";
@@ -20,6 +22,12 @@ export function WorkspacePerformance() {
       breadcrumbLabel="Performance"
       icon={Analytics01Icon}
     >
+      {selected ? (
+        <PageSelectionTitle
+          label={selected.name}
+          icon={<ScoutIcon name={selected.kind} />}
+        />
+      ) : null}
       <div className="grid min-w-0 gap-6">
         <MonitoringEntityPicker
           kind={kind}

--- a/apps/towbar-web-app/src/components/workspace-monitoring-shared.tsx
+++ b/apps/towbar-web-app/src/components/workspace-monitoring-shared.tsx
@@ -51,7 +51,17 @@ export function useMonitoringOverview<T>(
   state = "all",
   filter = "",
 ) {
-  const [cursors, setCursors] = useState<string[]>([""]);
+  const filterKey = `${area}:${state}:${filter}`;
+  const [cursorState, setCursorState] = useState({
+    key: filterKey,
+    cursors: [""],
+  });
+  const cursors = cursorState.key === filterKey ? cursorState.cursors : [""];
+  const setCursors = (value: string[] | ((old: string[]) => string[])) =>
+    setCursorState({
+      key: filterKey,
+      cursors: typeof value === "function" ? value(cursors) : value,
+    });
   const query = useApiQuery<{
     items: T[];
     nextBefore: string | null;

--- a/apps/towbar-web-app/src/hooks/use-detail-navigation.ts
+++ b/apps/towbar-web-app/src/hooks/use-detail-navigation.ts
@@ -13,8 +13,12 @@ export function useDetailNavigation() {
   const parts = match?.[2]?.split("/") ?? [];
   const section = parts[0] ?? search.get("section");
   const settings = parts[0] === "settings" ? parts[1] : search.get("settings");
-  function href(nextSection: string, nextSettings?: string) {
-    const params = new URLSearchParams(search.toString());
+  function href(
+    nextSection: string,
+    nextSettings?: string,
+    preserveQuery = false,
+  ) {
+    const params = new URLSearchParams(preserveQuery ? search.toString() : "");
     params.delete("section");
     params.delete("settings");
     params.delete("source-information");

--- a/apps/towbar-web-app/src/hooks/use-detail-navigation.ts
+++ b/apps/towbar-web-app/src/hooks/use-detail-navigation.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+export function useDetailNavigation() {
+  const pathname = usePathname();
+  const search = useSearchParams();
+  const router = useRouter();
+  const match = pathname.match(
+    /^(\/sources\/[^/]+\/(?:apps|resources)\/[^/]+|\/servers\/[^/]+|\/sources\/[^/]+)(?:\/(.*))?$/,
+  );
+  const base = match?.[1];
+  const parts = match?.[2]?.split("/") ?? [];
+  const section = parts[0] ?? search.get("section");
+  const settings = parts[0] === "settings" ? parts[1] : search.get("settings");
+  function href(nextSection: string, nextSettings?: string) {
+    const params = new URLSearchParams(search.toString());
+    params.delete("section");
+    params.delete("settings");
+    params.delete("source-information");
+    const query = params.toString();
+    return `${base}/${nextSection}${nextSettings ? `/${nextSettings}` : ""}${query ? `?${query}` : ""}`;
+  }
+  return { base, section, settings, subpage: parts[1], href, router, pathname };
+}

--- a/apps/towbar-web-app/src/hooks/use-monitoring-selection.ts
+++ b/apps/towbar-web-app/src/hooks/use-monitoring-selection.ts
@@ -1,0 +1,35 @@
+"use client";
+import { useCallback, useState } from "react";
+import type { MonitoringEntity } from "@/components/workspace-monitoring-shared";
+import { usePageQuery } from "./use-page-query";
+
+export function useMonitoringSelection() {
+  const { search, update } = usePageQuery();
+  const kind = ["server", "app", "resource"].includes(search.get("kind") ?? "")
+    ? search.get("kind")!
+    : "all";
+  const entityKey = search.get("entity");
+  const [resolved, resolve] = useState<MonitoringEntity | null>(null);
+  const selected =
+    resolved?.key === entityKey && (kind === "all" || resolved.kind === kind)
+      ? resolved
+      : null;
+  const select = useCallback(
+    (entity: MonitoringEntity | null, replace = false) => {
+      update({ entity: entity?.key ?? null, instance: null }, replace);
+      resolve(entity);
+    },
+    [update],
+  );
+  const setKind = useCallback(
+    (value: string) =>
+      update({
+        kind: value === "all" ? null : value,
+        entity: null,
+        instance: null,
+        entitySearch: null,
+      }),
+    [update],
+  );
+  return { kind, setKind, entityKey, selected, select, resolve };
+}

--- a/apps/towbar-web-app/src/hooks/use-page-query.ts
+++ b/apps/towbar-web-app/src/hooks/use-page-query.ts
@@ -1,0 +1,45 @@
+"use client";
+import { useCallback } from "react";
+import { useSearchParams } from "next/navigation";
+
+/** Read URL state during render; update from the current URL so batched controls compose. */
+export function usePageQuery() {
+  const search = useSearchParams();
+  const update = useCallback(
+    (values: Record<string, string | null>, replace = false) => {
+      const url = new URL(window.location.href);
+      for (const [key, value] of Object.entries(values)) {
+        if (value === null || value === "") url.searchParams.delete(key);
+        else url.searchParams.set(key, value);
+      }
+      if (url.href !== window.location.href)
+        window.history[replace ? "replaceState" : "pushState"](
+          null,
+          "",
+          `${url.pathname}${url.search}${url.hash}`,
+        );
+    },
+    [],
+  );
+  return { search, update };
+}
+export function useQueryChoice<T extends string>(
+  key: string,
+  choices: readonly T[],
+  fallback: T,
+) {
+  const { search, update } = usePageQuery();
+  const raw = search.get(key);
+  const value = choices.find((choice) => choice === raw) ?? fallback;
+  const set = useCallback(
+    (next: string) =>
+      update({
+        [key]:
+          next === fallback || !choices.some((choice) => choice === next)
+            ? null
+            : next,
+      }),
+    [key, fallback, choices, update],
+  );
+  return [value, set] as const;
+}

--- a/apps/towbar-web-app/src/lib/application-layout.ts
+++ b/apps/towbar-web-app/src/lib/application-layout.ts
@@ -15,6 +15,7 @@ import {
   Rocket01Icon,
   ServerStack01Icon,
   UserAccountIcon,
+  Settings01Icon,
 } from "@hugeicons/core-free-icons";
 import { createElement } from "react";
 
@@ -190,22 +191,14 @@ const sidebar = {
       ],
     },
     {
-      id: "account",
-      label: "Account",
+      id: "settings",
       items: [
         {
           kind: "link",
-          id: "profile",
-          label: "Profile",
-          href: "/account/profile",
-          icon: sidebarIcons.profile,
-        },
-        {
-          kind: "link",
-          id: "sessions",
-          label: "Sessions",
-          href: "/account/sessions",
-          icon: sidebarIcons.sessions,
+          id: "settings",
+          label: "Settings",
+          href: "/settings",
+          icon: Settings01Icon,
         },
       ],
     },

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -2123,17 +2123,26 @@
           "updatedAt"
         ]
       },
+      "Response_116": {
+        "type": "object",
+        "properties": {
+          "all": { "type": "number" },
+          "attention": { "type": "number" }
+        },
+        "required": ["all", "attention"]
+      },
       "Response_89": {
         "type": "object",
         "properties": {
           "apps": {
             "type": "array",
             "items": { "$ref": "#/components/schemas/Response_90" }
-          }
+          },
+          "counts": { "$ref": "#/components/schemas/Response_116" }
         },
-        "required": ["apps"]
+        "required": ["apps", "counts"]
       },
-      "Response_118": {
+      "Response_119": {
         "type": "object",
         "properties": {
           "port": { "type": "number" },
@@ -2141,10 +2150,10 @@
         },
         "required": ["port", "username"]
       },
-      "Response_117": {
+      "Response_118": {
         "type": "object",
         "properties": {
-          "serverSsh": { "$ref": "#/components/schemas/Response_118" },
+          "serverSsh": { "$ref": "#/components/schemas/Response_119" },
           "runtimeState": { "$ref": "#/components/schemas/Response_91" },
           "serverReady": { "type": "boolean" },
           "archivedAt": {
@@ -2198,14 +2207,14 @@
           "updatedAt"
         ]
       },
-      "Response_116": {
+      "Response_117": {
         "type": "object",
         "properties": {
-          "app": { "$ref": "#/components/schemas/Response_117" }
+          "app": { "$ref": "#/components/schemas/Response_118" }
         },
         "required": ["app"]
       },
-      "DeferredAutomaticDeployment_122": {
+      "DeferredAutomaticDeployment_123": {
         "type": "object",
         "properties": {
           "commitSha": { "type": "string" },
@@ -2229,13 +2238,13 @@
           "scope"
         ]
       },
-      "Response_121": {
+      "Response_122": {
         "type": "object",
         "properties": {
           "pending": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/DeferredAutomaticDeployment_122" }
+              { "$ref": "#/components/schemas/DeferredAutomaticDeployment_123" }
             ]
           },
           "paused": { "type": "boolean" },
@@ -2243,13 +2252,13 @@
         },
         "required": ["pending", "paused", "scope"]
       },
-      "Response_123": {
+      "Response_124": {
         "type": "object",
         "properties": {
           "pending": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/DeferredAutomaticDeployment_122" }
+              { "$ref": "#/components/schemas/DeferredAutomaticDeployment_123" }
             ]
           },
           "paused": { "type": "boolean" },
@@ -2262,13 +2271,35 @@
         },
         "required": ["pending", "paused", "scope"]
       },
+      "Response_121": {
+        "type": "object",
+        "properties": {
+          "effective": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/Response_122" },
+              { "$ref": "#/components/schemas/Response_124" }
+            ]
+          },
+          "manifestAutoDeployEnabled": { "type": "boolean" },
+          "paused": { "type": "boolean" }
+        },
+        "required": ["effective", "manifestAutoDeployEnabled", "paused"]
+      },
       "Response_120": {
         "type": "object",
         "properties": {
+          "autoDeploy": { "$ref": "#/components/schemas/Response_121" },
+          "canManageAutoDeploy": { "type": "boolean" }
+        },
+        "required": ["autoDeploy", "canManageAutoDeploy"]
+      },
+      "autoDeploy_126": {
+        "type": "object",
+        "properties": {
           "effective": {
             "anyOf": [
-              { "$ref": "#/components/schemas/Response_121" },
-              { "$ref": "#/components/schemas/Response_123" }
+              { "$ref": "#/components/schemas/Response_122" },
+              { "$ref": "#/components/schemas/Response_124" }
             ]
           },
           "manifestAutoDeployEnabled": { "type": "boolean" },
@@ -2276,37 +2307,15 @@
         },
         "required": ["effective", "manifestAutoDeployEnabled", "paused"]
       },
-      "Response_119": {
+      "Response_125": {
         "type": "object",
         "properties": {
-          "autoDeploy": { "$ref": "#/components/schemas/Response_120" },
+          "autoDeploy": { "$ref": "#/components/schemas/autoDeploy_126" },
           "canManageAutoDeploy": { "type": "boolean" }
         },
         "required": ["autoDeploy", "canManageAutoDeploy"]
       },
-      "autoDeploy_125": {
-        "type": "object",
-        "properties": {
-          "effective": {
-            "anyOf": [
-              { "$ref": "#/components/schemas/Response_121" },
-              { "$ref": "#/components/schemas/Response_123" }
-            ]
-          },
-          "manifestAutoDeployEnabled": { "type": "boolean" },
-          "paused": { "type": "boolean" }
-        },
-        "required": ["effective", "manifestAutoDeployEnabled", "paused"]
-      },
-      "Response_124": {
-        "type": "object",
-        "properties": {
-          "autoDeploy": { "$ref": "#/components/schemas/autoDeploy_125" },
-          "canManageAutoDeploy": { "type": "boolean" }
-        },
-        "required": ["autoDeploy", "canManageAutoDeploy"]
-      },
-      "Response_127": {
+      "Response_128": {
         "type": "object",
         "properties": {
           "appId": { "type": "string" },
@@ -2428,17 +2437,17 @@
           "updatedAt"
         ]
       },
-      "Response_126": {
+      "Response_127": {
         "type": "object",
         "properties": {
           "deployments": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_127" }
+            "items": { "$ref": "#/components/schemas/Response_128" }
           }
         },
         "required": ["deployments"]
       },
-      "Response_129": {
+      "Response_130": {
         "type": "object",
         "properties": {
           "id": { "type": "string" },
@@ -2507,17 +2516,17 @@
           "supersededAt"
         ]
       },
-      "Response_128": {
+      "Response_129": {
         "type": "object",
         "properties": {
           "releases": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_129" }
+            "items": { "$ref": "#/components/schemas/Response_130" }
           }
         },
         "required": ["releases"]
       },
-      "Response_131": {
+      "Response_132": {
         "type": "object",
         "properties": {
           "pullRequestUrl": { "type": "string" },
@@ -2578,17 +2587,17 @@
           "updatedAt"
         ]
       },
-      "Response_130": {
+      "Response_131": {
         "type": "object",
         "properties": {
           "previews": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_131" }
+            "items": { "$ref": "#/components/schemas/Response_132" }
           }
         },
         "required": ["previews"]
       },
-      "ResourceReleaseSnapshot_135": {
+      "ResourceReleaseSnapshot_136": {
         "type": "object",
         "properties": {
           "containerName": { "type": "string" },
@@ -2597,28 +2606,28 @@
         },
         "required": ["containerName", "imageTag", "releaseId"]
       },
-      "Response_134": {
+      "Response_135": {
         "type": "object",
         "properties": {
           "release": {
-            "$ref": "#/components/schemas/ResourceReleaseSnapshot_135"
+            "$ref": "#/components/schemas/ResourceReleaseSnapshot_136"
           },
           "type": { "type": "string", "const": "backup" }
         },
         "required": ["release", "type"]
       },
-      "Response_136": {
+      "Response_137": {
         "type": "object",
         "properties": {
           "release": {
-            "$ref": "#/components/schemas/ResourceReleaseSnapshot_135"
+            "$ref": "#/components/schemas/ResourceReleaseSnapshot_136"
           },
           "tail": { "type": "number" },
           "type": { "type": "string", "const": "capture_logs" }
         },
         "required": ["release", "tail", "type"]
       },
-      "Response_138": {
+      "Response_139": {
         "type": "object",
         "properties": {
           "kind": {
@@ -2633,46 +2642,46 @@
         },
         "required": ["kind", "name", "reason"]
       },
-      "Response_137": {
+      "Response_138": {
         "type": "object",
         "properties": {
           "items": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_138" }
+            "items": { "$ref": "#/components/schemas/Response_139" }
           },
           "type": { "type": "string", "const": "cleanup_orphans" }
         },
         "required": ["items", "type"]
       },
-      "Response_139": {
+      "Response_140": {
         "type": "object",
         "properties": {
           "backupId": { "type": "string" },
           "reason": { "type": "string" },
           "release": {
-            "$ref": "#/components/schemas/ResourceReleaseSnapshot_135"
+            "$ref": "#/components/schemas/ResourceReleaseSnapshot_136"
           },
           "type": { "type": "string", "const": "restore" }
         },
         "required": ["backupId", "reason", "release", "type"]
       },
-      "Response_140": {
+      "Response_141": {
         "type": "object",
         "properties": {
           "restoreId": { "type": "string" },
           "release": {
-            "$ref": "#/components/schemas/ResourceReleaseSnapshot_135"
+            "$ref": "#/components/schemas/ResourceReleaseSnapshot_136"
           },
           "type": { "type": "string", "const": "restore_cleanup" },
           "volumes": { "type": "array", "items": { "type": "string" } }
         },
         "required": ["restoreId", "release", "type", "volumes"]
       },
-      "Response_141": {
+      "Response_142": {
         "type": "object",
         "properties": {
           "release": {
-            "$ref": "#/components/schemas/ResourceReleaseSnapshot_135"
+            "$ref": "#/components/schemas/ResourceReleaseSnapshot_136"
           },
           "type": {
             "anyOf": [
@@ -2684,7 +2693,7 @@
         },
         "required": ["release", "type"]
       },
-      "BackupOperationResult_142": {
+      "BackupOperationResult_143": {
         "type": "object",
         "properties": {
           "backupId": { "type": "string" },
@@ -2734,35 +2743,27 @@
           "warnings"
         ]
       },
-      "Response_143": {
+      "Response_144": {
         "type": "object",
         "properties": {
           "cleaned": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_138" }
+            "items": { "$ref": "#/components/schemas/Response_139" }
           },
           "skipped": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_138" }
+            "items": { "$ref": "#/components/schemas/Response_139" }
           }
         },
         "required": ["cleaned", "skipped"]
       },
-      "Response_144": {
+      "Response_145": {
         "type": "object",
         "properties": {
           "logs": { "type": "string" },
           "truncated": { "type": "boolean" }
         },
         "required": ["logs", "truncated"]
-      },
-      "Response_146": {
-        "type": "object",
-        "properties": {
-          "logicalName": { "type": "string" },
-          "volumeName": { "type": "string" }
-        },
-        "required": ["logicalName", "volumeName"]
       },
       "Response_147": {
         "type": "object",
@@ -2773,6 +2774,14 @@
         "required": ["logicalName", "volumeName"]
       },
       "Response_148": {
+        "type": "object",
+        "properties": {
+          "logicalName": { "type": "string" },
+          "volumeName": { "type": "string" }
+        },
+        "required": ["logicalName", "volumeName"]
+      },
+      "Response_149": {
         "type": "object",
         "properties": {
           "databaseName": {
@@ -2796,12 +2805,12 @@
           "readable"
         ]
       },
-      "Response_145": {
+      "Response_146": {
         "type": "object",
         "properties": {
           "activeVolumes": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_146" }
+            "items": { "$ref": "#/components/schemas/Response_147" }
           },
           "candidateCleaned": { "type": "boolean" },
           "outcome": {
@@ -2814,7 +2823,7 @@
           },
           "previousVolumes": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_147" }
+            "items": { "$ref": "#/components/schemas/Response_148" }
           },
           "restoredBackupId": { "type": "string" },
           "rollbackAvailableUntil": {
@@ -2823,7 +2832,7 @@
           "validation": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/Response_148" }
+              { "$ref": "#/components/schemas/Response_149" }
             ]
           },
           "verifiedAt": { "anyOf": [{ "type": "null" }, { "type": "string" }] }
@@ -2839,7 +2848,7 @@
           "verifiedAt"
         ]
       },
-      "Response_149": {
+      "Response_150": {
         "type": "object",
         "properties": {
           "cleanedVolumes": { "type": "array", "items": { "type": "string" } },
@@ -2848,7 +2857,7 @@
         },
         "required": ["cleanedVolumes", "restoreId", "skippedVolumes"]
       },
-      "Response_150": {
+      "Response_151": {
         "type": "object",
         "properties": {
           "state": {
@@ -2860,7 +2869,7 @@
         },
         "required": ["state"]
       },
-      "Response_133": {
+      "Response_134": {
         "type": "object",
         "properties": {
           "createdAt": { "type": "string", "format": "date-time" },
@@ -2912,24 +2921,24 @@
           },
           "request": {
             "anyOf": [
-              { "$ref": "#/components/schemas/Response_134" },
-              { "$ref": "#/components/schemas/Response_136" },
+              { "$ref": "#/components/schemas/Response_135" },
               { "$ref": "#/components/schemas/Response_137" },
-              { "$ref": "#/components/schemas/Response_139" },
+              { "$ref": "#/components/schemas/Response_138" },
               { "$ref": "#/components/schemas/Response_140" },
-              { "$ref": "#/components/schemas/Response_141" }
+              { "$ref": "#/components/schemas/Response_141" },
+              { "$ref": "#/components/schemas/Response_142" }
             ]
           },
           "resourceId": { "anyOf": [{ "type": "null" }, { "type": "string" }] },
           "result": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/BackupOperationResult_142" },
-              { "$ref": "#/components/schemas/Response_143" },
+              { "$ref": "#/components/schemas/BackupOperationResult_143" },
               { "$ref": "#/components/schemas/Response_144" },
               { "$ref": "#/components/schemas/Response_145" },
-              { "$ref": "#/components/schemas/Response_149" },
-              { "$ref": "#/components/schemas/Response_150" }
+              { "$ref": "#/components/schemas/Response_146" },
+              { "$ref": "#/components/schemas/Response_150" },
+              { "$ref": "#/components/schemas/Response_151" }
             ]
           },
           "serverId": { "type": "string" },
@@ -2984,28 +2993,20 @@
           "updatedAt"
         ]
       },
-      "Response_132": {
+      "Response_133": {
         "type": "object",
         "properties": {
           "operations": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_133" }
+            "items": { "$ref": "#/components/schemas/Response_134" }
           }
         },
         "required": ["operations"]
       },
-      "Response_151": {
-        "type": "object",
-        "properties": {
-          "deployment": { "$ref": "#/components/schemas/Response_127" },
-          "replayed": { "type": "boolean" }
-        },
-        "required": ["deployment", "replayed"]
-      },
       "Response_152": {
         "type": "object",
         "properties": {
-          "deployment": { "$ref": "#/components/schemas/Response_127" },
+          "deployment": { "$ref": "#/components/schemas/Response_128" },
           "replayed": { "type": "boolean" }
         },
         "required": ["deployment", "replayed"]
@@ -3013,12 +3014,20 @@
       "Response_153": {
         "type": "object",
         "properties": {
-          "operation": { "$ref": "#/components/schemas/Response_133" },
+          "deployment": { "$ref": "#/components/schemas/Response_128" },
+          "replayed": { "type": "boolean" }
+        },
+        "required": ["deployment", "replayed"]
+      },
+      "Response_154": {
+        "type": "object",
+        "properties": {
+          "operation": { "$ref": "#/components/schemas/Response_134" },
           "replayed": { "type": "boolean" }
         },
         "required": ["operation", "replayed"]
       },
-      "Response_155": {
+      "Response_156": {
         "type": "object",
         "properties": {
           "appId": { "type": "string" },
@@ -3150,17 +3159,17 @@
           "queueBlocker"
         ]
       },
-      "Response_154": {
+      "Response_155": {
         "type": "object",
         "properties": {
           "deployments": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_155" }
+            "items": { "$ref": "#/components/schemas/Response_156" }
           }
         },
         "required": ["deployments"]
       },
-      "Response_157": {
+      "Response_158": {
         "type": "object",
         "properties": {
           "deployableName": { "type": "string" },
@@ -3294,7 +3303,7 @@
           "queueBlocker"
         ]
       },
-      "Response_158": {
+      "Response_159": {
         "type": "object",
         "properties": {
           "limit": { "type": "number" },
@@ -3304,18 +3313,18 @@
         },
         "required": ["limit", "page", "total", "totalPages"]
       },
-      "Response_156": {
+      "Response_157": {
         "type": "object",
         "properties": {
           "deployments": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_157" }
+            "items": { "$ref": "#/components/schemas/Response_158" }
           },
-          "pagination": { "$ref": "#/components/schemas/Response_158" }
+          "pagination": { "$ref": "#/components/schemas/Response_159" }
         },
         "required": ["deployments", "pagination"]
       },
-      "Response_162": {
+      "Response_163": {
         "type": "object",
         "properties": {
           "critical": { "type": "number" },
@@ -3326,7 +3335,7 @@
         },
         "required": ["critical", "high", "low", "medium", "unknown"]
       },
-      "Response_161": {
+      "Response_162": {
         "type": "object",
         "properties": {
           "completedAt": {
@@ -3349,7 +3358,7 @@
           "scannerVersion": {
             "anyOf": [{ "type": "null" }, { "type": "string" }]
           },
-          "severityTotals": { "$ref": "#/components/schemas/Response_162" },
+          "severityTotals": { "$ref": "#/components/schemas/Response_163" },
           "startedAt": {
             "anyOf": [
               { "type": "null" },
@@ -3389,13 +3398,13 @@
           "vulnerabilityDatabaseUpdatedAt"
         ]
       },
-      "Response_160": {
+      "Response_161": {
         "type": "object",
         "properties": {
           "vulnerabilityScan": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/Response_161" }
+              { "$ref": "#/components/schemas/Response_162" }
             ]
           },
           "vulnerabilityScanningEnabled": { "type": "boolean" },
@@ -3530,14 +3539,14 @@
           "queueBlocker"
         ]
       },
-      "Response_159": {
+      "Response_160": {
         "type": "object",
         "properties": {
-          "deployment": { "$ref": "#/components/schemas/Response_160" }
+          "deployment": { "$ref": "#/components/schemas/Response_161" }
         },
         "required": ["deployment"]
       },
-      "Response_164": {
+      "Response_165": {
         "type": "object",
         "properties": {
           "createdAt": { "type": "string", "format": "date-time" },
@@ -3604,17 +3613,17 @@
           "status"
         ]
       },
-      "Response_163": {
+      "Response_164": {
         "type": "object",
         "properties": {
           "steps": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_164" }
+            "items": { "$ref": "#/components/schemas/Response_165" }
           }
         },
         "required": ["steps"]
       },
-      "Response_166": {
+      "Response_167": {
         "type": "object",
         "properties": {
           "content": { "type": "string" },
@@ -3625,17 +3634,17 @@
         },
         "required": ["content", "createdAt", "id", "sequence", "stream"]
       },
-      "Response_165": {
+      "Response_166": {
         "type": "object",
         "properties": {
           "logs": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_166" }
+            "items": { "$ref": "#/components/schemas/Response_167" }
           }
         },
         "required": ["logs"]
       },
-      "Response_168": {
+      "Response_169": {
         "type": "object",
         "properties": {
           "advisoryId": { "type": "string" },
@@ -3666,47 +3675,47 @@
           "target"
         ]
       },
-      "Response_167": {
+      "Response_168": {
         "type": "object",
         "properties": {
           "findings": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_168" }
+            "items": { "$ref": "#/components/schemas/Response_169" }
           }
         },
         "required": ["findings"]
       },
-      "Response_169": {
+      "Response_170": {
         "type": "object",
         "properties": {
-          "deployment": { "$ref": "#/components/schemas/Response_160" },
+          "deployment": { "$ref": "#/components/schemas/Response_161" },
           "logs": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_166" }
+            "items": { "$ref": "#/components/schemas/Response_167" }
           },
           "steps": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_164" }
+            "items": { "$ref": "#/components/schemas/Response_165" }
           }
         },
         "required": ["deployment", "logs", "steps"]
       },
-      "Response_170": {
-        "type": "object",
-        "properties": {
-          "deployment": { "$ref": "#/components/schemas/Response_127" }
-        },
-        "required": ["deployment"]
-      },
       "Response_171": {
         "type": "object",
         "properties": {
+          "deployment": { "$ref": "#/components/schemas/Response_128" }
+        },
+        "required": ["deployment"]
+      },
+      "Response_172": {
+        "type": "object",
+        "properties": {
           "replayed": { "type": "boolean" },
-          "scan": { "$ref": "#/components/schemas/Response_161" }
+          "scan": { "$ref": "#/components/schemas/Response_162" }
         },
         "required": ["replayed", "scan"]
       },
-      "Response_173": {
+      "Response_174": {
         "type": "object",
         "properties": {
           "accessKeyIdSuffix": { "type": "string" },
@@ -3740,43 +3749,43 @@
           "verificationMessage"
         ]
       },
-      "Response_172": {
+      "Response_173": {
         "type": "object",
         "properties": {
           "canManage": { "type": "boolean" },
           "credential": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/Response_173" }
+              { "$ref": "#/components/schemas/Response_174" }
             ]
           }
         },
         "required": ["canManage", "credential"]
       },
-      "Response_174": {
+      "Response_175": {
         "type": "object",
         "properties": {
           "credential": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/Response_173" }
+              { "$ref": "#/components/schemas/Response_174" }
             ]
           }
         },
         "required": ["credential"]
       },
-      "Response_177": {
+      "Response_178": {
         "type": "object",
         "properties": {
           "status": { "type": "string", "const": "unavailable" }
         },
         "required": ["status"]
       },
-      "Response_176": {
+      "Response_177": {
         "type": "object",
         "properties": {
           "permissionReadiness": {
-            "$ref": "#/components/schemas/Response_177"
+            "$ref": "#/components/schemas/Response_178"
           },
           "accountLogin": { "type": "string" },
           "accountType": { "type": "string" },
@@ -3800,7 +3809,7 @@
           "updatedAt"
         ]
       },
-      "Response_179": {
+      "Response_180": {
         "type": "object",
         "properties": {
           "status": { "type": "string", "const": "available" },
@@ -3840,11 +3849,11 @@
           "pullRequests"
         ]
       },
-      "Response_178": {
+      "Response_179": {
         "type": "object",
         "properties": {
           "permissionReadiness": {
-            "$ref": "#/components/schemas/Response_179"
+            "$ref": "#/components/schemas/Response_180"
           },
           "accountLogin": { "type": "string" },
           "accountType": { "type": "string" },
@@ -3868,7 +3877,7 @@
           "updatedAt"
         ]
       },
-      "Response_180": {
+      "Response_181": {
         "type": "object",
         "properties": {
           "failedCount": { "type": "number" },
@@ -3882,21 +3891,21 @@
         },
         "required": ["failedCount", "lastError", "lastFailedAt"]
       },
-      "Response_175": {
+      "Response_176": {
         "type": "object",
         "properties": {
           "connection": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/Response_176" },
-              { "$ref": "#/components/schemas/Response_178" }
+              { "$ref": "#/components/schemas/Response_177" },
+              { "$ref": "#/components/schemas/Response_179" }
             ]
           },
-          "previewReporting": { "$ref": "#/components/schemas/Response_180" }
+          "previewReporting": { "$ref": "#/components/schemas/Response_181" }
         },
         "required": ["connection", "previewReporting"]
       },
-      "Response_181": {
+      "Response_182": {
         "type": "object",
         "properties": {
           "attempted": { "type": "number" },
@@ -3905,24 +3914,24 @@
         },
         "required": ["attempted", "failed", "succeeded"]
       },
-      "Response_182": {
+      "Response_183": {
         "type": "object",
         "properties": { "url": { "type": "string" } },
         "required": ["url"]
       },
-      "Response_184": {
+      "Response_185": {
         "type": "object",
         "properties": { "id": { "type": "string" } },
         "required": ["id"]
       },
-      "Response_183": {
+      "Response_184": {
         "type": "object",
         "properties": {
-          "installation": { "$ref": "#/components/schemas/Response_184" }
+          "installation": { "$ref": "#/components/schemas/Response_185" }
         },
         "required": ["installation"]
       },
-      "Response_186": {
+      "Response_187": {
         "type": "object",
         "properties": {
           "defaultBranch": { "type": "string" },
@@ -3941,17 +3950,17 @@
           "private"
         ]
       },
-      "Response_185": {
+      "Response_186": {
         "type": "object",
         "properties": {
           "repositories": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_186" }
+            "items": { "$ref": "#/components/schemas/Response_187" }
           }
         },
         "required": ["repositories"]
       },
-      "Response_190": {
+      "Response_191": {
         "type": "object",
         "properties": {
           "provider": {
@@ -3970,13 +3979,13 @@
         },
         "required": ["provider", "type"]
       },
-      "ServerHardware_189": {
+      "ServerHardware_190": {
         "type": "object",
         "properties": {
           "instance": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/Response_190" }
+              { "$ref": "#/components/schemas/Response_191" }
             ]
           },
           "cpuCount": { "anyOf": [{ "type": "null" }, { "type": "number" }] },
@@ -3984,7 +3993,7 @@
         },
         "required": ["instance", "cpuCount", "memoryBytes"]
       },
-      "Response_192": {
+      "Response_193": {
         "type": "object",
         "properties": {
           "at": { "type": "string" },
@@ -3995,7 +4004,7 @@
         },
         "required": ["at", "cpuPercent", "memoryPercent"]
       },
-      "ServerMonitoringSummary_191": {
+      "ServerMonitoringSummary_192": {
         "type": "object",
         "properties": {
           "enabled": { "type": "boolean" },
@@ -4007,7 +4016,7 @@
           "end": { "type": "string" },
           "points": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_192" }
+            "items": { "$ref": "#/components/schemas/Response_193" }
           }
         },
         "required": [
@@ -4019,17 +4028,18 @@
           "points"
         ]
       },
-      "Response_188": {
+      "Response_189": {
         "type": "object",
         "properties": {
+          "healthStatus": { "type": "string" },
           "hardware": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/ServerHardware_189" }
+              { "$ref": "#/components/schemas/ServerHardware_190" }
             ]
           },
           "scout": {
-            "$ref": "#/components/schemas/ServerMonitoringSummary_191"
+            "$ref": "#/components/schemas/ServerMonitoringSummary_192"
           },
           "setupStatus": {
             "anyOf": [
@@ -4040,19 +4050,28 @@
             ]
           }
         },
-        "required": ["hardware", "scout", "setupStatus"]
+        "required": ["healthStatus", "hardware", "scout", "setupStatus"]
       },
-      "Response_187": {
+      "Response_194": {
+        "type": "object",
+        "properties": {
+          "all": { "type": "number" },
+          "attention": { "type": "number" }
+        },
+        "required": ["all", "attention"]
+      },
+      "Response_188": {
         "type": "object",
         "properties": {
           "servers": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_188" }
-          }
+            "items": { "$ref": "#/components/schemas/Response_189" }
+          },
+          "counts": { "$ref": "#/components/schemas/Response_194" }
         },
-        "required": ["servers"]
+        "required": ["servers", "counts"]
       },
-      "Response_194": {
+      "Response_196": {
         "type": "object",
         "properties": {
           "setupStatus": {
@@ -4066,20 +4085,20 @@
         },
         "required": ["setupStatus"]
       },
-      "Response_193": {
+      "Response_195": {
         "type": "object",
         "properties": {
-          "server": { "$ref": "#/components/schemas/Response_194" }
+          "server": { "$ref": "#/components/schemas/Response_196" }
         },
         "required": ["server"]
       },
-      "Response_196": {
+      "Response_198": {
         "type": "object",
         "properties": {
           "hardware": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/ServerHardware_189" }
+              { "$ref": "#/components/schemas/ServerHardware_190" }
             ]
           },
           "setupStatus": {
@@ -4093,13 +4112,13 @@
         },
         "required": ["hardware", "setupStatus"]
       },
-      "Response_195": {
+      "Response_197": {
         "type": "object",
         "properties": {
           "canCleanupOrphans": { "type": "boolean" },
           "canManageServer": { "type": "boolean" },
           "canRemoveServer": { "type": "boolean" },
-          "server": { "$ref": "#/components/schemas/Response_196" }
+          "server": { "$ref": "#/components/schemas/Response_198" }
         },
         "required": [
           "canCleanupOrphans",
@@ -4108,14 +4127,14 @@
           "server"
         ]
       },
-      "Response_197": {
+      "Response_199": {
         "type": "object",
         "properties": {
-          "server": { "$ref": "#/components/schemas/Response_194" }
+          "server": { "$ref": "#/components/schemas/Response_196" }
         },
         "required": ["server"]
       },
-      "Response_200": {
+      "Response_202": {
         "type": "object",
         "properties": {
           "desiredState": {
@@ -4173,11 +4192,11 @@
           "observedImage"
         ]
       },
-      "Response_199": {
+      "Response_201": {
         "type": "object",
         "properties": {
           "serverReady": { "type": "boolean" },
-          "runtimeState": { "$ref": "#/components/schemas/Response_200" },
+          "runtimeState": { "$ref": "#/components/schemas/Response_202" },
           "archivedAt": {
             "anyOf": [
               { "type": "null" },
@@ -4227,37 +4246,37 @@
           "updatedAt"
         ]
       },
-      "Response_198": {
+      "Response_200": {
         "type": "object",
         "properties": {
           "apps": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_199" }
+            "items": { "$ref": "#/components/schemas/Response_201" }
           }
         },
         "required": ["apps"]
       },
-      "Response_201": {
+      "Response_203": {
         "type": "object",
         "properties": {
           "resources": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_199" }
+            "items": { "$ref": "#/components/schemas/Response_201" }
           }
         },
         "required": ["resources"]
       },
-      "Response_202": {
+      "Response_204": {
         "type": "object",
         "properties": {
           "deployments": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_127" }
+            "items": { "$ref": "#/components/schemas/Response_128" }
           }
         },
         "required": ["deployments"]
       },
-      "Response_205": {
+      "Response_207": {
         "type": "object",
         "properties": {
           "logicalCount": { "type": "number" },
@@ -4266,25 +4285,25 @@
         },
         "required": ["logicalCount", "loadAverage1m", "usagePercent"]
       },
-      "Response_206": {
-        "type": "object",
-        "properties": {
-          "availableBytes": { "type": "number" },
-          "totalBytes": { "type": "number" },
-          "usedPercent": { "type": "number" }
-        },
-        "required": ["availableBytes", "totalBytes", "usedPercent"]
-      },
-      "Response_207": {
-        "type": "object",
-        "properties": {
-          "availableBytes": { "type": "number" },
-          "totalBytes": { "type": "number" },
-          "usedPercent": { "type": "number" }
-        },
-        "required": ["availableBytes", "totalBytes", "usedPercent"]
-      },
       "Response_208": {
+        "type": "object",
+        "properties": {
+          "availableBytes": { "type": "number" },
+          "totalBytes": { "type": "number" },
+          "usedPercent": { "type": "number" }
+        },
+        "required": ["availableBytes", "totalBytes", "usedPercent"]
+      },
+      "Response_209": {
+        "type": "object",
+        "properties": {
+          "availableBytes": { "type": "number" },
+          "totalBytes": { "type": "number" },
+          "usedPercent": { "type": "number" }
+        },
+        "required": ["availableBytes", "totalBytes", "usedPercent"]
+      },
+      "Response_210": {
         "type": "object",
         "properties": {
           "cpuPercent": { "anyOf": [{ "type": "null" }, { "type": "number" }] },
@@ -4341,20 +4360,20 @@
           "startedAt"
         ]
       },
-      "RuntimeCapacity_204": {
+      "RuntimeCapacity_206": {
         "type": "object",
         "properties": {
           "checkedAt": { "anyOf": [{ "type": "null" }, { "type": "string" }] },
           "cpu": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/Response_205" }
+              { "$ref": "#/components/schemas/Response_207" }
             ]
           },
           "disk": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/Response_206" }
+              { "$ref": "#/components/schemas/Response_208" }
             ]
           },
           "id": { "type": "string" },
@@ -4371,12 +4390,12 @@
           "memory": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/Response_207" }
+              { "$ref": "#/components/schemas/Response_209" }
             ]
           },
           "runtimes": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_208" }
+            "items": { "$ref": "#/components/schemas/Response_210" }
           },
           "status": {
             "anyOf": [
@@ -4403,15 +4422,15 @@
           "uptimeSeconds"
         ]
       },
-      "Response_203": {
+      "Response_205": {
         "type": "object",
         "properties": {
-          "capacity": { "$ref": "#/components/schemas/RuntimeCapacity_204" }
+          "capacity": { "$ref": "#/components/schemas/RuntimeCapacity_206" }
         },
         "required": ["capacity"]
       },
-      "Record_211": { "type": "object", "additionalProperties": {} },
-      "Response_210": {
+      "Record_213": { "type": "object", "additionalProperties": {} },
+      "Response_212": {
         "type": "object",
         "properties": {
           "createdAt": { "type": "string", "format": "date-time" },
@@ -4429,7 +4448,7 @@
           "result": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/Record_211" }
+              { "$ref": "#/components/schemas/Record_213" }
             ]
           },
           "startedAt": {
@@ -4458,7 +4477,7 @@
           "status"
         ]
       },
-      "Response_212": {
+      "Response_214": {
         "type": "object",
         "properties": {
           "limit": { "type": "number" },
@@ -4468,24 +4487,24 @@
         },
         "required": ["limit", "page", "total", "totalPages"]
       },
-      "Response_209": {
+      "Response_211": {
         "type": "object",
         "properties": {
           "checks": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_210" }
+            "items": { "$ref": "#/components/schemas/Response_212" }
           },
           "latestCheck": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/Response_210" }
+              { "$ref": "#/components/schemas/Response_212" }
             ]
           },
-          "pagination": { "$ref": "#/components/schemas/Response_212" }
+          "pagination": { "$ref": "#/components/schemas/Response_214" }
         },
         "required": ["checks", "latestCheck", "pagination"]
       },
-      "ServerPreparationStep_215": {
+      "ServerPreparationStep_217": {
         "type": "object",
         "properties": {
           "finishedAt": { "anyOf": [{ "type": "null" }, { "type": "string" }] },
@@ -4521,7 +4540,7 @@
           "title"
         ]
       },
-      "Response_214": {
+      "Response_216": {
         "type": "object",
         "properties": {
           "createdAt": { "type": "string", "format": "date-time" },
@@ -4539,7 +4558,7 @@
           "result": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/Record_211" }
+              { "$ref": "#/components/schemas/Record_213" }
             ]
           },
           "startedAt": {
@@ -4559,7 +4578,7 @@
           "steps": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ServerPreparationStep_215"
+              "$ref": "#/components/schemas/ServerPreparationStep_217"
             }
           }
         },
@@ -4575,27 +4594,27 @@
           "steps"
         ]
       },
-      "Response_213": {
+      "Response_215": {
         "type": "object",
         "properties": {
           "preparations": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_214" }
+            "items": { "$ref": "#/components/schemas/Response_216" }
           }
         },
         "required": ["preparations"]
       },
-      "Response_216": {
+      "Response_218": {
         "type": "object",
         "properties": {
           "orphans": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_138" }
+            "items": { "$ref": "#/components/schemas/Response_139" }
           }
         },
         "required": ["orphans"]
       },
-      "Response_218": {
+      "Response_220": {
         "type": "object",
         "properties": {
           "algorithm": { "type": "string" },
@@ -4605,17 +4624,17 @@
         },
         "required": ["algorithm", "createdAt", "fingerprint", "id"]
       },
-      "Response_217": {
+      "Response_219": {
         "type": "object",
         "properties": {
           "hostKeys": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_218" }
+            "items": { "$ref": "#/components/schemas/Response_220" }
           }
         },
         "required": ["hostKeys"]
       },
-      "Response_220": {
+      "Response_222": {
         "type": "object",
         "properties": {
           "createdAt": { "type": "string", "format": "date-time" },
@@ -4633,7 +4652,7 @@
           "result": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/Record_211" }
+              { "$ref": "#/components/schemas/Record_213" }
             ]
           },
           "startedAt": {
@@ -4662,14 +4681,14 @@
           "status"
         ]
       },
-      "Response_219": {
+      "Response_221": {
         "type": "object",
         "properties": {
-          "check": { "$ref": "#/components/schemas/Response_220" }
+          "check": { "$ref": "#/components/schemas/Response_222" }
         },
         "required": ["check"]
       },
-      "Response_222": {
+      "Response_224": {
         "type": "object",
         "properties": {
           "createdAt": { "type": "string", "format": "date-time" },
@@ -4687,7 +4706,7 @@
           "result": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/Record_211" }
+              { "$ref": "#/components/schemas/Record_213" }
             ]
           },
           "startedAt": {
@@ -4707,7 +4726,7 @@
           "steps": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ServerPreparationStep_215"
+              "$ref": "#/components/schemas/ServerPreparationStep_217"
             }
           }
         },
@@ -4723,14 +4742,14 @@
           "steps"
         ]
       },
-      "Response_221": {
+      "Response_223": {
         "type": "object",
         "properties": {
-          "preparation": { "$ref": "#/components/schemas/Response_222" }
+          "preparation": { "$ref": "#/components/schemas/Response_224" }
         },
         "required": ["preparation"]
       },
-      "Response_224": {
+      "Response_226": {
         "type": "object",
         "properties": {
           "algorithm": { "type": "string" },
@@ -4739,50 +4758,51 @@
         },
         "required": ["algorithm", "fingerprint", "id"]
       },
-      "Response_223": {
+      "Response_225": {
         "type": "object",
         "properties": {
-          "hostKey": { "$ref": "#/components/schemas/Response_224" }
+          "hostKey": { "$ref": "#/components/schemas/Response_226" }
         },
         "required": ["hostKey"]
       },
-      "Response_225": {
+      "Response_227": {
         "type": "object",
         "properties": { "pending": { "type": "boolean" } },
         "required": ["pending"]
       },
-      "Response_226": {
+      "Response_228": {
         "type": "object",
         "properties": {
           "resources": {
             "type": "array",
             "items": { "$ref": "#/components/schemas/Response_90" }
-          }
+          },
+          "counts": { "$ref": "#/components/schemas/Response_116" }
         },
-        "required": ["resources"]
+        "required": ["resources", "counts"]
       },
-      "Response_227": {
+      "Response_229": {
         "type": "object",
         "properties": {
-          "resource": { "$ref": "#/components/schemas/Response_117" }
+          "resource": { "$ref": "#/components/schemas/Response_118" }
         },
         "required": ["resource"]
       },
-      "Response_228": {
+      "Response_230": {
         "type": "object",
         "properties": {
-          "autoDeploy": { "$ref": "#/components/schemas/Response_120" },
+          "autoDeploy": { "$ref": "#/components/schemas/Response_121" },
           "canManageAutoDeploy": { "type": "boolean" }
         },
         "required": ["autoDeploy", "canManageAutoDeploy"]
       },
-      "autoDeploy_230": {
+      "autoDeploy_232": {
         "type": "object",
         "properties": {
           "effective": {
             "anyOf": [
-              { "$ref": "#/components/schemas/Response_121" },
-              { "$ref": "#/components/schemas/Response_123" }
+              { "$ref": "#/components/schemas/Response_122" },
+              { "$ref": "#/components/schemas/Response_124" }
             ]
           },
           "manifestAutoDeployEnabled": { "type": "boolean" },
@@ -4790,45 +4810,45 @@
         },
         "required": ["effective", "manifestAutoDeployEnabled", "paused"]
       },
-      "Response_229": {
+      "Response_231": {
         "type": "object",
         "properties": {
-          "autoDeploy": { "$ref": "#/components/schemas/autoDeploy_230" },
+          "autoDeploy": { "$ref": "#/components/schemas/autoDeploy_232" },
           "canManageAutoDeploy": { "type": "boolean" }
         },
         "required": ["autoDeploy", "canManageAutoDeploy"]
       },
-      "Response_231": {
+      "Response_233": {
         "type": "object",
         "properties": {
           "deployments": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_127" }
+            "items": { "$ref": "#/components/schemas/Response_128" }
           }
         },
         "required": ["deployments"]
       },
-      "Response_232": {
+      "Response_234": {
         "type": "object",
         "properties": {
           "releases": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_129" }
+            "items": { "$ref": "#/components/schemas/Response_130" }
           }
         },
         "required": ["releases"]
       },
-      "Response_233": {
+      "Response_235": {
         "type": "object",
         "properties": {
           "operations": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_133" }
+            "items": { "$ref": "#/components/schemas/Response_134" }
           }
         },
         "required": ["operations"]
       },
-      "Response_236": {
+      "Response_238": {
         "type": "object",
         "properties": {
           "message": { "type": "string" },
@@ -4847,14 +4867,14 @@
         },
         "required": ["message", "name", "passed"]
       },
-      "Response_235": {
+      "Response_237": {
         "type": "object",
         "properties": {
           "backupOperationId": { "type": "string" },
           "checkedAt": { "type": "string", "format": "date-time" },
           "checks": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_236" }
+            "items": { "$ref": "#/components/schemas/Response_238" }
           },
           "resourceId": { "type": "string" },
           "restoreReady": { "type": "boolean" },
@@ -4878,25 +4898,25 @@
           "updatedAt"
         ]
       },
-      "Response_234": {
+      "Response_236": {
         "type": "object",
         "properties": {
           "assurance": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/Response_235" }
+              { "$ref": "#/components/schemas/Response_237" }
             ]
           },
           "assurances": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_235" }
+            "items": { "$ref": "#/components/schemas/Response_237" }
           },
           "awsConfigured": { "type": "boolean" },
           "canRestore": { "type": "boolean" }
         },
         "required": ["assurance", "assurances", "awsConfigured", "canRestore"]
       },
-      "Record_239": {
+      "Record_241": {
         "type": "object",
         "additionalProperties": {
           "anyOf": [
@@ -4907,7 +4927,7 @@
           ]
         }
       },
-      "Response_238": {
+      "Response_240": {
         "type": "object",
         "properties": {
           "command": { "anyOf": [{ "type": "null" }, { "type": "string" }] },
@@ -4921,7 +4941,7 @@
             ]
           },
           "message": { "type": "string" },
-          "metadata": { "$ref": "#/components/schemas/Record_239" },
+          "metadata": { "$ref": "#/components/schemas/Record_241" },
           "phase": {
             "anyOf": [
               { "type": "string", "const": "queued" },
@@ -4954,29 +4974,29 @@
           "sequence"
         ]
       },
-      "Response_237": {
+      "Response_239": {
         "type": "object",
         "properties": {
           "events": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_238" }
+            "items": { "$ref": "#/components/schemas/Response_240" }
           }
         },
         "required": ["events"]
       },
-      "Response_240": {
+      "Response_242": {
         "type": "object",
         "properties": {
-          "operation": { "$ref": "#/components/schemas/Response_133" }
+          "operation": { "$ref": "#/components/schemas/Response_134" }
         },
         "required": ["operation"]
       },
-      "Response_241": {
+      "Response_243": {
         "type": "object",
         "properties": { "accepted": { "type": "boolean" } },
         "required": ["accepted"]
       },
-      "Response_242": {
+      "Response_244": {
         "type": "object",
         "properties": {
           "accepted": { "type": "boolean" },
@@ -4984,53 +5004,11 @@
         },
         "required": ["accepted", "deploymentId"]
       },
-      "Response_244": {
-        "type": "object",
-        "properties": {
-          "branch": { "type": "string" },
-          "createdAt": { "type": "string", "format": "date-time" },
-          "id": { "type": "string" },
-          "latestCommitSha": {
-            "anyOf": [{ "type": "null" }, { "type": "string" }]
-          },
-          "latestManifestDigest": {
-            "anyOf": [{ "type": "null" }, { "type": "string" }]
-          },
-          "repositoryName": { "type": "string" },
-          "repositoryOwner": { "type": "string" },
-          "status": {
-            "anyOf": [
-              { "type": "string", "const": "active" },
-              { "type": "string", "const": "archived" }
-            ]
-          },
-          "updatedAt": { "type": "string", "format": "date-time" }
-        },
-        "required": [
-          "branch",
-          "createdAt",
-          "id",
-          "latestCommitSha",
-          "latestManifestDigest",
-          "repositoryName",
-          "repositoryOwner",
-          "status",
-          "updatedAt"
-        ]
-      },
-      "Response_243": {
-        "type": "object",
-        "properties": {
-          "sources": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_244" }
-          }
-        },
-        "required": ["sources"]
-      },
       "Response_246": {
         "type": "object",
         "properties": {
+          "latestSyncStatus": { "type": "string" },
+          "autoDeployPaused": { "type": "boolean" },
           "branch": { "type": "string" },
           "createdAt": { "type": "string", "format": "date-time" },
           "id": { "type": "string" },
@@ -5051,6 +5029,8 @@
           "updatedAt": { "type": "string", "format": "date-time" }
         },
         "required": [
+          "latestSyncStatus",
+          "autoDeployPaused",
           "branch",
           "createdAt",
           "id",
@@ -5061,23 +5041,110 @@
           "status",
           "updatedAt"
         ]
-      },
-      "Response_245": {
-        "type": "object",
-        "properties": {
-          "source": { "$ref": "#/components/schemas/Response_246" }
-        },
-        "required": ["source"]
       },
       "Response_247": {
         "type": "object",
         "properties": {
+          "all": { "type": "number" },
+          "attention": { "type": "number" }
+        },
+        "required": ["all", "attention"]
+      },
+      "Response_245": {
+        "type": "object",
+        "properties": {
+          "sources": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Response_246" }
+          },
+          "counts": { "$ref": "#/components/schemas/Response_247" }
+        },
+        "required": ["sources", "counts"]
+      },
+      "Response_249": {
+        "type": "object",
+        "properties": {
+          "branch": { "type": "string" },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "id": { "type": "string" },
+          "latestCommitSha": {
+            "anyOf": [{ "type": "null" }, { "type": "string" }]
+          },
+          "latestManifestDigest": {
+            "anyOf": [{ "type": "null" }, { "type": "string" }]
+          },
+          "repositoryName": { "type": "string" },
+          "repositoryOwner": { "type": "string" },
+          "status": {
+            "anyOf": [
+              { "type": "string", "const": "active" },
+              { "type": "string", "const": "archived" }
+            ]
+          },
+          "updatedAt": { "type": "string", "format": "date-time" }
+        },
+        "required": [
+          "branch",
+          "createdAt",
+          "id",
+          "latestCommitSha",
+          "latestManifestDigest",
+          "repositoryName",
+          "repositoryOwner",
+          "status",
+          "updatedAt"
+        ]
+      },
+      "Response_248": {
+        "type": "object",
+        "properties": {
+          "source": { "$ref": "#/components/schemas/Response_249" }
+        },
+        "required": ["source"]
+      },
+      "Response_251": {
+        "type": "object",
+        "properties": {
+          "branch": { "type": "string" },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "id": { "type": "string" },
+          "latestCommitSha": {
+            "anyOf": [{ "type": "null" }, { "type": "string" }]
+          },
+          "latestManifestDigest": {
+            "anyOf": [{ "type": "null" }, { "type": "string" }]
+          },
+          "repositoryName": { "type": "string" },
+          "repositoryOwner": { "type": "string" },
+          "status": {
+            "anyOf": [
+              { "type": "string", "const": "active" },
+              { "type": "string", "const": "archived" }
+            ]
+          },
+          "updatedAt": { "type": "string", "format": "date-time" }
+        },
+        "required": [
+          "branch",
+          "createdAt",
+          "id",
+          "latestCommitSha",
+          "latestManifestDigest",
+          "repositoryName",
+          "repositoryOwner",
+          "status",
+          "updatedAt"
+        ]
+      },
+      "Response_250": {
+        "type": "object",
+        "properties": {
           "canManageSource": { "type": "boolean" },
-          "source": { "$ref": "#/components/schemas/Response_244" }
+          "source": { "$ref": "#/components/schemas/Response_251" }
         },
         "required": ["canManageSource", "source"]
       },
-      "Response_250": {
+      "Response_254": {
         "type": "object",
         "properties": {
           "pending": { "type": "null" },
@@ -5086,7 +5153,7 @@
         },
         "required": ["pending", "paused", "scope"]
       },
-      "Response_251": {
+      "Response_255": {
         "type": "object",
         "properties": {
           "pending": { "type": "null" },
@@ -5100,34 +5167,13 @@
         },
         "required": ["pending", "paused", "scope"]
       },
-      "Response_249": {
+      "Response_253": {
         "type": "object",
         "properties": {
           "effective": {
             "anyOf": [
-              { "$ref": "#/components/schemas/Response_250" },
-              { "$ref": "#/components/schemas/Response_251" }
-            ]
-          },
-          "paused": { "type": "boolean" }
-        },
-        "required": ["effective", "paused"]
-      },
-      "Response_248": {
-        "type": "object",
-        "properties": {
-          "autoDeploy": { "$ref": "#/components/schemas/Response_249" },
-          "canManageAutoDeploy": { "type": "boolean" }
-        },
-        "required": ["autoDeploy", "canManageAutoDeploy"]
-      },
-      "autoDeploy_253": {
-        "type": "object",
-        "properties": {
-          "effective": {
-            "anyOf": [
-              { "$ref": "#/components/schemas/Response_250" },
-              { "$ref": "#/components/schemas/Response_251" }
+              { "$ref": "#/components/schemas/Response_254" },
+              { "$ref": "#/components/schemas/Response_255" }
             ]
           },
           "paused": { "type": "boolean" }
@@ -5137,12 +5183,33 @@
       "Response_252": {
         "type": "object",
         "properties": {
-          "autoDeploy": { "$ref": "#/components/schemas/autoDeploy_253" },
+          "autoDeploy": { "$ref": "#/components/schemas/Response_253" },
           "canManageAutoDeploy": { "type": "boolean" }
         },
         "required": ["autoDeploy", "canManageAutoDeploy"]
       },
-      "Response_254": {
+      "autoDeploy_257": {
+        "type": "object",
+        "properties": {
+          "effective": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/Response_254" },
+              { "$ref": "#/components/schemas/Response_255" }
+            ]
+          },
+          "paused": { "type": "boolean" }
+        },
+        "required": ["effective", "paused"]
+      },
+      "Response_256": {
+        "type": "object",
+        "properties": {
+          "autoDeploy": { "$ref": "#/components/schemas/autoDeploy_257" },
+          "canManageAutoDeploy": { "type": "boolean" }
+        },
+        "required": ["autoDeploy", "canManageAutoDeploy"]
+      },
+      "Response_258": {
         "type": "object",
         "properties": {
           "apps": {
@@ -5152,7 +5219,7 @@
         },
         "required": ["apps"]
       },
-      "Response_255": {
+      "Response_259": {
         "type": "object",
         "properties": {
           "resources": {
@@ -5162,27 +5229,27 @@
         },
         "required": ["resources"]
       },
-      "Response_256": {
+      "Response_260": {
         "type": "object",
         "properties": {
           "capacities": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/RuntimeCapacity_204" }
+            "items": { "$ref": "#/components/schemas/RuntimeCapacity_206" }
           }
         },
         "required": ["capacities"]
       },
-      "Response_257": {
+      "Response_261": {
         "type": "object",
         "properties": {
           "deployments": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_155" }
+            "items": { "$ref": "#/components/schemas/Response_156" }
           }
         },
         "required": ["deployments"]
       },
-      "Response_259": {
+      "Response_263": {
         "type": "object",
         "properties": {
           "resourceKind": {
@@ -5244,24 +5311,24 @@
           },
           "request": {
             "anyOf": [
-              { "$ref": "#/components/schemas/Response_134" },
-              { "$ref": "#/components/schemas/Response_136" },
+              { "$ref": "#/components/schemas/Response_135" },
               { "$ref": "#/components/schemas/Response_137" },
-              { "$ref": "#/components/schemas/Response_139" },
+              { "$ref": "#/components/schemas/Response_138" },
               { "$ref": "#/components/schemas/Response_140" },
-              { "$ref": "#/components/schemas/Response_141" }
+              { "$ref": "#/components/schemas/Response_141" },
+              { "$ref": "#/components/schemas/Response_142" }
             ]
           },
           "resourceId": { "anyOf": [{ "type": "null" }, { "type": "string" }] },
           "result": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/BackupOperationResult_142" },
-              { "$ref": "#/components/schemas/Response_143" },
+              { "$ref": "#/components/schemas/BackupOperationResult_143" },
               { "$ref": "#/components/schemas/Response_144" },
               { "$ref": "#/components/schemas/Response_145" },
-              { "$ref": "#/components/schemas/Response_149" },
-              { "$ref": "#/components/schemas/Response_150" }
+              { "$ref": "#/components/schemas/Response_146" },
+              { "$ref": "#/components/schemas/Response_150" },
+              { "$ref": "#/components/schemas/Response_151" }
             ]
           },
           "serverId": { "type": "string" },
@@ -5319,32 +5386,32 @@
           "updatedAt"
         ]
       },
-      "Response_258": {
+      "Response_262": {
         "type": "object",
         "properties": {
           "backups": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_259" }
+            "items": { "$ref": "#/components/schemas/Response_263" }
           }
         },
         "required": ["backups"]
       },
-      "Response_260": {
+      "Response_264": {
         "type": "object",
         "properties": {
           "previews": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_131" }
+            "items": { "$ref": "#/components/schemas/Response_132" }
           }
         },
         "required": ["previews"]
       },
-      "Response_264": {
+      "Response_268": {
         "type": "object",
         "properties": { "branch": { "type": "string" } },
         "required": ["branch"]
       },
-      "NormalizedDeploymentManifest_263": {
+      "NormalizedDeploymentManifest_267": {
         "type": "object",
         "properties": {
           "apps": {
@@ -5355,12 +5422,12 @@
             "type": "array",
             "items": { "$ref": "#/components/schemas/NormalizedResource_102" }
           },
-          "source": { "$ref": "#/components/schemas/Response_264" },
+          "source": { "$ref": "#/components/schemas/Response_268" },
           "version": { "type": "number", "const": 1 }
         },
         "required": ["apps", "source", "version"]
       },
-      "Response_262": {
+      "Response_266": {
         "type": "object",
         "properties": {
           "commitSha": { "anyOf": [{ "type": "null" }, { "type": "string" }] },
@@ -5368,7 +5435,7 @@
             "anyOf": [
               { "type": "null" },
               {
-                "$ref": "#/components/schemas/NormalizedDeploymentManifest_263"
+                "$ref": "#/components/schemas/NormalizedDeploymentManifest_267"
               }
             ]
           },
@@ -5379,19 +5446,19 @@
         },
         "required": ["commitSha", "manifest", "manifestDigest", "rawManifest"]
       },
-      "Response_261": {
+      "Response_265": {
         "type": "object",
         "properties": {
           "manifest": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/Response_262" }
+              { "$ref": "#/components/schemas/Response_266" }
             ]
           }
         },
         "required": ["manifest"]
       },
-      "MaterializedManifestEntity_268": {
+      "MaterializedManifestEntity_272": {
         "type": "object",
         "properties": {
           "archivedAt": {
@@ -5407,7 +5474,7 @@
         },
         "required": ["archivedAt", "config", "configDigest", "id", "identity"]
       },
-      "ReconciliationAction_267": {
+      "ReconciliationAction_271": {
         "type": "object",
         "properties": {
           "action": {
@@ -5420,14 +5487,14 @@
             ]
           },
           "current": {
-            "$ref": "#/components/schemas/MaterializedManifestEntity_268"
+            "$ref": "#/components/schemas/MaterializedManifestEntity_272"
           },
           "desired": { "$ref": "#/components/schemas/NormalizedApp_92" },
           "id": { "type": "string" }
         },
         "required": ["action", "id"]
       },
-      "MaterializedManifestEntity_270": {
+      "MaterializedManifestEntity_274": {
         "type": "object",
         "properties": {
           "archivedAt": {
@@ -5443,7 +5510,7 @@
         },
         "required": ["archivedAt", "config", "configDigest", "id", "identity"]
       },
-      "ReconciliationAction_269": {
+      "ReconciliationAction_273": {
         "type": "object",
         "properties": {
           "action": {
@@ -5456,39 +5523,39 @@
             ]
           },
           "current": {
-            "$ref": "#/components/schemas/MaterializedManifestEntity_270"
+            "$ref": "#/components/schemas/MaterializedManifestEntity_274"
           },
           "desired": { "$ref": "#/components/schemas/NormalizedResource_102" },
           "id": { "type": "string" }
         },
         "required": ["action", "id"]
       },
-      "Record_271": { "type": "object" },
-      "ManifestReconciliation_266": {
+      "Record_275": { "type": "object" },
+      "ManifestReconciliation_270": {
         "type": "object",
         "properties": {
           "apps": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/ReconciliationAction_267" }
+            "items": { "$ref": "#/components/schemas/ReconciliationAction_271" }
           },
           "resources": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/ReconciliationAction_269" }
+            "items": { "$ref": "#/components/schemas/ReconciliationAction_273" }
           },
-          "summary": { "$ref": "#/components/schemas/Record_271" }
+          "summary": { "$ref": "#/components/schemas/Record_275" }
         },
         "required": ["apps", "resources", "summary"]
       },
-      "Response_265": {
+      "Response_269": {
         "type": "object",
         "properties": {
           "commitSha": { "type": "string" },
           "manifest": {
-            "$ref": "#/components/schemas/NormalizedDeploymentManifest_263"
+            "$ref": "#/components/schemas/NormalizedDeploymentManifest_267"
           },
           "manifestDigest": { "type": "string" },
           "reconciliation": {
-            "$ref": "#/components/schemas/ManifestReconciliation_266"
+            "$ref": "#/components/schemas/ManifestReconciliation_270"
           }
         },
         "required": [
@@ -5498,19 +5565,19 @@
           "reconciliation"
         ]
       },
-      "Response_273": {
+      "Response_277": {
         "type": "object",
         "properties": { "id": { "type": "string" } },
         "required": ["id"]
       },
-      "Response_272": {
+      "Response_276": {
         "type": "object",
         "properties": {
-          "sync": { "$ref": "#/components/schemas/Response_273" }
+          "sync": { "$ref": "#/components/schemas/Response_277" }
         },
         "required": ["sync"]
       },
-      "ManifestIssue_276": {
+      "ManifestIssue_280": {
         "type": "object",
         "properties": {
           "column": { "type": "number" },
@@ -5523,7 +5590,7 @@
         },
         "required": ["message", "path"]
       },
-      "Response_275": {
+      "Response_279": {
         "type": "object",
         "properties": {
           "commitSha": { "anyOf": [{ "type": "null" }, { "type": "string" }] },
@@ -5540,7 +5607,7 @@
               { "type": "null" },
               {
                 "type": "array",
-                "items": { "$ref": "#/components/schemas/ManifestIssue_276" }
+                "items": { "$ref": "#/components/schemas/ManifestIssue_280" }
               }
             ]
           },
@@ -5550,7 +5617,7 @@
           "reconciliation": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/ManifestReconciliation_266" }
+              { "$ref": "#/components/schemas/ManifestReconciliation_270" }
             ]
           },
           "startedAt": {
@@ -5580,24 +5647,24 @@
           "status"
         ]
       },
-      "Response_274": {
+      "Response_278": {
         "type": "object",
         "properties": {
           "syncs": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_275" }
+            "items": { "$ref": "#/components/schemas/Response_279" }
           }
         },
         "required": ["syncs"]
       },
-      "Response_277": {
+      "Response_281": {
         "type": "object",
         "properties": {
-          "sync": { "$ref": "#/components/schemas/Response_275" }
+          "sync": { "$ref": "#/components/schemas/Response_279" }
         },
         "required": ["sync"]
       },
-      "SystemHealthCheck_279": {
+      "SystemHealthCheck_283": {
         "type": "object",
         "properties": {
           "checkedAt": { "anyOf": [{ "type": "null" }, { "type": "string" }] },
@@ -5637,13 +5704,13 @@
           "title"
         ]
       },
-      "SystemHealth_278": {
+      "SystemHealth_282": {
         "type": "object",
         "properties": {
           "checkedAt": { "type": "string" },
           "checks": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/SystemHealthCheck_279" }
+            "items": { "$ref": "#/components/schemas/SystemHealthCheck_283" }
           },
           "status": {
             "anyOf": [
@@ -5657,7 +5724,7 @@
         },
         "required": ["checkedAt", "checks", "status", "version"]
       },
-      "Response_281": {
+      "Response_285": {
         "type": "object",
         "properties": {
           "categories": {
@@ -5704,19 +5771,19 @@
           "updatedAt"
         ]
       },
-      "Response_280": {
+      "Response_284": {
         "type": "object",
         "properties": {
           "canManageNotifications": { "type": "boolean" },
           "destinations": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_281" }
+            "items": { "$ref": "#/components/schemas/Response_285" }
           },
           "providers": { "$ref": "#/components/schemas/Response_41" }
         },
         "required": ["canManageNotifications", "destinations", "providers"]
       },
-      "Response_283": {
+      "Response_287": {
         "type": "object",
         "properties": {
           "categories": {
@@ -5763,21 +5830,21 @@
           "updatedAt"
         ]
       },
-      "Response_282": {
-        "type": "object",
-        "properties": {
-          "destination": { "$ref": "#/components/schemas/Response_283" }
-        },
-        "required": ["destination"]
-      },
-      "Response_284": {
-        "type": "object",
-        "properties": {
-          "destination": { "$ref": "#/components/schemas/Response_281" }
-        },
-        "required": ["destination"]
-      },
       "Response_286": {
+        "type": "object",
+        "properties": {
+          "destination": { "$ref": "#/components/schemas/Response_287" }
+        },
+        "required": ["destination"]
+      },
+      "Response_288": {
+        "type": "object",
+        "properties": {
+          "destination": { "$ref": "#/components/schemas/Response_285" }
+        },
+        "required": ["destination"]
+      },
+      "Response_290": {
         "type": "object",
         "properties": {
           "cycle": { "type": "number" },
@@ -5785,21 +5852,21 @@
         },
         "required": ["cycle", "id"]
       },
-      "Response_285": {
+      "Response_289": {
         "type": "object",
         "properties": {
-          "delivery": { "$ref": "#/components/schemas/Response_286" }
+          "delivery": { "$ref": "#/components/schemas/Response_290" }
         },
         "required": ["delivery"]
       },
-      "Response_287": {
+      "Response_291": {
         "type": "object",
         "properties": {
           "providers": { "$ref": "#/components/schemas/Response_41" }
         },
         "required": ["providers"]
       },
-      "Response_291": {
+      "Response_295": {
         "type": "object",
         "properties": {
           "id": { "type": "string" },
@@ -5820,7 +5887,7 @@
         },
         "required": ["id", "kind", "name"]
       },
-      "Response_292": {
+      "Response_296": {
         "type": "object",
         "properties": {
           "id": { "type": "string" },
@@ -5828,17 +5895,17 @@
         },
         "required": ["id", "name"]
       },
-      "Response_290": {
+      "Response_294": {
         "type": "object",
         "properties": {
-          "details": { "$ref": "#/components/schemas/Record_239" },
-          "entity": { "$ref": "#/components/schemas/Response_291" },
+          "details": { "$ref": "#/components/schemas/Record_241" },
+          "entity": { "$ref": "#/components/schemas/Response_295" },
           "message": { "type": "string" },
           "occurredAt": { "type": "string" },
           "source": {
             "anyOf": [
               { "type": "null" },
-              { "$ref": "#/components/schemas/Response_292" }
+              { "$ref": "#/components/schemas/Response_296" }
             ]
           },
           "title": { "type": "string" }
@@ -5852,7 +5919,7 @@
           "title"
         ]
       },
-      "Response_289": {
+      "Response_293": {
         "type": "object",
         "properties": {
           "category": {
@@ -5869,7 +5936,7 @@
           "createdAt": { "type": "string", "format": "date-time" },
           "id": { "type": "string" },
           "occurredAt": { "type": "string", "format": "date-time" },
-          "payload": { "$ref": "#/components/schemas/Response_290" },
+          "payload": { "$ref": "#/components/schemas/Response_294" },
           "type": {
             "anyOf": [
               { "type": "string", "const": "deployment.queued" },
@@ -5907,12 +5974,12 @@
           "type"
         ]
       },
-      "Response_288": {
+      "Response_292": {
         "type": "object",
         "properties": {
           "notifications": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Response_289" }
+            "items": { "$ref": "#/components/schemas/Response_293" }
           }
         },
         "required": ["notifications"]
@@ -5990,7 +6057,7 @@
             "description": "JSON object containing connection, previewReporting.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_175" }
+                "schema": { "$ref": "#/components/schemas/Response_176" }
               }
             }
           },
@@ -6039,7 +6106,7 @@
             "description": "The number of preview reports queued for retry.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_181" }
+                "schema": { "$ref": "#/components/schemas/Response_182" }
               }
             }
           },
@@ -6068,7 +6135,7 @@
             "description": "JSON object containing repositories.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_185" }
+                "schema": { "$ref": "#/components/schemas/Response_186" }
               }
             }
           },
@@ -6097,7 +6164,7 @@
             "description": "JSON object containing canManage, credential.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_172" }
+                "schema": { "$ref": "#/components/schemas/Response_173" }
               }
             }
           },
@@ -6155,7 +6222,7 @@
             "description": "JSON object containing credential.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_174" }
+                "schema": { "$ref": "#/components/schemas/Response_175" }
               }
             }
           },
@@ -9217,13 +9284,45 @@
         "tags": ["Sources / Overview"],
         "description": "Available to workspace members and owners. Read-only and full-access keys are accepted.",
         "security": [{ "bearerAuth": [] }],
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "maxLength": 200 }
+          },
+          {
+            "name": "view",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "default": "all",
+              "type": "string",
+              "enum": ["all", "attention"]
+            }
+          },
+          {
+            "name": "sync",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["never", "queued", "running", "succeeded", "failed"]
+            }
+          },
+          {
+            "name": "autoDeploy",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "enum": ["enabled", "paused"] }
+          }
+        ],
         "responses": {
           "200": {
             "description": "JSON object containing sources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_243" }
+                "schema": { "$ref": "#/components/schemas/Response_245" }
               }
             }
           },
@@ -9290,7 +9389,7 @@
             "description": "JSON object containing source.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_245" }
+                "schema": { "$ref": "#/components/schemas/Response_248" }
               }
             }
           },
@@ -9331,7 +9430,7 @@
             "description": "JSON object containing canManageSource, source.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_247" }
+                "schema": { "$ref": "#/components/schemas/Response_250" }
               }
             }
           },
@@ -9404,7 +9503,7 @@
             "description": "JSON object containing autoDeploy, canManageAutoDeploy.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_248" }
+                "schema": { "$ref": "#/components/schemas/Response_252" }
               }
             }
           },
@@ -9457,7 +9556,7 @@
             "description": "JSON object containing autoDeploy, canManageAutoDeploy.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_252" }
+                "schema": { "$ref": "#/components/schemas/Response_256" }
               }
             }
           },
@@ -9498,7 +9597,7 @@
             "description": "JSON object containing apps.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_254" }
+                "schema": { "$ref": "#/components/schemas/Response_258" }
               }
             }
           },
@@ -9539,7 +9638,7 @@
             "description": "JSON object containing resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_255" }
+                "schema": { "$ref": "#/components/schemas/Response_259" }
               }
             }
           },
@@ -9580,7 +9679,7 @@
             "description": "JSON object containing capacities.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_256" }
+                "schema": { "$ref": "#/components/schemas/Response_260" }
               }
             }
           },
@@ -9621,7 +9720,7 @@
             "description": "JSON object containing deployments.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_257" }
+                "schema": { "$ref": "#/components/schemas/Response_261" }
               }
             }
           },
@@ -9662,7 +9761,7 @@
             "description": "JSON object containing backups.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_258" }
+                "schema": { "$ref": "#/components/schemas/Response_262" }
               }
             }
           },
@@ -9703,7 +9802,7 @@
             "description": "JSON object containing previews.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_260" }
+                "schema": { "$ref": "#/components/schemas/Response_264" }
               }
             }
           },
@@ -9744,7 +9843,7 @@
             "description": "JSON object containing manifest.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_261" }
+                "schema": { "$ref": "#/components/schemas/Response_265" }
               }
             }
           },
@@ -9785,7 +9884,7 @@
             "description": "The proposed manifest changes and reconciliation result.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_265" }
+                "schema": { "$ref": "#/components/schemas/Response_269" }
               }
             }
           },
@@ -9826,7 +9925,7 @@
             "description": "JSON object containing sync. Accepted work continues asynchronously; poll its ID.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_272" }
+                "schema": { "$ref": "#/components/schemas/Response_276" }
               }
             }
           },
@@ -9867,7 +9966,7 @@
             "description": "JSON object containing syncs.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_274" }
+                "schema": { "$ref": "#/components/schemas/Response_278" }
               }
             }
           },
@@ -9919,7 +10018,7 @@
             "description": "JSON object containing sync.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_277" }
+                "schema": { "$ref": "#/components/schemas/Response_281" }
               }
             }
           },
@@ -9942,7 +10041,67 @@
         "tags": ["Apps / Overview"],
         "description": "Available to workspace members and owners. Read-only and full-access keys are accepted.",
         "security": [{ "bearerAuth": [] }],
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "maxLength": 200 }
+          },
+          {
+            "name": "view",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "default": "all",
+              "type": "string",
+              "enum": ["all", "attention"]
+            }
+          },
+          {
+            "name": "sourceId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            }
+          },
+          {
+            "name": "serverIp",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "maxLength": 100 }
+          },
+          {
+            "name": "resourceType",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["image", "postgres", "redis"]
+            }
+          },
+          {
+            "name": "running",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["running", "stopped", "missing", "unknown"]
+            }
+          },
+          {
+            "name": "health",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["healthy", "unhealthy", "starting", "none", "unknown"]
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "JSON object containing apps.",
@@ -9989,7 +10148,7 @@
             "description": "JSON object containing app.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_116" }
+                "schema": { "$ref": "#/components/schemas/Response_117" }
               }
             }
           },
@@ -10030,7 +10189,7 @@
             "description": "JSON object containing autoDeploy, canManageAutoDeploy.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_119" }
+                "schema": { "$ref": "#/components/schemas/Response_120" }
               }
             }
           },
@@ -10083,7 +10242,7 @@
             "description": "JSON object containing autoDeploy, canManageAutoDeploy.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_124" }
+                "schema": { "$ref": "#/components/schemas/Response_125" }
               }
             }
           },
@@ -10124,7 +10283,7 @@
             "description": "JSON object containing deployments.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_126" }
+                "schema": { "$ref": "#/components/schemas/Response_127" }
               }
             }
           },
@@ -10165,7 +10324,7 @@
             "description": "JSON object containing releases.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_128" }
+                "schema": { "$ref": "#/components/schemas/Response_129" }
               }
             }
           },
@@ -10206,7 +10365,7 @@
             "description": "JSON object containing previews.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_130" }
+                "schema": { "$ref": "#/components/schemas/Response_131" }
               }
             }
           },
@@ -10247,7 +10406,7 @@
             "description": "JSON object containing operations.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_132" }
+                "schema": { "$ref": "#/components/schemas/Response_133" }
               }
             }
           },
@@ -10294,7 +10453,7 @@
             "description": "The deployment and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_151" }
+                "schema": { "$ref": "#/components/schemas/Response_152" }
               }
             }
           },
@@ -10302,7 +10461,7 @@
             "description": "The deployment and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_151" }
+                "schema": { "$ref": "#/components/schemas/Response_152" }
               }
             }
           },
@@ -10368,7 +10527,7 @@
             "description": "The rollback deployment and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_152" }
+                "schema": { "$ref": "#/components/schemas/Response_153" }
               }
             }
           },
@@ -10376,7 +10535,7 @@
             "description": "The rollback deployment and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_152" }
+                "schema": { "$ref": "#/components/schemas/Response_153" }
               }
             }
           },
@@ -10423,7 +10582,7 @@
             "description": "The runtime operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -10431,7 +10590,7 @@
             "description": "The runtime operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -10478,7 +10637,7 @@
             "description": "The runtime operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -10486,7 +10645,7 @@
             "description": "The runtime operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -10533,7 +10692,7 @@
             "description": "The runtime operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -10541,7 +10700,7 @@
             "description": "The runtime operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -10604,7 +10763,7 @@
             "description": "The runtime operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -10612,7 +10771,7 @@
             "description": "The runtime operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -10635,13 +10794,73 @@
         "tags": ["Resources / Overview"],
         "description": "Available to workspace members and owners. Read-only and full-access keys are accepted.",
         "security": [{ "bearerAuth": [] }],
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "maxLength": 200 }
+          },
+          {
+            "name": "view",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "default": "all",
+              "type": "string",
+              "enum": ["all", "attention"]
+            }
+          },
+          {
+            "name": "sourceId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            }
+          },
+          {
+            "name": "serverIp",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "maxLength": 100 }
+          },
+          {
+            "name": "resourceType",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["image", "postgres", "redis"]
+            }
+          },
+          {
+            "name": "running",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["running", "stopped", "missing", "unknown"]
+            }
+          },
+          {
+            "name": "health",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["healthy", "unhealthy", "starting", "none", "unknown"]
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "JSON object containing resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_226" }
+                "schema": { "$ref": "#/components/schemas/Response_228" }
               }
             }
           },
@@ -10682,7 +10901,7 @@
             "description": "JSON object containing resource.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_227" }
+                "schema": { "$ref": "#/components/schemas/Response_229" }
               }
             }
           },
@@ -10723,7 +10942,7 @@
             "description": "JSON object containing autoDeploy, canManageAutoDeploy.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_228" }
+                "schema": { "$ref": "#/components/schemas/Response_230" }
               }
             }
           },
@@ -10776,7 +10995,7 @@
             "description": "JSON object containing autoDeploy, canManageAutoDeploy.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_229" }
+                "schema": { "$ref": "#/components/schemas/Response_231" }
               }
             }
           },
@@ -10817,7 +11036,7 @@
             "description": "JSON object containing deployments.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_231" }
+                "schema": { "$ref": "#/components/schemas/Response_233" }
               }
             }
           },
@@ -10858,7 +11077,7 @@
             "description": "JSON object containing releases.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_232" }
+                "schema": { "$ref": "#/components/schemas/Response_234" }
               }
             }
           },
@@ -10899,7 +11118,7 @@
             "description": "JSON object containing operations.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_233" }
+                "schema": { "$ref": "#/components/schemas/Response_235" }
               }
             }
           },
@@ -10940,7 +11159,7 @@
             "description": "JSON object containing assurance, assurances, awsConfigured, canRestore.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_234" }
+                "schema": { "$ref": "#/components/schemas/Response_236" }
               }
             }
           },
@@ -10992,7 +11211,7 @@
             "description": "JSON object containing events.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_237" }
+                "schema": { "$ref": "#/components/schemas/Response_239" }
               }
             }
           },
@@ -11039,7 +11258,7 @@
             "description": "The deployment and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_151" }
+                "schema": { "$ref": "#/components/schemas/Response_152" }
               }
             }
           },
@@ -11047,7 +11266,7 @@
             "description": "The deployment and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_151" }
+                "schema": { "$ref": "#/components/schemas/Response_152" }
               }
             }
           },
@@ -11113,7 +11332,7 @@
             "description": "The rollback deployment and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_152" }
+                "schema": { "$ref": "#/components/schemas/Response_153" }
               }
             }
           },
@@ -11121,7 +11340,7 @@
             "description": "The rollback deployment and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_152" }
+                "schema": { "$ref": "#/components/schemas/Response_153" }
               }
             }
           },
@@ -11168,7 +11387,7 @@
             "description": "The runtime operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -11176,7 +11395,7 @@
             "description": "The runtime operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -11223,7 +11442,7 @@
             "description": "The runtime operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -11231,7 +11450,7 @@
             "description": "The runtime operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -11278,7 +11497,7 @@
             "description": "The runtime operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -11286,7 +11505,7 @@
             "description": "The runtime operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -11333,7 +11552,7 @@
             "description": "The runtime operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -11341,7 +11560,7 @@
             "description": "The runtime operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -11418,7 +11637,7 @@
             "description": "The restore operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -11426,7 +11645,7 @@
             "description": "The restore operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -11493,7 +11712,7 @@
             "description": "The restore cleanup operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -11501,7 +11720,7 @@
             "description": "The restore cleanup operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -11553,7 +11772,7 @@
             "description": "JSON object containing operation.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_240" }
+                "schema": { "$ref": "#/components/schemas/Response_242" }
               }
             }
           },
@@ -11616,7 +11835,7 @@
             "description": "The runtime operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -11624,7 +11843,7 @@
             "description": "The runtime operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -11665,7 +11884,7 @@
             "description": "The preview cleanup operation and its status. Accepted work continues asynchronously; poll its ID.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_241" }
+                "schema": { "$ref": "#/components/schemas/Response_243" }
               }
             }
           },
@@ -11673,7 +11892,7 @@
             "description": "The preview cleanup operation and its status. Accepted work continues asynchronously; poll its ID.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_241" }
+                "schema": { "$ref": "#/components/schemas/Response_243" }
               }
             }
           },
@@ -11714,7 +11933,7 @@
             "description": "The preview deployment and whether the request was replayed. Accepted work continues asynchronously; poll its ID.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_242" }
+                "schema": { "$ref": "#/components/schemas/Response_244" }
               }
             }
           },
@@ -11737,13 +11956,66 @@
         "tags": ["Servers / Overview"],
         "description": "Available to workspace members and owners. Read-only and full-access keys are accepted.",
         "security": [{ "bearerAuth": [] }],
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "maxLength": 200 }
+          },
+          {
+            "name": "view",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "default": "all",
+              "type": "string",
+              "enum": ["all", "attention"]
+            }
+          },
+          {
+            "name": "setup",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["ready", "pending", "preparing", "failed"]
+            }
+          },
+          {
+            "name": "health",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["healthy", "unhealthy", "unknown"]
+            }
+          },
+          {
+            "name": "scout",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "online",
+                "offline",
+                "disabled",
+                "queued",
+                "installing",
+                "uninstalling",
+                "waiting",
+                "failed"
+              ]
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "JSON object containing servers.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_187" }
+                "schema": { "$ref": "#/components/schemas/Response_188" }
               }
             }
           },
@@ -11827,7 +12099,7 @@
             "description": "JSON object containing server.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_193" }
+                "schema": { "$ref": "#/components/schemas/Response_195" }
               }
             }
           },
@@ -11868,7 +12140,7 @@
             "description": "JSON object containing canCleanupOrphans, canManageServer, canRemoveServer, server.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_195" }
+                "schema": { "$ref": "#/components/schemas/Response_197" }
               }
             }
           },
@@ -11964,7 +12236,7 @@
             "description": "JSON object containing server.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_197" }
+                "schema": { "$ref": "#/components/schemas/Response_199" }
               }
             }
           },
@@ -12042,7 +12314,7 @@
             "description": "JSON object containing apps.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_198" }
+                "schema": { "$ref": "#/components/schemas/Response_200" }
               }
             }
           },
@@ -12083,7 +12355,7 @@
             "description": "JSON object containing resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_201" }
+                "schema": { "$ref": "#/components/schemas/Response_203" }
               }
             }
           },
@@ -12124,7 +12396,7 @@
             "description": "JSON object containing deployments.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_202" }
+                "schema": { "$ref": "#/components/schemas/Response_204" }
               }
             }
           },
@@ -12165,7 +12437,7 @@
             "description": "JSON object containing capacity.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_203" }
+                "schema": { "$ref": "#/components/schemas/Response_205" }
               }
             }
           },
@@ -12228,7 +12500,7 @@
             "description": "Server checks and pagination metadata.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_209" }
+                "schema": { "$ref": "#/components/schemas/Response_211" }
               }
             }
           },
@@ -12269,7 +12541,7 @@
             "description": "JSON object containing preparations.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_213" }
+                "schema": { "$ref": "#/components/schemas/Response_215" }
               }
             }
           },
@@ -12310,7 +12582,7 @@
             "description": "JSON object containing orphans.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_216" }
+                "schema": { "$ref": "#/components/schemas/Response_218" }
               }
             }
           },
@@ -12351,7 +12623,7 @@
             "description": "JSON object containing hostKeys.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_217" }
+                "schema": { "$ref": "#/components/schemas/Response_219" }
               }
             }
           },
@@ -12392,7 +12664,7 @@
             "description": "JSON object containing check. Accepted work continues asynchronously; poll its ID.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_219" }
+                "schema": { "$ref": "#/components/schemas/Response_221" }
               }
             }
           },
@@ -12433,7 +12705,7 @@
             "description": "JSON object containing preparation. Accepted work continues asynchronously; poll its ID.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_221" }
+                "schema": { "$ref": "#/components/schemas/Response_223" }
               }
             }
           },
@@ -12516,7 +12788,7 @@
             "description": "The cleanup operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -12524,7 +12796,7 @@
             "description": "The cleanup operation and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_153" }
+                "schema": { "$ref": "#/components/schemas/Response_154" }
               }
             }
           },
@@ -12594,7 +12866,7 @@
             "description": "JSON object containing hostKey.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_223" }
+                "schema": { "$ref": "#/components/schemas/Response_225" }
               }
             }
           },
@@ -12668,7 +12940,7 @@
             "description": "JSON object containing deployments.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_154" }
+                "schema": { "$ref": "#/components/schemas/Response_155" }
               }
             }
           },
@@ -12794,7 +13066,7 @@
             "description": "Deployment history and pagination metadata.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_156" }
+                "schema": { "$ref": "#/components/schemas/Response_157" }
               }
             }
           },
@@ -12835,7 +13107,7 @@
             "description": "JSON object containing deployment.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_159" }
+                "schema": { "$ref": "#/components/schemas/Response_160" }
               }
             }
           },
@@ -12876,7 +13148,7 @@
             "description": "JSON object containing steps.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_163" }
+                "schema": { "$ref": "#/components/schemas/Response_164" }
               }
             }
           },
@@ -12927,7 +13199,7 @@
             "description": "JSON object containing logs.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_165" }
+                "schema": { "$ref": "#/components/schemas/Response_166" }
               }
             }
           },
@@ -12968,7 +13240,7 @@
             "description": "JSON object containing findings.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_167" }
+                "schema": { "$ref": "#/components/schemas/Response_168" }
               }
             }
           },
@@ -13025,7 +13297,7 @@
             "description": "JSON object containing deployment, logs, steps.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_169" }
+                "schema": { "$ref": "#/components/schemas/Response_170" }
               },
               "text/event-stream": { "schema": { "type": "string" } }
             }
@@ -13067,7 +13339,7 @@
             "description": "JSON object containing deployment. Accepted work continues asynchronously; poll its ID.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_170" }
+                "schema": { "$ref": "#/components/schemas/Response_171" }
               }
             }
           },
@@ -13114,7 +13386,7 @@
             "description": "The retry deployment and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_151" }
+                "schema": { "$ref": "#/components/schemas/Response_152" }
               }
             }
           },
@@ -13122,7 +13394,7 @@
             "description": "The retry deployment and whether the request was replayed. Accepted work continues asynchronously; poll its ID. An idempotent replay returns 200.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Response_151" }
+                "schema": { "$ref": "#/components/schemas/Response_152" }
               }
             }
           },
@@ -13166,7 +13438,7 @@
                 "schema": {
                   "anyOf": [
                     { "type": "null" },
-                    { "$ref": "#/components/schemas/Response_171" }
+                    { "$ref": "#/components/schemas/Response_172" }
                   ]
                 }
               }
@@ -13197,7 +13469,7 @@
             "description": "Control-plane, integration, and server health checks.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SystemHealth_278" }
+                "schema": { "$ref": "#/components/schemas/SystemHealth_282" }
               }
             }
           },
@@ -13226,7 +13498,7 @@
             "description": "Updated control-plane, integration, and server health checks.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SystemHealth_278" }
+                "schema": { "$ref": "#/components/schemas/SystemHealth_282" }
               }
             }
           },

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -12713,6 +12713,80 @@
               "minimum": 1,
               "maximum": 100
             }
+          },
+          {
+            "name": "environment",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "enum": ["production", "preview"] }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "enum": ["app", "resource"] }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "queued",
+                "waiting_for_server",
+                "preparing",
+                "validating_credentials",
+                "checking_server",
+                "fetching_source",
+                "resolving_secrets",
+                "transferring",
+                "building",
+                "running_pre_deploy",
+                "starting_candidate",
+                "checking_health",
+                "configuring_routing",
+                "provisioning_tls",
+                "checking_public_endpoint",
+                "switching_traffic",
+                "running_post_deploy",
+                "cleaning_up",
+                "succeeded",
+                "succeeded_with_warnings",
+                "skipped",
+                "failed",
+                "cancelled"
+              ]
+            }
+          },
+          {
+            "name": "trigger",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["auto_deploy", "manual", "rollback"]
+            }
+          },
+          {
+            "name": "serverId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "default": "newest",
+              "type": "string",
+              "enum": ["newest", "oldest", "name_asc", "name_desc"]
+            }
           }
         ],
         "responses": {

--- a/docs/docs/deployments.mdx
+++ b/docs/docs/deployments.mdx
@@ -30,6 +30,12 @@ A deployment is one attempt to put an app or resource into service. Towbar recor
   </p>
 </div>
 
+## Browse deployment history
+
+Use the Deployments page sidebar to filter by workload type, environment, status, trigger, or server. Sort by request time or workload name. Filters and sorting apply to the full history before pagination, and the URL preserves your selection.
+
+On mobile, open **Page menu** to access the filters.
+
 ## Deploy manually
 
 Open an app or resource and choose **Deploy**. The server must be prepared and trusted, and required credentials must be configured. Follow the queued operation through its recorded stages; a queued request is not a completed deployment.

--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -51,6 +51,18 @@ Sources, servers, workloads, deployments, and releases.
   </Card>
 </CardGroup>
 
+## Filter and share views
+
+The secondary sidebar contains the current page’s filters and sections. On mobile, open **Page menu**. Apps, Resources, Servers, and Sources have **All** and **Needs attention** views with counts for the full inventory.
+
+- **Apps and Resources:** filter by Source, server, running state, and health. Resources also supports resource type.
+- **Servers:** filter by setup status, latest check health, and Scout Agent status. An absent or unfinished check is shown as unknown.
+- **Sources:** filter by latest sync result and whether automatic deployments are enabled or paused.
+
+Needs attention includes workloads with unprepared servers, unhealthy runtime checks, configuration drift, or a missing/stopped container that should be running. Servers need attention when setup is pending or failed, the latest check failed, or an enabled Scout Agent is offline or in error. Sources need attention after a failed latest sync. An intentionally stopped workload or a disabled Scout Agent does not by itself need attention.
+
+Search and filter selections are stored in the URL. Opening a copied URL restores the view; browser Back and Forward restore earlier selections. Performance and Alerts links also retain the selected entity. Monitoring links preserve the time range, environment, aggregation, and instance selection, while shared-secret links preserve environment and stage. Secret values are never included in these links.
+
 ## Operate with context
 
 | I want to…                    | Read                                                                                 |

--- a/docs/docs/monitoring.mdx
+++ b/docs/docs/monitoring.mdx
@@ -5,6 +5,10 @@ description: "Read control-plane checks, runtime health, resource usage, and ope
 
 Towbar exposes several kinds of health. Read the relevant check and its timestamp before deciding whether an installation or workload is ready.
 
+## Navigate monitoring
+
+On Performance and Alerts, choose an entity type in the secondary sidebar, then select a server, app, or resource from the list. Search the list by name or IP address. Alerts also supports all entities of the selected type. On Incidents, choose **All incidents**, **Active**, or **Resolved**. On mobile, open **Page menu** for these controls.
+
 ## System health
 
 Open **Manage → System health** and choose **Run checks**.
@@ -43,7 +47,7 @@ A provider configuration badge means required settings exist. It does not confir
 
 ## Server and workload health
 
-The server's Checks view records connectivity and runtime observations. Its Apps and Resources tabs separate the workloads assigned to the host. Health indicators and tooltips identify healthy, unhealthy, starting, and unavailable observations.
+The server's Checks view records connectivity and runtime observations. Its Apps and Resources sidebar items separate the workloads assigned to the host. Health indicators and tooltips identify healthy, unhealthy, starting, and unavailable observations.
 
 A deployment can succeed and later become unhealthy. Check the latest runtime state and logs instead of relying only on deployment history.
 

--- a/packages/towbar-core/package.json
+++ b/packages/towbar-core/package.json
@@ -15,7 +15,8 @@
     "./temporal": "./dist/temporal.js",
     "./schema": "./schemas/deployment.v1.json",
     "./scout-alerts": "./dist/scout-alerts.js",
-    "./deployment-comparison": "./dist/deployment-comparison.js"
+    "./deployment-comparison": "./dist/deployment-comparison.js",
+    "./inventory": "./dist/inventory.js"
   },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",

--- a/packages/towbar-core/src/inventory.test.ts
+++ b/packages/towbar-core/src/inventory.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  filterServers,
+  filterSources,
+  filterWorkloads,
+  serverFilters,
+  sourceFilters,
+  workloadFilters,
+} from "./inventory.js";
+const sourceId = "11111111-1111-4111-8111-111111111111";
+const healthy = {
+  name: "API",
+  sourceId,
+  serverIp: "192.0.2.10",
+  kind: "app",
+  serverReady: true,
+  runtimeState: {
+    desiredState: "running",
+    observedState: "running",
+    healthStatus: "healthy",
+    driftStatus: "in_sync",
+  },
+};
+void test("inventory filters intersect, preserve all/attention counts, and distinguish intentional stops", () => {
+  const stopped = {
+    ...healthy,
+    name: "Stopped",
+    runtimeState: {
+      ...healthy.runtimeState,
+      desiredState: "stopped",
+      observedState: "stopped",
+    },
+  };
+  const missing = {
+    ...healthy,
+    name: "Missing",
+    runtimeState: { ...healthy.runtimeState, observedState: "missing" },
+  };
+  const unhealthy = {
+    ...healthy,
+    name: "Cache",
+    kind: "redis",
+    runtimeState: { ...healthy.runtimeState, healthStatus: "unhealthy" },
+  };
+  const items = [healthy, stopped, missing, unhealthy];
+  const result = filterWorkloads(
+    items,
+    workloadFilters.parse({
+      view: "attention",
+      resourceType: "redis",
+      q: "CACHE",
+      sourceId,
+      serverIp: "192.0.2.10",
+      health: "unhealthy",
+      running: "running",
+    }),
+  );
+  assert.deepEqual(result.items, [unhealthy]);
+  assert.deepEqual(result.counts, { all: 4, attention: 2 });
+  assert.equal(
+    filterWorkloads(
+      items,
+      workloadFilters.parse({ view: "attention", running: "stopped" }),
+    ).items.length,
+    0,
+  );
+  assert.equal(
+    filterWorkloads(items, workloadFilters.parse({ serverIp: "192.0.2.11" }))
+      .items.length,
+    0,
+  );
+});
+void test("servers preserve unknown health and treat disabled Scout separately from offline", () => {
+  const items = [
+    {
+      canonicalIp: "192.0.2.10",
+      setupStatus: "ready",
+      healthStatus: "healthy",
+      scout: { enabled: false, status: "offline" },
+    },
+    {
+      canonicalIp: "192.0.2.11",
+      setupStatus: "ready",
+      scout: { enabled: true, status: "offline" },
+    },
+    {
+      canonicalIp: "192.0.2.12",
+      setupStatus: "failed",
+      healthStatus: "unhealthy",
+    },
+  ];
+  assert.deepEqual(
+    filterServers(
+      items,
+      serverFilters.parse({ scout: "disabled", health: "healthy" }),
+    ).items,
+    [items[0]],
+  );
+  assert.deepEqual(
+    filterServers(
+      items,
+      serverFilters.parse({ view: "attention", health: "unknown" }),
+    ).items,
+    [items[1]],
+  );
+  assert.deepEqual(
+    filterServers(items, serverFilters.parse({ setup: "failed", q: ".12" }))
+      .counts,
+    { all: 3, attention: 2 },
+  );
+});
+void test("source filters use latest sync outcomes and deployment pause independently", () => {
+  const items = [
+    {
+      repositoryOwner: "Acme",
+      repositoryName: "Web",
+      latestSyncStatus: "failed",
+      autoDeployPaused: false,
+    },
+    {
+      repositoryOwner: "Acme",
+      repositoryName: "API",
+      latestSyncStatus: "succeeded",
+      autoDeployPaused: true,
+    },
+  ];
+  assert.deepEqual(
+    filterSources(
+      items,
+      sourceFilters.parse({
+        view: "attention",
+        sync: "failed",
+        autoDeploy: "enabled",
+        q: "acme/web",
+      }),
+    ).items,
+    [items[0]],
+  );
+  assert.equal(
+    filterSources(
+      items,
+      sourceFilters.parse({ view: "attention", autoDeploy: "paused" }),
+    ).items.length,
+    0,
+  );
+});
+void test("inventory filter validation rejects unsupported state, malformed ids and long search", () => {
+  assert.equal(workloadFilters.safeParse({ sourceId: "wrong" }).success, false);
+  assert.equal(workloadFilters.safeParse({ health: "good" }).success, false);
+  assert.equal(serverFilters.safeParse({ scout: "good" }).success, false);
+  assert.equal(sourceFilters.safeParse({ autoSync: "true" }).success, false);
+  assert.equal(sourceFilters.safeParse({ q: "x".repeat(201) }).success, false);
+});

--- a/packages/towbar-core/src/inventory.ts
+++ b/packages/towbar-core/src/inventory.ts
@@ -1,0 +1,143 @@
+import { z } from "zod";
+
+const base = z.object({
+  q: z.string().trim().max(200).optional(),
+  view: z.enum(["all", "attention"]).default("all"),
+});
+export const workloadFilters = base
+  .extend({
+    sourceId: z.uuid().optional(),
+    serverIp: z.string().max(100).optional(),
+    resourceType: z.enum(["image", "postgres", "redis"]).optional(),
+    running: z.enum(["running", "stopped", "missing", "unknown"]).optional(),
+    health: z
+      .enum(["healthy", "unhealthy", "starting", "none", "unknown"])
+      .optional(),
+  })
+  .strict();
+export const serverFilters = base
+  .extend({
+    setup: z.enum(["ready", "pending", "preparing", "failed"]).optional(),
+    health: z.enum(["healthy", "unhealthy", "unknown"]).optional(),
+    scout: z
+      .enum([
+        "online",
+        "offline",
+        "disabled",
+        "queued",
+        "installing",
+        "uninstalling",
+        "waiting",
+        "failed",
+      ])
+      .optional(),
+  })
+  .strict();
+export const sourceFilters = base
+  .extend({
+    sync: z
+      .enum(["never", "queued", "running", "succeeded", "failed"])
+      .optional(),
+    autoDeploy: z.enum(["enabled", "paused"]).optional(),
+  })
+  .strict();
+
+type Base = z.output<typeof base>;
+function select<T>(
+  items: T[],
+  query: Base,
+  attention: (item: T) => boolean,
+  matches: (item: T) => boolean,
+) {
+  return {
+    items: items.filter(
+      (item) =>
+        (query.view !== "attention" || attention(item)) && matches(item),
+    ),
+    counts: { all: items.length, attention: items.filter(attention).length },
+  };
+}
+const includes = (text: string, q?: string) =>
+  !q || text.toLowerCase().includes(q.toLowerCase());
+export function filterWorkloads<
+  T extends {
+    name: string;
+    sourceId: string;
+    serverIp: string;
+    kind: string;
+    serverReady: boolean;
+    runtimeState: {
+      healthStatus: string;
+      observedState: string;
+      desiredState: string;
+      driftStatus: string;
+    };
+  },
+>(items: T[], query: z.output<typeof workloadFilters>) {
+  return select(
+    items,
+    query,
+    (item) =>
+      !item.serverReady ||
+      item.runtimeState.healthStatus === "unhealthy" ||
+      item.runtimeState.driftStatus === "drifted" ||
+      (item.runtimeState.desiredState === "running" &&
+        ["stopped", "missing"].includes(item.runtimeState.observedState)),
+    (item) =>
+      includes(`${item.name} ${item.serverIp}`, query.q) &&
+      (!query.sourceId || item.sourceId === query.sourceId) &&
+      (!query.serverIp || item.serverIp === query.serverIp) &&
+      (!query.resourceType || item.kind === query.resourceType) &&
+      (!query.running || item.runtimeState.observedState === query.running) &&
+      (!query.health || item.runtimeState.healthStatus === query.health),
+  );
+}
+export function filterServers<
+  T extends {
+    canonicalIp: string;
+    setupStatus: string;
+    healthStatus?: string;
+    scout?: { enabled: boolean; status: string };
+  },
+>(items: T[], query: z.output<typeof serverFilters>) {
+  const scoutState = (item: T) =>
+    !item.scout?.enabled &&
+    !["queued", "uninstalling", "failed"].includes(
+      item.scout?.status ?? "disabled",
+    )
+      ? "disabled"
+      : (item.scout?.status ?? "disabled");
+  return select(
+    items,
+    query,
+    (item) =>
+      item.setupStatus === "failed" ||
+      item.setupStatus === "pending" ||
+      item.healthStatus === "unhealthy" ||
+      ["offline", "failed"].includes(scoutState(item)),
+    (item) =>
+      includes(item.canonicalIp, query.q) &&
+      (!query.setup || item.setupStatus === query.setup) &&
+      (!query.health || (item.healthStatus ?? "unknown") === query.health) &&
+      (!query.scout || scoutState(item) === query.scout),
+  );
+}
+export function filterSources<
+  T extends {
+    repositoryOwner: string;
+    repositoryName: string;
+    latestSyncStatus?: string;
+    autoDeployPaused?: boolean;
+  },
+>(items: T[], query: z.output<typeof sourceFilters>) {
+  return select(
+    items,
+    query,
+    (item) => item.latestSyncStatus === "failed",
+    (item) =>
+      includes(`${item.repositoryOwner}/${item.repositoryName}`, query.q) &&
+      (!query.sync || (item.latestSyncStatus ?? "never") === query.sync) &&
+      (!query.autoDeploy ||
+        Boolean(item.autoDeployPaused) === (query.autoDeploy === "paused")),
+  );
+}

--- a/packages/towbar-web-client/src/index.ts
+++ b/packages/towbar-web-client/src/index.ts
@@ -24,3 +24,5 @@ export type {
   ComparisonPoint,
   ComparisonMetricSummary,
 } from "@workspace/towbar-core";
+
+export { deploymentStates } from "@workspace/towbar-core/temporal";

--- a/packages/web-design-system/src/layouts/app-shell.tsx
+++ b/packages/web-design-system/src/layouts/app-shell.tsx
@@ -131,7 +131,7 @@ export function ApplicationNavbar({
   };
 
   return (
-    <header className="sticky top-0 z-30 flex min-h-16 items-center justify-between gap-5 border-b border-separator bg-background/90 px-4 backdrop-blur sm:px-6">
+    <header className="sticky top-0 z-30 flex min-h-16 items-center justify-between gap-5 border-b border-separator bg-background/90 px-4 backdrop-blur">
       <div className="flex min-w-0 items-center gap-2">
         {hasSidebar ? (
           <Button


### PR DESCRIPTION
## Changes

Adds a secondary sidebar using the primary menu styling, with independent scrolling, a 240px desktop width, and a collapsible Page menu on mobile.

- Apps, Resources, Servers and Sources: All/Needs attention views with counts, server-backed filters and search. Workloads support source, server, running state and health; Resources adds resource type. Servers support setup, latest check health and Scout Agent status. Sources support latest sync result and the automatic deployment pause control.
- Deployments: server-backed workload, environment, status, trigger and server filters, plus request-time and workload-name sorting. Filtered totals and pagination use the same database conditions.
- Performance and Alerts: entity type selector and searchable entity list in the sidebar.
- Incidents: All, Active and Resolved menu items.
- Integrations and API & MCP: existing section menus move into the sidebar.
- Shared secrets: environment and stage menus sit together in the sidebar; Form/File stays inside the editor widget.
- Settings: Profile and Sessions share one page, with redirects from the previous account URLs.
- App, resource, server and source detail pages: section navigation and nested settings move into the sidebar.

Filter selections and monitoring entities are restored from permalinks and browser Back/Forward. Monitoring links also preserve ranges (including custom dates), environment, aggregation and instance; secret links preserve environment and stage without including secret values. An unavailable entity link shows an explicit message instead of silently selecting another entity.

Updates API documentation and navigation guidance. Shared pure filtering rules keep the fixture aligned with the API; existing unfiltered list responses retain their collection fields and add counts.

## Validation

- `pnpm verify`: documentation, formatting, lint, type checks, tests and production builds.
- Four inventory filter tests covering intersections, counts, intentional stops, unknown health, Scout status, source sync/pause state and validation.
- PostgreSQL integration suite: 14 tests passed, including deployment filtering/pagination and workspace isolation for inventory status queries.
- Chrome checks across the requested routes, direct filtered links, permalink reload, entity selection, browser Back/Forward, unavailable entities, secret environment/stage and mobile overflow.
