### PR TITLE
Add entity filters to Incidents

### DIFF
--- a/apps/towbar-web-app/src/components/workspace-monitoring-incidents.tsx
+++ b/apps/towbar-web-app/src/components/workspace-monitoring-incidents.tsx
@@ -1,5 +1,7 @@
 "use client";
 import { SecondaryItems } from "./secondary-sidebar";
+import { MonitoringEntityPicker } from "./monitoring-entity-picker";
+import { useMonitoringSelection } from "@/hooks/use-monitoring-selection";
 import { ScoutIcon } from "./scout-icons";
 import { useState } from "react";
 import { useQueryChoice } from "@/hooks/use-page-query";
@@ -15,6 +17,7 @@ import {
   type ResourceTableColumn,
 } from "@workspace/towbar-web-ui/resource-table";
 import { DashboardPage } from "./page-parts";
+import { PageSelectionTitle } from "./page-selection-title";
 import { conditionDescription, scoutValue } from "./scout-controls";
 import { RelativeTime } from "./last-synced-time";
 import { ScoutIncidentDrawer } from "./scout-incident-drawer";
@@ -25,6 +28,14 @@ import {
 } from "./workspace-monitoring-shared";
 
 export function WorkspaceIncidents() {
+  const {
+    kind,
+    setKind,
+    selected: selectedEntity,
+    select: setSelectedEntity,
+    entityKey,
+    resolve,
+  } = useMonitoringSelection();
   const [state, setState] = useQueryChoice(
     "state",
     ["all", "active", "resolved"],
@@ -34,6 +45,7 @@ export function WorkspaceIncidents() {
   const { query, pagination, reset } = useMonitoringOverview<OverviewIncident>(
     "incidents",
     state,
+    `&kind=${kind}${selectedEntity ? `&entityId=${selectedEntity.id}` : ""}`,
   );
   const columns: ResourceTableColumn<OverviewIncident>[] = [
     {
@@ -143,14 +155,22 @@ export function WorkspaceIncidents() {
   return (
     <DashboardPage
       title={
-        state === "active"
-          ? "Active incidents"
-          : state === "resolved"
-            ? "Resolved incidents"
-            : "All incidents"
+        selectedEntity
+          ? `${selectedEntity.name} · ${state === "active" ? "Active incidents" : state === "resolved" ? "Resolved incidents" : "All incidents"}`
+          : state === "active"
+            ? "Active incidents"
+            : state === "resolved"
+              ? "Resolved incidents"
+              : "All incidents"
       }
       icon={state === "resolved" ? CheckmarkCircle02Icon : AlertCircleIcon}
     >
+      {selectedEntity ? (
+        <PageSelectionTitle
+          label={`${selectedEntity.name} · ${state === "active" ? "Active incidents" : state === "resolved" ? "Resolved incidents" : "All incidents"}`}
+          icon={<ScoutIcon name={selectedEntity.kind} />}
+        />
+      ) : null}
       <SecondaryItems
         title="Incident status"
         selected={state}
@@ -172,9 +192,28 @@ export function WorkspaceIncidents() {
           },
         ]}
       />
+      <MonitoringEntityPicker
+        allowAll
+        kind={kind}
+        entityKey={entityKey}
+        onResolve={resolve}
+        onKindChange={(value) => {
+          setKind(value);
+          reset();
+        }}
+        selected={selectedEntity}
+        onSelect={(entity, replace) => {
+          setSelectedEntity(entity, replace);
+          reset();
+        }}
+      />
       <div className="grid gap-5">
         {query.error ? <QueryError message={query.error} /> : null}
-        {query.data ? (
+        {entityKey && !selectedEntity ? (
+          <p className="text-sm text-muted">
+            Select an available entity to view its incidents.
+          </p>
+        ) : query.data ? (
           <ResourceTable
             ariaLabel="Workspace incidents"
             columns={columns}


### PR DESCRIPTION
## Summary

- Add type and entity filters to the Incidents page, matching Performance and Alerts.
- Filter incident requests by kind and entity ID.
- Preserve selection in the permalink and reset pagination when filters change.
- Keep the selected entity reflected in the page title.

## Validation

- pnpm --filter towbar-web-app typecheck
- pnpm --filter towbar-web-app lint
- Browser fixture checks for entity filtering and permalink state.